### PR TITLE
Add an optional app prop to GuStack

### DIFF
--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -53,4 +53,33 @@ describe("The GuStack construct", () => {
       ],
     });
   });
+
+  it("should apply the app tag to resources added to it if provided", () => {
+    const stack = new GuStack(new App(), "Test", { app: "MyApp" });
+
+    new Role(stack, "MyRole", {
+      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+    });
+
+    expect(stack).toHaveResource("AWS::IAM::Role", {
+      Tags: [
+        {
+          Key: "App",
+          Value: "MyApp",
+        },
+        {
+          Key: "Stack",
+          Value: {
+            Ref: "Stack",
+          },
+        },
+        {
+          Key: "Stage",
+          Value: {
+            Ref: "Stage",
+          },
+        },
+      ],
+    });
+  });
 });

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -88,59 +88,9 @@ describe("The GuStack construct", () => {
 
     expect(stack.app).toBe("MyApp");
   });
-
-  it("should create an app parameter and use that to tag the stack if the appParameter props is true", () => {
-    const stack = new GuStack(new App(), "Test", { appParameter: true });
-
-    new Role(stack, "MyRole", {
-      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-    });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(json.Parameters.App).toEqual({
-      Description: "The name of the app",
-      Type: "String",
-    });
-
-    expect(stack).toHaveResource("AWS::IAM::Role", {
-      Tags: [
-        {
-          Key: "App",
-          Value: {
-            Ref: "App",
-          },
-        },
-        {
-          Key: "Stack",
-          Value: {
-            Ref: "Stack",
-          },
-        },
-        {
-          Key: "Stage",
-          Value: {
-            Ref: "Stage",
-          },
-        },
-      ],
-    });
-  });
-
-  it("should return a value when app is accessed and appParameter is set", () => {
-    const stack = new GuStack(new App(), "Test", { appParameter: true });
-
-    expect(() => stack.app).not.toThrowError();
-  });
-
   it("should return an error when app is accessed and no app is set", () => {
     const stack = new GuStack(new App(), "Test");
 
     expect(() => stack.app).toThrowError("App is not set");
-  });
-
-  it("should throw an error if both app and appParameter provided", () => {
-    expect(() => new GuStack(new App(), "Test", { app: "test", appParameter: true })).toThrowError(
-      "Cannot provide both app and appParameter"
-    );
   });
 });

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -82,4 +82,65 @@ describe("The GuStack construct", () => {
       ],
     });
   });
+
+  it("should return the correct app value when app is set", () => {
+    const stack = new GuStack(new App(), "Test", { app: "MyApp" });
+
+    expect(stack.app).toBe("MyApp");
+  });
+
+  it("should create an app parameter and use that to tag the stack if the appParameter props is true", () => {
+    const stack = new GuStack(new App(), "Test", { appParameter: true });
+
+    new Role(stack, "MyRole", {
+      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Parameters.App).toEqual({
+      Description: "The name of the app",
+      Type: "String",
+    });
+
+    expect(stack).toHaveResource("AWS::IAM::Role", {
+      Tags: [
+        {
+          Key: "App",
+          Value: {
+            Ref: "App",
+          },
+        },
+        {
+          Key: "Stack",
+          Value: {
+            Ref: "Stack",
+          },
+        },
+        {
+          Key: "Stage",
+          Value: {
+            Ref: "Stage",
+          },
+        },
+      ],
+    });
+  });
+
+  it("should return a value when app is accessed and appParameter is set", () => {
+    const stack = new GuStack(new App(), "Test", { appParameter: true });
+
+    expect(() => stack.app).not.toThrowError();
+  });
+
+  it("should return an error when app is accessed and no app is set", () => {
+    const stack = new GuStack(new App(), "Test");
+
+    expect(() => stack.app).toThrowError("App is not set");
+  });
+
+  it("should throw an error if both app and appParameter provided", () => {
+    expect(() => new GuStack(new App(), "Test", { app: "test", appParameter: true })).toThrowError(
+      "Cannot provide both app and appParameter"
+    );
+  });
 });

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -2,11 +2,15 @@ import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { GuStackParameter, GuStageParameter } from "./parameters";
 
