### PR TITLE
Simplify GuSubnetListParameter and enforce passing of ID

### DIFF
--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -71,14 +71,8 @@ export class GuSSMParameter extends GuParameter {
 }
 
 export class GuSubnetListParameter extends GuParameter {
-  static defaultProps: GuParameterProps = {};
-
-  constructor(scope: GuStack, props: GuNoTypeParameterProps) {
-    super(scope, "Subnets", {
-      ...GuSubnetListParameter.defaultProps,
-      ...props,
-      type: "List<AWS::EC2::Subnet::Id>",
-    });
+  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
+    super(scope, id, { ...props, type: "List<AWS::EC2::Subnet::Id>" });
   }
 }
 


### PR DESCRIPTION
## What does this change?

Having hard-coded IDs can introduce some frustrating issues with CDK, and the value of having predefined custom is when you make it strict in terms of what it can receive and takes care of the rest. This PR:

 * Introduces an `id` parameter to the constructor so you have to specify an ID
* Removes unnecessary complexity in the props by simplifying the constructor

## Does this change require changes to existing projects or CDK CLI?

Yes: 

 * https://github.com/guardian/deploy-tools-platform/blob/2c94305f23c1a78fb4214042ddd7cd47b42696cd/cdk/lib/amiable/amiable.ts#L27
 * Once merged: https://github.com/guardian/tag-janitor/pull/10/files#

These changes would be straightforward to implement once this is in.
