### PR TITLE
Add PR template with question about changes to other projects

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What does this change?
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
+
+## Does this change require changes to existing projects or CDK CLI?
+<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->
+
+## How to test
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+## How can we measure success?
+<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
+
+## Have we considered potential risks?
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
+
+## Images
+<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


### PR DESCRIPTION
## What does this change?

This PR adds a PR template to the repository which extends the organisation default to add the following question.

```markdown
## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->
```

Particularly while we are in the early stages of development, many of the changes we make here require related changes to the projects we have already migrated across or to the [cdk-cli](https://github.com/guardian/cdk-migrator). This step will remind us of that.