+export interface GuStackProps extends StackProps {
+  app?: string;
+}
+
 export class GuStack extends Stack {
   protected stage: GuStageParameter;
   protected stack: GuStackParameter;
 
-  constructor(app: App, id?: string, props?: StackProps) {
+  constructor(app: App, id?: string, props?: GuStackProps) {
     super(app, id, props);
 
     this.stage = new GuStageParameter(this);
@@ -14,5 +18,7 @@ export class GuStack extends Stack {
 
     Tags.of(this).add("Stack", this.stack.valueAsString);
     Tags.of(this).add("Stage", this.stage.valueAsString);
+
+    props?.app && Tags.of(this).add("App", props.app);
   }
 }

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,24 +1,23 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
-import { GuStackParameter, GuStageParameter, GuStringParameter } from "./parameters";
+import { GuStackParameter, GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
   app?: string;
-  appParameter?: boolean;
 }
 
 export class GuStack extends Stack {
   protected stage: GuStageParameter;
   protected stack: GuStackParameter;
 
-  private _app: string | GuStringParameter | undefined;
+  private _app: string | undefined;
 
   get app(): string {
-    if (typeof this._app === "string") {
+    if (this._app) {
       return this._app;
-    } else if (this._app instanceof GuStringParameter) {
-      return this._app.valueAsString;
     } else {
+      // Throw an error here so that if you forget to set app and
+      // try to use it, your stack fails to generate
       throw new Error("App is not set");
     }
   }
@@ -32,15 +31,9 @@ export class GuStack extends Stack {
     Tags.of(this).add("Stack", this.stack.valueAsString);
     Tags.of(this).add("Stage", this.stage.valueAsString);
 
-    if (props?.app && props.appParameter) {
-      // TODO: How do we do this better with types?
-      throw new Error("Cannot provide both app and appParameter props");
-    } else if (props?.appParameter) {
-      this._app = new GuStringParameter(this, "App", { description: "The name of the app" });
-      Tags.of(this).add("App", this._app.valueAsString);
-    } else if (props?.app) {
-      Tags.of(this).add("App", props.app);
+    if (props?.app) {
       this._app = props.app;
+      Tags.of(this).add("App", props.app);
     }
   }
 }

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,14 +1,27 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
-import { GuStackParameter, GuStageParameter } from "./parameters";
+import { GuStackParameter, GuStageParameter, GuStringParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
   app?: string;
+  appParameter?: boolean;
 }
 
 export class GuStack extends Stack {
   protected stage: GuStageParameter;
   protected stack: GuStackParameter;
+
+  private _app: string | GuStringParameter | undefined;
+
+  get app(): string {
+    if (typeof this._app === "string") {
+      return this._app;
+    } else if (this._app instanceof GuStringParameter) {
+      return this._app.valueAsString;
+    } else {
+      throw new Error("App is not set");
+    }
+  }
 
   constructor(app: App, id?: string, props?: GuStackProps) {
     super(app, id, props);
@@ -19,6 +32,15 @@ export class GuStack extends Stack {
     Tags.of(this).add("Stack", this.stack.valueAsString);
     Tags.of(this).add("Stage", this.stage.valueAsString);
 
-    props?.app && Tags.of(this).add("App", props.app);
+    if (props?.app && props.appParameter) {
+      // TODO: How do we do this better with types?
+      throw new Error("Cannot provide both app and appParameter props");
+    } else if (props?.appParameter) {
+      this._app = new GuStringParameter(this, "App", { description: "The name of the app" });
+      Tags.of(this).add("App", this._app.valueAsString);
+    } else if (props?.app) {
+      Tags.of(this).add("App", props.app);
+      this._app = props.app;
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

This PR updates the GuStack to take a new `GuStackProps` interface which allows for an app value to be set. This app value is added as a tag to all resources on the stack and a getter is added to return either the string or throw an error if the app is not set.

## Does this change require changes to existing projects or CDK CLI?

This change means existing stacks can pass the app prop through instead of setting the tags themselves. It is a non-breaking change. 

## How to test

Create a new stack with the `app` prop set and check that the tag is correctly applied to all resources. 

## How can we measure success?

Resources are all tagged with the relevant app with less effort for users. 

## Have we considered potential risks?

n/a

## Images

n/a
