### PR TITLE
move aws-cdk/* libs to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "typescript": "~4.1.2"
   },
   "peerDependencies": {
-    "@aws-cdk/core": "~1.74.0"
-  },
-  "dependencies": {
     "@aws-cdk/assert": "~1.74.0",
     "@aws-cdk/aws-autoscaling": "~1.74.0",
     "@aws-cdk/aws-ec2": "~1.74.0",
@@ -45,5 +42,7 @@
     "@aws-cdk/aws-events-targets": "~1.74.0",
     "@aws-cdk/aws-rds": "~1.74.0",
     "@aws-cdk/core": "~1.74.0"
+  },
+  "dependencies": {
   }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As I understand it, `peerDependencies` are a way of saying "@guardian/cdk is compatible with this version of @aws-cdk/*". This is important as the AWS CDK library has quite a [frequent release cycle](https://github.com/aws/aws-cdk/tags) with [breaking changes introduced in minor bumps](https://github.com/aws/aws-cdk/releases/tag/v1.75.0).

Another benefit of `peerDependencies` is it helps keep `node_modules` flat. [This](https://medium.com/angular-in-depth/npm-peer-dependencies-f843f3ac4e7f) is a good read.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More descriptive `package.json`?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a