### PR TITLE
update asg to only take singular target group

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -65,7 +65,7 @@ describe("The GuAutoScalingGroup", () => {
     const app = new App();
     const stack = new GuStack(app);
 
-    const targetGroup1 = new GuApplicationTargetGroup(stack, "TargetGroup1", {
+    const targetGroup = new GuApplicationTargetGroup(stack, "TargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
       overrideId: true,
@@ -73,13 +73,13 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       ...defaultProps,
-      targetGroups: [targetGroup1],
+      targetGroup: targetGroup,
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::AutoScalingGroup", {
       TargetGroupARNs: [
         {
-          Ref: "TargetGroup1",
+          Ref: "TargetGroup",
         },
       ],
     });

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -19,7 +19,7 @@ export interface GuAutoScalingGroupProps
   instanceType: string;
   userData: string;
   securityGroups?: ISecurityGroup[];
-  targetGroups?: ApplicationTargetGroup[];
+  targetGroup?: ApplicationTargetGroup;
 }
 
 export class GuAutoScalingGroup extends AutoScalingGroup {
@@ -42,9 +42,8 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
       userData: UserData.custom(props.userData),
     });
 
-    // TODO: When I tried adding more than one target group, this failed. I think you
-    // may only be able to add one TG to an ASG
-    props.targetGroups?.forEach((tg) => this.attachToApplicationTargetGroup(tg));
+    props.targetGroup && this.attachToApplicationTargetGroup(props.targetGroup);
+
     props.securityGroups?.forEach((sg) => this.addSecurityGroup(sg));
 
     const cfnAsg = this.node.defaultChild as CfnAutoScalingGroup;


### PR DESCRIPTION
## What does this change?

When testing the `GuAutoscalingGroup` component, it was noted that providing more than one target group produced an error. This PR updates the `targetGroups` prop to be `targetGroup` which is now a singular item and updates the implementation logic accordingly.

## Does this change require changes to existing projects or CDK CLI?

Yes. Any projects using the `targetGroups` prop will need to be updated. This is currently only one project.

## How to test

Run `yarn test` and see the updated tests pass.

## How can we measure success?

A user can no longer pass an array of target groups into the `GuAutoscalingGroup` component, triggering a runtime error.
