### PR TITLE
0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/cdk",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/cdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Release v0.2.0 had an issue due to the move from `npm` to `yarn`. This release contains the same code changes but uses `npm` so that the library contains the correct files.