### PR TITLE
update config for distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated / builds
-dist
+lib
 
 # IDEs
 .idea

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@guardian/cdk",
   "version": "0.1.0",
-  "main": "src/index.js",
-  "types": "src/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write \"(src|test)/**/*.ts\"",
     "watch": "tsc -w",
-    "test": "jest --detectOpenHandles --runInBand"
+    "test": "jest --detectOpenHandles --runInBand",
+    "prepare": "yarn build"
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.4.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,7 @@
 {
-  "ts-node": {
-    "compilerOptions": {
-      "module": "CommonJS"
-    }
-  },
   "compilerOptions": {
     "target": "ES2020",
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
     "esModuleInterop": true,
@@ -19,7 +14,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "typeRoots": ["./node_modules/@types"],
-    "outDir": "dist"
+    "outDir": "lib"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "src/**/*.test.ts", "src/**/__snapshots__/**"]


### PR DESCRIPTION
## What does this change?

This PR updates the output dir to be `lib` so that the imports of constructs look nicer. It also transpiles to `commonjs` so that jest is happy in apps that use the library.
