### PR TITLE
Add getters for stack and stage values

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -7,8 +7,16 @@ export interface GuStackProps extends StackProps {
 }
 
 export class GuStack extends Stack {
-  protected stage: GuStageParameter;
-  protected stack: GuStackParameter;
+  protected _stage: GuStageParameter;
+  protected _stack: GuStackParameter;
+
+  get stage(): string {
+    return this._stage.valueAsString;
+  }
+
+  get stack(): string {
+    return this._stack.valueAsString;
+  }
 
   private _app: string | undefined;
 
@@ -25,11 +33,11 @@ export class GuStack extends Stack {
   constructor(app: App, id?: string, props?: GuStackProps) {
     super(app, id, props);
 
-    this.stage = new GuStageParameter(this);
-    this.stack = new GuStackParameter(this);
+    this._stage = new GuStageParameter(this);
+    this._stack = new GuStackParameter(this);
 
-    Tags.of(this).add("Stack", this.stack.valueAsString);
-    Tags.of(this).add("Stage", this.stage.valueAsString);
+    Tags.of(this).add("Stack", this.stack);
+    Tags.of(this).add("Stage", this.stage);
 
     if (props?.app) {
       this._app = props.app;


### PR DESCRIPTION
## What does this change?

This PR adds getters for the `stack` and `stage` values in `GuStack` so that it is possible to use `this.stack` or `this.stage` directory rather than having to add `valueAsString` everywhere. This also means that once #30 is merged, the `GuStack` will have a consistent interface for accessing stack, stage and app.

## Does this change require changes to existing projects or CDK CLI?

Yes, everything that uses `this.stage.valueAsString` or `this.stack.valueAsString` at the moment will need to be updated.

## How to test

n/a

## How can we measure success?

Slightly less typing is required to use the stack and stage values.

## Have we considered potential risks?

n/a

## Images

n/a
