### PR TITLE
require a GuStack for all constructs

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -3,7 +3,7 @@ import { AutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import type { ISecurityGroup, MachineImage, MachineImageConfig } from "@aws-cdk/aws-ec2";
 import { InstanceType, OperatingSystemType, UserData } from "@aws-cdk/aws-ec2";
 import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
-import type { Construct } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 // TODO: Can GuAutoScalingGroup be more tightly integrated with amigo?
 //       Do we want to restrict to only allow amigo images?
 
@@ -23,7 +23,7 @@ export interface GuAutoScalingGroupProps
 }
 
 export class GuAutoScalingGroup extends AutoScalingGroup {
-  constructor(scope: Construct, id: string, props: GuAutoScalingGroupProps) {
+  constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {
     // We need to override getImage() so that we can pass in the AMI as a parameter
     // Otherwise, MachineImage.lookup({ name: 'some str' }) would work as long
     // as the name is hard-coded

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -1,6 +1,7 @@
-import type { CfnParameterProps, Construct } from "@aws-cdk/core";
+import type { CfnParameterProps } from "@aws-cdk/core";
 import { CfnParameter } from "@aws-cdk/core";
 import { Stage, Stages } from "../../constants";
+import type { GuStack } from "./stack";
 
 export type GuParameterProps = CfnParameterProps;
 
@@ -9,19 +10,19 @@ export type GuNoTypeParameterProps = Omit<GuParameterProps, "type">;
 export class GuParameter extends CfnParameter {
   static defaultProps: GuParameterProps = {};
 
-  constructor(scope: Construct, id: string, props: GuParameterProps) {
+  constructor(scope: GuStack, id: string, props: GuParameterProps) {
     super(scope, id, { ...GuParameter.defaultProps, ...props });
   }
 }
 
 export class GuStringParameter extends GuParameter {
-  constructor(scope: Construct, id: string, props: GuNoTypeParameterProps) {
+  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, { ...props, type: "String" });
   }
 }
 
 export class GuStageParameter extends GuParameter {
-  constructor(scope: Construct) {
+  constructor(scope: GuStack) {
     super(scope, "Stage", {
       type: "String",
       description: "Stage name",
@@ -32,7 +33,7 @@ export class GuStageParameter extends GuParameter {
 }
 
 export class GuStackParameter extends GuParameter {
-  constructor(scope: Construct) {
+  constructor(scope: GuStack) {
     super(scope, "Stack", {
       type: "String",
       description: "Name of this stack",
@@ -50,7 +51,7 @@ export class GuInstanceTypeParameter extends GuParameter {
     default: "t3.small",
   };
 
-  constructor(scope: Construct, id: string = "InstanceType", props: GuParameterProps = {}) {
+  constructor(scope: GuStack, id: string = "InstanceType", props: GuParameterProps = {}) {
     super(scope, id, { ...GuInstanceTypeParameter.defaultProps, ...props });
   }
 }
@@ -60,7 +61,7 @@ export class GuSSMParameter extends GuParameter {
     noEcho: true,
   };
 
-  constructor(scope: Construct, id: string, props: GuNoTypeParameterProps) {
+  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {
       ...GuSSMParameter.defaultProps,
       ...props,
@@ -72,7 +73,7 @@ export class GuSSMParameter extends GuParameter {
 export class GuSubnetListParameter extends GuParameter {
   static defaultProps: GuParameterProps = {};
 
-  constructor(scope: Construct, props: GuNoTypeParameterProps) {
+  constructor(scope: GuStack, props: GuNoTypeParameterProps) {
     super(scope, "Subnets", {
       ...GuSubnetListParameter.defaultProps,
       ...props,
@@ -84,7 +85,7 @@ export class GuSubnetListParameter extends GuParameter {
 export class GuVpcParameter extends GuParameter {
   static defaultProps: GuParameterProps = {};
 
-  constructor(scope: Construct, id: string, props: GuNoTypeParameterProps) {
+  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {
       ...GuVpcParameter.defaultProps,
       ...props,
@@ -96,7 +97,7 @@ export class GuVpcParameter extends GuParameter {
 export class GuAmiParameter extends GuParameter {
   static defaultProps: GuParameterProps = {};
 
-  constructor(scope: Construct, id: string, props: GuNoTypeParameterProps) {
+  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {
       ...GuAmiParameter.defaultProps,
       ...props,

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -2,11 +2,12 @@ import "@aws-cdk/assert/jest";
 
 import { SynthUtils } from "@aws-cdk/assert";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
+import { App } from "@aws-cdk/core";
 import { GuStack } from "./stack";
 
 describe("GuStack", () => {
   it("should apply the stack and stage tags to resources added to it", () => {
-    const stack = new GuStack();
+    const stack = new GuStack(new App());
 
     new Role(stack, "MyRole", {
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,4 +1,4 @@
-import type { Construct, StackProps } from "@aws-cdk/core";
+import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { GuStackParameter, GuStageParameter } from "./parameters";
 
@@ -6,8 +6,8 @@ export class GuStack extends Stack {
   protected stage: GuStageParameter;
   protected stack: GuStackParameter;
 
-  constructor(scope?: Construct, id?: string, props?: StackProps) {
-    super(scope, id, props);
+  constructor(app: App, id?: string, props?: StackProps) {
+    super(app, id, props);
 
     this.stage = new GuStageParameter(this);
     this.stack = new GuStackParameter(this);

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -1,6 +1,6 @@
 import type { CfnSecurityGroup, IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { Port, SecurityGroup } from "@aws-cdk/aws-ec2";
-import type { Construct } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 
 export interface CidrIngress {
   range: IPeer;
@@ -22,7 +22,7 @@ export interface GuSecurityGroupProps extends SecurityGroupProps {
 export class GuSecurityGroup extends SecurityGroup {
   static defaultIngressPort = Port.tcp(443);
 
-  constructor(scope: Construct, id: string, props: GuSecurityGroupProps) {
+  constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
     super(scope, id, props);
 
     if (props.overrideId) {

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -1,13 +1,13 @@
 import type { ISubnet, IVpc, VpcAttributes } from "@aws-cdk/aws-ec2";
 import { Subnet, Vpc } from "@aws-cdk/aws-ec2";
-import type { Stack } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 
 export class GuVpc {
-  static subnets(scope: Stack, subnets: string[]): ISubnet[] {
+  static subnets(scope: GuStack, subnets: string[]): ISubnet[] {
     return subnets.map((subnetId) => Subnet.fromSubnetId(scope, `subnet-${subnetId}`, subnetId));
   }
 
-  static fromId(scope: Stack, id: string, vpcId: string, props?: Partial<VpcAttributes>): IVpc {
+  static fromId(scope: GuStack, id: string, vpcId: string, props?: Partial<VpcAttributes>): IVpc {
     return Vpc.fromVpcAttributes(scope, id, {
       vpcId: vpcId,
       availabilityZones: scope.availabilityZones,

--- a/src/constructs/iam/policies.test.ts
+++ b/src/constructs/iam/policies.test.ts
@@ -1,10 +1,11 @@
 import "@aws-cdk/assert/jest";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
-import { Stack } from "@aws-cdk/core";
+import { App } from "@aws-cdk/core";
+import { GuStack } from "../core";
 import { GuSSMRunCommandPolicy } from "./policies";
 
 test("GuSSMRunCommandPolicy component", () => {
-  const stack = new Stack();
+  const stack = new GuStack(new App());
 
   const ssmPolicy = new GuSSMRunCommandPolicy(stack, "SSMRunCommandPolicy", {});
 

--- a/src/constructs/iam/policies.ts
+++ b/src/constructs/iam/policies.ts
@@ -2,7 +2,7 @@
 
 import type { CfnPolicy, PolicyProps } from "@aws-cdk/aws-iam";
 import { Effect, Policy, PolicyStatement } from "@aws-cdk/aws-iam";
-import type { Construct, Stack } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 
 export interface GuPolicyProps extends PolicyProps {
   overrideId?: boolean;
@@ -11,7 +11,7 @@ export interface GuPolicyProps extends PolicyProps {
 export class GuPolicy extends Policy {
   static defaultProps: Partial<GuPolicyProps> = {};
 
-  constructor(scope: Construct, id: string, props: GuPolicyProps) {
+  constructor(scope: GuStack, id: string, props: GuPolicyProps) {
     super(scope, id, { ...GuPolicy.defaultProps, ...props });
 
     if (props.overrideId) {
@@ -28,7 +28,7 @@ export interface GuLogShippingPolicyProps extends GuPolicyProps {
 // TODO: Should the constructor require a stack (which so far is the only thing it ever will be) or
 // should we pass through account and region explicitly?
 export class GuLogShippingPolicy extends GuPolicy {
-  private static getDefaultProps(scope: Stack, props: GuLogShippingPolicyProps): Partial<PolicyProps> {
+  private static getDefaultProps(scope: GuStack, props: GuLogShippingPolicyProps): Partial<PolicyProps> {
     return {
       policyName: "log-shipping-policy",
       statements: [
@@ -41,7 +41,7 @@ export class GuLogShippingPolicy extends GuPolicy {
     };
   }
 
-  constructor(scope: Stack, id: string = "LogShippingPolicy", props: GuLogShippingPolicyProps) {
+  constructor(scope: GuStack, id: string = "LogShippingPolicy", props: GuLogShippingPolicyProps) {
     super(scope, id, {
       ...GuLogShippingPolicy.getDefaultProps(scope, props),
       ...props,
@@ -81,7 +81,7 @@ export class GuSSMRunCommandPolicy extends GuPolicy {
   }
 
   // TODO: It's not possible to use the default id if you want to pass props in, should it?
-  constructor(scope: Construct, id: string = "SSMRunCommandPolicy", props: GuPolicyProps) {
+  constructor(scope: GuStack, id: string = "SSMRunCommandPolicy", props: GuPolicyProps) {
     super(scope, id, {
       ...GuSSMRunCommandPolicy.getDefaultProps(),
       ...props,
@@ -94,7 +94,7 @@ export interface GuGetS3ObjectPolicyProps extends GuPolicyProps {
 }
 
 export class GuGetS3ObjectPolicy extends GuPolicy {
-  constructor(scope: Stack, id: string, props: GuGetS3ObjectPolicyProps) {
+  constructor(scope: GuStack, id: string, props: GuGetS3ObjectPolicyProps) {
     // TODO validate `props.bucket` based on the rules defined here https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
 
     const policy = {

--- a/src/constructs/iam/roles.ts
+++ b/src/constructs/iam/roles.ts
@@ -1,6 +1,6 @@
 import type { CfnRole, RoleProps } from "@aws-cdk/aws-iam";
 import { Role } from "@aws-cdk/aws-iam";
-import type { Construct } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 
 export interface GuRoleProps extends RoleProps {
   overrideId?: boolean;
@@ -11,7 +11,7 @@ export class GuRole extends Role {
 
   private child: CfnRole;
 
-  constructor(scope: Construct, id: string, props: GuRoleProps) {
+  constructor(scope: GuStack, id: string, props: GuRoleProps) {
     super(scope, id, { ...GuRole.defaultProps, ...props });
 
     this.child = this.node.defaultChild as CfnRole;

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -12,14 +12,14 @@ import {
   ApplicationProtocol,
   ApplicationTargetGroup,
 } from "@aws-cdk/aws-elasticloadbalancingv2";
-import type { Construct } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 
 // TODO: By default, an application load balancer has deletion protection set to false.
 // We probably want to protect this load balancer as much as possible
 // should we set it to true instead?
 
 export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
-  constructor(scope: Construct, id: string, props: ApplicationLoadBalancerProps) {
+  constructor(scope: GuStack, id: string, props: ApplicationLoadBalancerProps) {
     super(scope, id, { ...props });
 
     // TODO: Maybe we should put these behind an option(s) so that the user
@@ -36,7 +36,7 @@ export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupPro
 }
 
 export class GuApplicationTargetGroup extends ApplicationTargetGroup {
-  constructor(scope: Construct, id: string, props: GuApplicationTargetGroupProps) {
+  constructor(scope: GuStack, id: string, props: GuApplicationTargetGroupProps) {
     super(scope, id, props);
 
     if (props.overrideId) {
@@ -55,7 +55,7 @@ export class GuApplicationListener extends ApplicationListener {
     protocol: ApplicationProtocol.HTTPS,
   };
 
-  constructor(scope: Construct, id: string, props: GuApplicationListenerProps) {
+  constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
     super(scope, id, { ...GuApplicationListener.defaultProps, ...props });
 
     if (props.overrideId) {

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -1,8 +1,8 @@
 import { InstanceType } from "@aws-cdk/aws-ec2";
 import type { CfnDBInstance, DatabaseInstanceProps, IParameterGroup } from "@aws-cdk/aws-rds";
 import { DatabaseInstance, ParameterGroup } from "@aws-cdk/aws-rds";
-import type { Construct } from "@aws-cdk/core";
 import { Fn } from "@aws-cdk/core";
+import type { GuStack } from "../core";
 
 export interface GuDatabaseInstanceProps extends Omit<DatabaseInstanceProps, "instanceType"> {
   overrideId?: boolean;
@@ -11,7 +11,7 @@ export interface GuDatabaseInstanceProps extends Omit<DatabaseInstanceProps, "in
 }
 
 export class GuDatabaseInstance extends DatabaseInstance {
-  constructor(scope: Construct, id: string, props: GuDatabaseInstanceProps) {
+  constructor(scope: GuStack, id: string, props: GuDatabaseInstanceProps) {
     // CDK just wants "t3.micro" format, whereas
     // some CFN yaml might have the older "db.t3.micro" with the "db." prefix
     // This logic ensures the "db." prefix is removed before applying the CFN

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -2,6 +2,22 @@
 
 exports[`The InstanceRole construct should allow additional policies to be specified 1`] = `
 Object {
+  "Parameters": Object {
+    "Stack": Object {
+      "Default": "deploy",
+      "Description": "Name of this stack",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
   "Resources": Object {
     "GetConfigPolicy6F934A1C": Object {
       "Properties": Object {
@@ -70,6 +86,20 @@ Object {
           "Version": "2012-10-17",
         },
         "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
     },
@@ -115,6 +145,22 @@ Object {
 
 exports[`The InstanceRole construct should create an additional logging policy if logging stream is specified 1`] = `
 Object {
+  "Parameters": Object {
+    "Stack": Object {
+      "Default": "deploy",
+      "Description": "Name of this stack",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
   "Resources": Object {
     "GetDistributablesPolicy": Object {
       "Properties": Object {
@@ -162,6 +208,20 @@ Object {
           "Version": "2012-10-17",
         },
         "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
     },
@@ -246,6 +306,22 @@ Object {
 
 exports[`The InstanceRole construct should create the correct resources with minimal config 1`] = `
 Object {
+  "Parameters": Object {
+    "Stack": Object {
+      "Default": "deploy",
+      "Description": "Name of this stack",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
   "Resources": Object {
     "GetDistributablesPolicy": Object {
       "Properties": Object {
@@ -293,6 +369,20 @@ Object {
           "Version": "2012-10-17",
         },
         "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
       },
       "Type": "AWS::IAM::Role",
     },

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -1,12 +1,13 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
-import { Stack } from "@aws-cdk/core";
+import { App } from "@aws-cdk/core";
+import { GuStack } from "../constructs/core";
 import { GuGetS3ObjectPolicy } from "../constructs/iam";
 import { InstanceRole } from "./instance-role";
 
 describe("The InstanceRole construct", () => {
   it("should create the correct resources with minimal config", () => {
-    const stack = new Stack();
+    const stack = new GuStack(new App());
     new InstanceRole(stack, { artifactBucket: "test" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -15,7 +16,7 @@ describe("The InstanceRole construct", () => {
   });
 
   it("should create an additional logging policy if logging stream is specified", () => {
-    const stack = new Stack();
+    const stack = new GuStack(new App());
     new InstanceRole(stack, { artifactBucket: "test", loggingStreamName: "my-logging-stream" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -24,7 +25,7 @@ describe("The InstanceRole construct", () => {
   });
 
   it("should allow additional policies to be specified", () => {
-    const stack = new Stack();
+    const stack = new GuStack(new App());
 
     new InstanceRole(stack, {
       artifactBucket: "test",

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -1,5 +1,5 @@
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
-import type { Stack } from "@aws-cdk/core";
+import type { GuStack } from "../constructs/core";
 import type { GuPolicy } from "../constructs/iam";
 import { GuGetS3ObjectPolicy, GuLogShippingPolicy, GuRole, GuSSMRunCommandPolicy } from "../constructs/iam";
 
@@ -12,7 +12,7 @@ export interface InstanceRoleProps {
 export class InstanceRole extends GuRole {
   private policies: GuPolicy[];
 
-  constructor(scope: Stack, props: InstanceRoleProps) {
+  constructor(scope: GuStack, props: InstanceRoleProps) {
     super(scope, "InstanceRole", {
       overrideId: true,
       path: "/",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

GuStack will apply the Stack and Stage tags, which we've deemed best practice.

Changing the constructor of constructs to take a GuStack ensures everything meets our best practice.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Best practice is provided by default.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a