### PR TITLE
Update cdk cli repository url

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -5,7 +5,7 @@
 The [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) provides a command to generate
 a starter project. From there, you can install this library and get started defining your new stack.
 
-The [Guardian CDK CLI](https://github.com/guardian/cdk-migrator) can be used to generate the boiler plate for you stack and
+The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) can be used to generate the boiler plate for you stack and
 to migrate across parameters from existing cloudformation templates.
 
 ## Comparing outputs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cloudformation.
 The [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) provides a command to generate
 a starter project. From there, you can install this library and get started defining your new stack.
 
-The [Guardian CDK CLI](https://github.com/guardian/cdk-migrator) also provides some tooling, currently focused on migration
+The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) also provides some tooling, currently focused on migration
 but eventually for setting up new stacks too.
 
 ## Migration


### PR DESCRIPTION
## What does this change?

This PR updates the links to the CDK CLI now that it has been rename (as of https://github.com/guardian/cdk-cli/pull/9)

## Does this change require changes to existing projects or CDK CLI?

No

## How to test

1) Click the link in the README or MIGRATING.md docs
2) Marvel at the power of the internet

## How can we measure success?

The links to CDK CLI send us to the correct repository
