### PR TITLE
add organisation identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdk",
+  "name": "@guardian/cdk",
   "version": "0.1.0",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
This ensures the package gets released into the Guardian's NPM organisation.