### PR TITLE
Update documentation and add ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,25 @@ Welcome to the Guardian CDK library! This library contains a number of reusable 
 
 You can read more about it in the [aws-cdk README](https://github.com/aws/aws-cdk).
 
-## Patterns
+## Architecture
+
+Read more about constructs, patterns and other architectural decisions in (docs)[docs]
+
+### Patterns
 
 Patterns are high level classes which compose a number of constructs to produce standard architectures. For example, you should be able to get all of the resources you need to deploy a new lambda function from one `GuLambdaStack` class. We're still working on these right now but hope to start bringing you
 some of the most common Guardian stacks soon!
 
 Patterns should be your default entry point to this library.
 
-## Constructs
+### Constructs
 
 Constructs are lower level classes which will create one or more resources to produce one element of a stack. For example, the `GuDatabaseInstance` will create an RDS instance as well as a parameter group, if required. This library defines a number of constructs which are combined to create the higher level patterns.
 
 If there is a pattern available for your use case, prefer to use that over composing constructs yourself. We welcome feedback and/or PRs to extend the functionality of patterns. Where you need to do something outside of currently available patterns, you can use the constructs to provide some level of abstraction. In this case, consider whether it's worth defining a pattern.
 
 ## Useful commands
+
 We follow the [`script/task`](https://github.com/github/scripts-to-rule-them-all) pattern,
 find useful scripts within the [`script`](./script) directory for common tasks.
 
@@ -33,6 +38,7 @@ find useful scripts within the [`script`](./script) directory for common tasks.
 - `./script/release` to release a new version to NPM
 
 There are also some other commands defined in `package.json`:
+
 - `npm run lint --fix` attempt to autofix any linter errors
 - `npm run format` format the code using Prettier
 - `npm run watch` watch for changes and compile
@@ -55,44 +61,9 @@ yarn add @guardian/cdk
 
 Patterns can be imported from the top level of the library (e.g. `import { InstanceRole } from "@guardian/cdk";`) while constructs must be imported from their construct directory (e.g. `import { GuAutoScalingGroup } from "@guardian/cdk/lib/constructs/autoscaling";`)
 
-### AWS Library Versions
-
-Any versions of the `@aws-cdk` libraries that you have installed in your project must be the same version as those used in the `@guardian/cdk` library.
-
-### Profile
-
-You may need to set the profile value in the `cdk.json` file to a value which does not exist (e.g. `does-not-exist`).
-This is a workaround to a known
-[issue](https://github.com/aws/aws-cdk/issues/7849) where expired credentials
-cause an error when running the `cdk synth` command. As we don't (yet) use any
-features which require connecting to an account this does not break anything but
-in the future we may actually require valid credentials to generate the
-cloudformation.
-
-## Starting a new CDK project
-
-The [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) provides a command to generate
-a starter project. From there, you can install this library and get started defining your new stack.
-
-The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) also provides some tooling, currently focused on migration
-but eventually for setting up new stacks too.
-
-## Migration
-
-You can read more about migrating from Cloudformation to CDK in [MIGRATING.md](MIGRATING.md)
-
-## Testing
-
-For unit testing, the two key strategies are direct assertions and snapshot tests. When testing constructs, prefer using direct asserts while for patterns, make greater use of snapshot testing. For examples of these two approaches see [src/constructs/autoscaling/asg.test.ts](src/constructs/autoscaling/asg.test.ts) and [src/patterns/instance-role.test.ts](src/patterns/instance-role.test.ts) respectively.
+There are more details on using the CDK library in [docs](docs)
 
 ## Releasing
 
 We use [`np`](https://www.npmjs.com/package/np) to help orchestrate the release process.
 To release a new version, run `./script/release`. You will need to be logged in to your `npm` account (`npm login`) which must be part of the Guardian organisation. If you have 2fa enabled, you will be prompted for an OTP during the release process.
-
-## Yarn
-
-This repository uses npm as attempts to move to `yarn` have highlighted issues including those below:
-
-- `yarn login` still prompts for a password at release time which doesn't work with `np`
-- publishing with `yarn` leaves only the `index.js` file in the `lib` directory

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can read more about it in the [aws-cdk README](https://github.com/aws/aws-cd
 
 ## Architecture
 
-Read more about constructs, patterns and other architectural decisions in (docs)[docs]
+Read more about constructs, patterns and other architectural decisions in [docs](docs)
 
 ### Patterns
 

--- a/docs/001-general-usage.md
+++ b/docs/001-general-usage.md
@@ -33,13 +33,3 @@ Patterns can be imported from the top level of the library (e.g. `import { Insta
 ## AWS Library Versions
 
 Any versions of the `@aws-cdk` libraries that you have installed in your project must be the same version as those used in the `@guardian/cdk` library.
-
-## Profile
-
-You may need to set the profile value in the `cdk.json` file to a value which does not exist (e.g. `does-not-exist`).
-This is a workaround to a known
-[issue](https://github.com/aws/aws-cdk/issues/7849) where expired credentials
-cause an error when running the `cdk synth` command. As we don't (yet) use any
-features which require connecting to an account this does not break anything but
-in the future we may actually require valid credentials to generate the
-cloudformation.

--- a/docs/001-general-usage.md
+++ b/docs/001-general-usage.md
@@ -33,3 +33,7 @@ Patterns can be imported from the top level of the library (e.g. `import { Insta
 ## AWS Library Versions
 
 Any versions of the `@aws-cdk` libraries that you have installed in your project must be the same version as those used in the `@guardian/cdk` library.
+
+## Synthesising
+
+The `cdk synth` command can be used to generate cloudformation from CDK defintions. This will, by default, generate JSON in the `cdk.out` directory. Apps written in typescript will need to either be built first so the javascript can be passed to the app value, or can be passed in directly using `ts-node` (e.g. `--app="ts-node ./bin/my-app.ts"`). For apps with a single stack, the generated yaml will also be printed in the console. For app with multiple stacks, you can specify a stack to see the yaml output. This yaml can then be directed to a file if desired.

--- a/docs/001-general-usage.md
+++ b/docs/001-general-usage.md
@@ -1,0 +1,45 @@
+# General Usage
+
+## Installation
+
+This library can be installed from npm.
+
+```
+npm install --save @guardian/cdk
+```
+
+or
+
+```
+yarn add @guardian/cdk
+```
+
+## Patterns
+
+Patterns are high level classes which compose a number of constructs to produce standard architectures. For example, you should be able to get all of the resources you need to deploy a new lambda function from one `GuLambdaStack` class. We're still working on these right now but hope to start bringing you some of the most common Guardian stacks soon!
+
+Patterns should be your default entry point to this library.
+
+## Constructs
+
+Constructs are lower level classes which will create one or more resources to produce one element of a stack. For example, the `GuDatabaseInstance` will create an RDS instance as well as a parameter group, if required. This library defines a number of constructs which are combined to create the higher level patterns.
+
+If there is a pattern available for your use case, prefer to use that over composing constructs yourself. We welcome feedback and/or PRs to extend the functionality of patterns. Where you need to do something outside of currently available patterns, you can use the constructs to provide some level of abstraction. In this case, consider whether it's worth defining a pattern.
+
+## Using patterns and constructs
+
+Patterns can be imported from the top level of the library (e.g. `import { InstanceRole } from "@guardian/cdk";`) while constructs must be imported from their construct directory (e.g. `import { GuAutoScalingGroup } from "@guardian/cdk/lib/constructs/autoscaling";`)
+
+## AWS Library Versions
+
+Any versions of the `@aws-cdk` libraries that you have installed in your project must be the same version as those used in the `@guardian/cdk` library.
+
+## Profile
+
+You may need to set the profile value in the `cdk.json` file to a value which does not exist (e.g. `does-not-exist`).
+This is a workaround to a known
+[issue](https://github.com/aws/aws-cdk/issues/7849) where expired credentials
+cause an error when running the `cdk synth` command. As we don't (yet) use any
+features which require connecting to an account this does not break anything but
+in the future we may actually require valid credentials to generate the
+cloudformation.

--- a/docs/002-starting-a-new-project.md
+++ b/docs/002-starting-a-new-project.md
@@ -1,7 +1,27 @@
-**TODO: Improve these docs**
-
 # Starting a new CDK project
 
 The [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) provides a command to generate a starter project. From there, you can install this library and get started defining your new stack.
 
 The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) also provides some tooling, currently focused on migration but eventually for setting up new stacks too.
+
+This will generate a `cdk` directory where you can start to define your infrastructure.
+
+## Directory structure
+
+This directory will contains directories in which your code is written as well as a number of configuration files. Some of the key directories and files are detailed below.
+
+**bin**
+
+This directory contains a file for each app that your cdk defines. For each app, there may be multiple stacks. For single apps, that file can be called `cdk.ts` whereas for multiple apps it is recommended to name them accordingly.
+
+**lib**
+
+The lib directory contains all of the stack defitions. For single apps, these file(s) will be at the top level of the directory and for a single stack, the file may be called `cdk-stack.ts`. Multiple stacks should be named accordingly and if multiple apps exist, nested in sub directories.
+
+**cdk.out**
+
+This directory is where the synthesised cloudformation will be written to.
+
+**cdk.json**
+
+This file contains configuration regarding your CDK.

--- a/docs/002-starting-a-new-project.md
+++ b/docs/002-starting-a-new-project.md
@@ -1,0 +1,7 @@
+**TODO: Improve these docs**
+
+# Starting a new CDK project
+
+The [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) provides a command to generate a starter project. From there, you can install this library and get started defining your new stack.
+
+The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) also provides some tooling, currently focused on migration but eventually for setting up new stacks too.

--- a/docs/002-starting-a-new-project.md
+++ b/docs/002-starting-a-new-project.md
@@ -20,7 +20,7 @@ The lib directory contains all of the stack defitions. For single apps, these fi
 
 **cdk.out**
 
-This directory is where the synthesised cloudformation will be written to.
+This directory is where the synthesised cloudformation will be written to in JSON format.
 
 **cdk.json**
 

--- a/docs/003-migrating-existing-stacks.md
+++ b/docs/003-migrating-existing-stacks.md
@@ -5,8 +5,7 @@
 The [AWS CDK CLI](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-typescript.html) provides a command to generate
 a starter project. From there, you can install this library and get started defining your new stack.
 
-The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) can be used to generate the boiler plate for you stack and
-to migrate across parameters from existing cloudformation templates.
+The [Guardian CDK CLI](https://github.com/guardian/cdk-cli) can be used to generate the boiler plate for you stack and to migrate across parameters from existing cloudformation templates.
 
 ## Comparing outputs
 

--- a/docs/004-tips-tricks-and-gotchas.md
+++ b/docs/004-tips-tricks-and-gotchas.md
@@ -1,0 +1,19 @@
+# Tips, Tracks and Gotchas
+
+## Parameter Store
+
+Values from parameter store can either be included via parameters or resolved directly.
+
+When using via parameters, set the type value to be `AWS::SSM::Parameter::Value<TYPE>` where TYPE is type of the value itself. You can then provide a path to the value. This can be any supported parameter type.
+
+To resolve a parameter within your CDK code you can use one of the [methods provided](https://docs.aws.amazon.com/cdk/latest/guide/get_ssm_value.html). Note that a version number can be provided for all values and for secret values it must be provided.
+
+## Profile
+
+You may need to set the profile value in the `cdk.json` file to a value which does not exist (e.g. `does-not-exist`).
+This is a workaround to a known
+[issue](https://github.com/aws/aws-cdk/issues/7849) where expired credentials
+cause an error when running the `cdk synth` command. As we don't (yet) use any
+features which require connecting to an account this does not break anything but
+in the future we may actually require valid credentials to generate the
+cloudformation.

--- a/docs/architecture-decision-records/000-template.md
+++ b/docs/architecture-decision-records/000-template.md
@@ -1,0 +1,21 @@
+# Title
+
+## Status
+
+<!--- What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.? -->
+
+## Context
+
+<!--- What is the issue that we're seeing that is motivating this decision or change? -->
+
+## Positions
+
+<!--- What are the differing positions or proposals on this issue? -->
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->

--- a/docs/architecture-decision-records/001-constructs-and-patterns.md
+++ b/docs/architecture-decision-records/001-constructs-and-patterns.md
@@ -1,0 +1,43 @@
+**TODO: Write this in full sentences**
+
+# Constructs and Patterns
+
+## Status
+
+<!--- What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.? -->
+
+proposed
+
+## Context
+
+<!--- What is the issue that we're seeing that is motivating this decision or change? -->
+
+- It's possible to abstract at many levels.
+- AWS already provide multiple levels:
+  - CfnComponent - maps 1-to-1 with a cfn resource
+  - Construct - create 1 to many resources but all grouped on a similar concept. e.g an RDS instance construct may also create a parameters object which it references, rather than requiring it to be defined separately.
+- Plus lots of open source patterns which group Constructs to provide an templated stacks
+  - e.g. an ec2 app stack might give you ASG, LB, SG
+  - likely composed of multiple constructs under the hood
+
+## Positions
+
+<!--- What are the differing positions or proposals on this issue? -->
+
+- Provide constructs and patterns
+- Any other option?
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+- Produce both constructs and patterns
+- Patterns for common Guardian stacks
+- Utility constructs covering common patterns for each construct (e.g. policy -> SSM policy, S3Artifact Policy, LogShippingPolicy)
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+
+- Clear definition makes library use and maintainence easier.
+- Some difficult where components are across the boundary?

--- a/docs/architecture-decision-records/001-constructs-and-patterns.md
+++ b/docs/architecture-decision-records/001-constructs-and-patterns.md
@@ -1,5 +1,3 @@
-**TODO: Write this in full sentences**
-
 # Constructs and Patterns
 
 ## Status
@@ -12,32 +10,36 @@ proposed
 
 <!--- What is the issue that we're seeing that is motivating this decision or change? -->
 
-- It's possible to abstract at many levels.
-- AWS already provide multiple levels:
-  - CfnComponent - maps 1-to-1 with a cfn resource
-  - Construct - create 1 to many resources but all grouped on a similar concept. e.g an RDS instance construct may also create a parameters object which it references, rather than requiring it to be defined separately.
-- Plus lots of open source patterns which group Constructs to provide an templated stacks
-  - e.g. an ec2 app stack might give you ASG, LB, SG
-  - likely composed of multiple constructs under the hood
+The AWS CDK provides components with two levels of abstraction. CfnComponents map directly to cloudformation resources whilst constructs are a higher abstraction which may create multiple related resources. For example, the `AutoScalingGroup` construct will also create `LaunchConfig` and `SecurityGroup` resources. This is a useful abstraction as it allows you to define all the components required for a particular concept in one place.
+
+Further to this, various patterns are available - both AWS supported and open source. These patterns define an entire stack, based around common template. For example, a `EC2App` pattern might provide an `AutoScalingGroup`, `LoadBalancer` and the required `Roles` and `SecurityGroups`. These patterns are likely composed of multiple constrcuts (rather than CfnComponents) under-the-hood.
+
+This library aims to standardise and simplify the process of setting up Guardian stacks by providing reusable components but what level(s) of abstraction should be provided?
 
 ## Positions
 
 <!--- What are the differing positions or proposals on this issue? -->
 
-- Provide constructs and patterns
-- Any other option?
+1. Provide Constructs only
+
+   Constructs would give teams components they can use to get sensbile Guardian settings by default but with the flexibility to architect there stacks however they choose.
+
+2. Provide both Constructs and Patterns
+
+   Providing both patterns and constructs gives teams the flexibility to use constructs where required but also the ability to standup standard stacks with minimal effort. It also brings even greater standardisation and allows more complex features to be built in "for free".
 
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
 
-- Produce both constructs and patterns
-- Patterns for common Guardian stacks
-- Utility constructs covering common patterns for each construct (e.g. policy -> SSM policy, S3Artifact Policy, LogShippingPolicy)
+This library should define a number of Guardian flavoured constructs which extend those provided by the AWS CDK library with Guardian defaults baked in. For example, a `GuAutoScalingGroup` and `GuApplicationLoadBalancer`.
+
+Where those constructs are used in multiple ways, it should provide utlity classes for any common usages. For example, for the `Policy` constructs: `GuSSMPolicy`, `GuLogShippingPolicy` and `GuGetS3ObjectPolicy`
+
+Built on top of those, it should also provide a number of patterns to cover common Guardian stack architectures. For example, `GuEC2App` and `GuLambdaApp` patterns. These patterns should be the encouraged entry point to the library, with the constructs only used outside of standard cases.
 
 ## Consequences
 
 <!-- What becomes easier or more difficult to do because of this change? -->
 
-- Clear definition makes library use and maintainence easier.
-- Some difficult where components are across the boundary?
+Providing patterns makes the developer experience far quicker and simpler in cases where developers are standing up standard stack types. From a maintainence viewpoint, it adds some complexity in designing, building and maintaing the patterns.

--- a/docs/architecture-decision-records/002-component-constuctors.md
+++ b/docs/architecture-decision-records/002-component-constuctors.md
@@ -1,5 +1,3 @@
-**TODO: Write this in full sentences**
-
 # Component Constructors
 
 ## Status
@@ -12,31 +10,135 @@ proposed
 
 <!--- What is the issue that we're seeing that is motivating this decision or change? -->
 
-- This library contains a large number of classes, making up the various constructs and patterns
+This project contains a large number of classes, making up the various constructs and patterns. The project is intended to be used as a component library and, therefore, used by a number of people who don't have extensive knowledge of either the CDK or this library. It is therefore important to make the experience of using these classes as intuitive as possible.
 
 ## Positions
 
 <!--- What are the differing positions or proposals on this issue? -->
 
-- Constructors should all be the same for consistency
-- Constrctors should be the best fit for each class
-  - this mainly means that we can sometimes miss out the id and hardcode it or that id comes after props when its defaulted
+1. Constructors should be the same or as similar as possible for consistency
+
+   By having a consistent style for constructors, users will know what to expect every time they use a class from the library. This makes the developer experience easier and faster as users do not have to check what is required for each class.
+
+2. Constrctors should be the best fit for each class
+
+   In the case of this library, this mainly means either missing out the id or changing the order of the id and props inputs. In scenarios where a sensible id can either be hardcoded or defaulted, this would prevent users from having to add ids everywhere, reducing the amount of code they have to write.
 
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
 
-- Constructors should all accept a scope of type GuStack and an id of type string
-- They can also take a props object which should be correctly typed
-- Where all props are optional, the props object should be optional as a whole
-- Where props are optional, a default value for the id can be provided where appropriate
-- A default value should not be provided for the id value where props are required
+Constructors should follow the following rules for consistency.
+
+1. Constructors should all accept a `scope` of type `GuStack` and an `id` of type `string`
+
+   :white_check_mark: Valid
+
+   ```ts
+   class MyConstruct {
+     constructor(scope: GuStack, id: string) {
+       ...
+     }
+   }
+   ```
+
+   :x: Invalid
+
+   ```ts
+   class MyConstruct {
+     constructor(scope: Stack, id: string) {
+       ...
+     }
+   }
+   ```
+
+2. They can also take a `props` object which should be correctly typed
+
+   :white_check_mark: Valid
+
+   ```ts
+   interface MyConstructProps {...}
+
+   class MyConstruct {
+     constructor(scope: GuStack, id: string, props: MyConstructProps) {
+       ...
+     }
+   }
+   ```
+
+   :x: Invalid
+
+   ```ts
+   class MyConstruct {
+     constructor(scope: GuStack, id: string, props: object) {
+       ...
+     }
+   }
+   ```
+
+3. Where all `props` are optional, the `props` object should be optional as a whole
+
+   :white_check_mark: Valid
+
+   ```ts
+   interface MyConstructProps {
+     prop1?: string;
+     prop2?: string
+   }
+
+   class MyConstruct {
+     constructor(scope: GuStack, id: string, props?: MyConstructProps) {
+       ...
+     }
+   }
+   ```
+
+   :x: Invalid
+
+   ```ts
+   interface MyConstructProps {
+     prop1?: string;
+     prop2?: string
+   }
+
+   class MyConstruct {
+     constructor(scope: GuStack, id: string, props: MyConstructProps) {
+       ...
+     }
+   }
+   ```
+
+4. Where `props` are optional, a default value for the `id` can be provided where appropriate
+
+   :white_check_mark: Valid
+
+   ```ts
+   interface MyConstructProps {
+     prop1?: string;
+     prop2?: string
+   }
+
+   class MyConstruct {
+     constructor(scope: GuStack, id: string = "MyConstruct", props?: MyConstructProps) {
+       ...
+     }
+   }
+   ```
+
+   :x: Invalid
+
+   ```ts
+   interface MyConstructProps {...}
+
+   class MyConstruct {
+     constructor(scope: GuStack, id: string = "MyConstruct", props: MyConstructProps) {
+       ...
+     }
+   }
+   ```
 
 ## Consequences
 
 <!-- What becomes easier or more difficult to do because of this change? -->
 
-- Having all constructors follow a consistent patterns makes it easier for users of the library as they always know what to expect
-- The tradeoff is that some constructors may be sub-optimal
-- Generally this will means passing through and id where we could have
-  defaulted the value.
+Having all constructors follow a consistent patterns makes it easier for users of the library as they always know what to expect. The tradeoff is that some constructors may be sub-optimal. Generally this will means passing through an id where we could have defaulted the value which adds slightly to the amount of code required.

--- a/docs/architecture-decision-records/002-component-constuctors.md
+++ b/docs/architecture-decision-records/002-component-constuctors.md
@@ -1,0 +1,42 @@
+**TODO: Write this in full sentences**
+
+# Component Constructors
+
+## Status
+
+<!--- What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.? -->
+
+proposed
+
+## Context
+
+<!--- What is the issue that we're seeing that is motivating this decision or change? -->
+
+- This library contains a large number of classes, making up the various constructs and patterns
+
+## Positions
+
+<!--- What are the differing positions or proposals on this issue? -->
+
+- Constructors should all be the same for consistency
+- Constrctors should be the best fit for each class
+  - this mainly means that we can sometimes miss out the id and hardcode it or that id comes after props when its defaulted
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+- Constructors should all accept a scope of type GuStack and an id of type string
+- They can also take a props object which should be correctly typed
+- Where all props are optional, the props object should be optional as a whole
+- Where props are optional, a default value for the id can be provided where appropriate
+- A default value should not be provided for the id value where props are required
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+
+- Having all constructors follow a consistent patterns makes it easier for users of the library as they always know what to expect
+- The tradeoff is that some constructors may be sub-optimal
+- Generally this will means passing through and id where we could have
+  defaulted the value.

--- a/docs/architecture-decision-records/003-package-manager.md
+++ b/docs/architecture-decision-records/003-package-manager.md
@@ -1,0 +1,43 @@
+**TODO: Write this in full sentences**
+
+# Package Manager
+
+## Status
+
+<!--- What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.? -->
+
+proposed
+
+## Context
+
+<!--- What is the issue that we're seeing that is motivating this decision or change? -->
+
+- We can either use npm or yarn
+- This should be an either or situation but we've had some problems.
+- Yarn is (maybe) more commonly used across the department
+- It doesn't work for us with our current config
+  - `yarn login` still prompts for a password at release time which doesn't work with `np`
+  - publishing with `yarn` leaves only the `index.js` file in the `lib` directory
+- We could spend time fixing this but is it worth it?
+- script pattern makes this (more) transparent
+
+## Positions
+
+<!--- What are the differing positions or proposals on this issue? -->
+
+- Make it work with yarn
+- Stick with npm
+- Stick with npm but use the script pattern to make it (more) transparent to the user
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+- Use npm with the script pattern
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+
+- Using script pattern everywhere makes this easier (but only if we do it everywhere)
+- Relies on people knowing the abstraction

--- a/docs/architecture-decision-records/003-package-manager.md
+++ b/docs/architecture-decision-records/003-package-manager.md
@@ -27,7 +27,7 @@ The project can either use `npm` or `yarn` as the package manager. This should b
 
    Given that issues have been encountered using `yarn` and the fact that `npm` provides a working alternative with no obvious drawbacks (save the more common use of `yarn` in the department), it's not worth fixing the `yarn` issues.
 
-3. Use `npm` but use the script pattern to make it (more) transparent to the user
+3. Use `npm` but use the script pattern to make it (more) opaque to the user
 
    The [script pattern](https://github.com/github/scripts-to-rule-them-all) abstracts the choice of package manager (and the implementation of various tasks) away from the user. This would allow whichever tool was the best fit to be used across all projects whilst maintaining a consistent experience for developers.
 

--- a/docs/architecture-decision-records/003-package-manager.md
+++ b/docs/architecture-decision-records/003-package-manager.md
@@ -1,5 +1,3 @@
-**TODO: Write this in full sentences**
-
 # Package Manager
 
 ## Status
@@ -12,32 +10,39 @@ proposed
 
 <!--- What is the issue that we're seeing that is motivating this decision or change? -->
 
-- We can either use npm or yarn
-- This should be an either or situation but we've had some problems.
-- Yarn is (maybe) more commonly used across the department
-- It doesn't work for us with our current config
-  - `yarn login` still prompts for a password at release time which doesn't work with `np`
-  - publishing with `yarn` leaves only the `index.js` file in the `lib` directory
-- We could spend time fixing this but is it worth it?
-- script pattern makes this (more) transparent
+The project can either use `npm` or `yarn` as the package manager. This should be an either/or situation but a number of issues have been encountered when using `yarn` including:
+
+- `yarn login` still prompts for a password at release time which doesn't work with `np`
+- publishing with `yarn` leaves only the `index.js` file in the `lib` directory
 
 ## Positions
 
 <!--- What are the differing positions or proposals on this issue? -->
 
-- Make it work with yarn
-- Stick with npm
-- Stick with npm but use the script pattern to make it (more) transparent to the user
+1. Use `yarn` and fix the existing issues
+
+   `Yarn` is more widely used across the team's, and wider department's, projects so it would present a more consistent approach. There are more examples of common tasks written in `yarn` from our existing projects and developer's are more likely to default to running `yarn` commands.
+
+2. Use `npm`
+
+   Given that issues have been encountered using `yarn` and the fact that `npm` provides a working alternative with no obvious drawbacks (save the more common use of `yarn` in the department), it's not worth fixing the `yarn` issues.
+
+3. Use `npm` but use the script pattern to make it (more) transparent to the user
+
+   The [script pattern](https://github.com/github/scripts-to-rule-them-all) abstracts the choice of package manager (and the implementation of various tasks) away from the user. This would allow whichever tool was the best fit to be used across all projects whilst maintaining a consistent experience for developers.
 
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
 
-- Use npm with the script pattern
+Use npm with the script pattern.
+
+Any common tasks (e.g. `lint`, `test`, `build`) should have a script defined in the `script` directory. Any scripts run by CI should also be stored in this directory.
 
 ## Consequences
 
 <!-- What becomes easier or more difficult to do because of this change? -->
 
-- Using script pattern everywhere makes this easier (but only if we do it everywhere)
-- Relies on people knowing the abstraction
+Using the script pattern allows us to present a consistent interface whilst using whichever tool works best. Further to that, it makes it easier for new developers coming to a project as they don't have to know the specific commands to perform each task. Instead, they can easily see the available commands and run them simply by name.
+
+This pattern becomes increasingly useful the more projects it is used in as developers get used to going to the `./script` directory rather than running command directly. Without common usage across the team it risks becoming a third standard rather than a replacement for the previous two ([Relevant XKCD](https://xkcd.com/927/)).

--- a/docs/architecture-decision-records/004-testing.md
+++ b/docs/architecture-decision-records/004-testing.md
@@ -1,5 +1,3 @@
-**TODO: Write this in full sentences**
-
 # Testing
 
 ## Status
@@ -10,27 +8,23 @@ proposed
 
 <!--- What is the issue that we're seeing that is motivating this decision or change? -->
 
-- One of the benefits of writing our infrastructure in a fully fledged programming language is the ability to write reusable components which can be tested.
-- This library defines those components, both in the form of constructs and patterns
-  - see [001-constructs-and-patterns](./001-constructs-and-patterns.md) for more details
-- There are two main strategies that can be used to unit test these components.
+One of the benefits of writing our infrastructure in a fully fledged programming language is the ability to write reusable components which can be tested. This library defines those components, both in the form of constructs and patterns (see [001-constructs-and-patterns](./001-constructs-and-patterns.md) for more details).
 
-  - Snapshots
+There are two main strategies that can be used to unit test these components.
+
+Snapshot tests synthesise a given stack and compare the output to a previous version that has been verified by the user and checked into the repository. If there are any changes, the test fails and the user is displayed the diff to either fix or update the stored snapshot.
+
     [+] Quick and easy to write
 
     [+] Pick up any changes to the output cloudformation (particularly useful for unintended side effects)
 
     [-] A change to the component may cause many unrelated tests to also fail
 
-    [-] When testing different permutations of a component, a number of snapshots will be created, each of which contains a
-    certain amount of information which is irrelevant to the particular test. This adds some extra effort to understand what
-    is relevant to the test which you're looking at
+    [-] When testing different permutations of a component, a number of snapshots will be created, each of which contains a certain amount of information which is irrelevant to the particular test. This adds some extra effort to understand what is relevant to the test which you're looking at
 
-    [-] Snapshots are easy to update which, especially when multiple are affected by a change, makes it easy to accidentally
-    update them incorrectly. Further to this, as the snapshot (which is essentially the assertion) is stored in a different file,
-    it's not immediately obvious if the assertions are valid
+    [-] Snapshots are easy to update which, especially when multiple are affected by a change, makes it easy to accidentally update them incorrectly. Further to this, as the snapshot (which is essentially the assertion) is stored in a different file, it's not immediately obvious if the assertions are valid
 
-  - Direct Assertions
+Direct Assertions use the different assertions provided by the test framework to test specific functionality. For example, asserting that a property exists or that an array contains a particular value.
 
     [+] Each test only contains the relevant assertions for the test, making it easier to understand the consequence of settings certain props
 
@@ -42,20 +36,26 @@ proposed
 
 <!--- What are the differing positions or proposals on this issue? -->
 
-- Use snapshots for everything
-- Use direct assertions for everything
-- Use a combination of both for everything
-- Use direct assertions for constructs and patterns for patterns (and stacks)
+1. Use snapshots for everything
+
+2. Use direct assertions for everything
+
+3. Use a combination of both for everything
+
+4. Use direct assertions for constructs and snapshots for patterns (and stacks)
 
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
 
-- Use direct assertions for constructs and patterns for patterns (and stacks)
+Use direct assertions for constructs and snapshots for patterns (and stacks)
+
+_This decision is a recommendation for the general approach. There may be some cases where using a different approach is more applicable for a given test._
 
 ## Consequences
 
 <!-- What becomes easier or more difficult to do because of this change? -->
 
-- We have a consistent style for testing which makes it easier to decide how to test
-- It might take more effort if we commit to direct assertions for constructs
+Haivng a consistent style for tests makes it easier to decide what and how to test each component. This approach should ensure that the unit tests provide good coverage whilst being easy to understand and maintain.
+
+As direct assertion tests are more time consuming and complex to write than snapshots, this will create some additional work.

--- a/docs/architecture-decision-records/004-testing.md
+++ b/docs/architecture-decision-records/004-testing.md
@@ -1,0 +1,61 @@
+**TODO: Write this in full sentences**
+
+# Testing
+
+## Status
+
+proposed
+
+## Context
+
+<!--- What is the issue that we're seeing that is motivating this decision or change? -->
+
+- One of the benefits of writing our infrastructure in a fully fledged programming language is the ability to write reusable components which can be tested.
+- This library defines those components, both in the form of constructs and patterns
+  - see [001-constructs-and-patterns](./001-constructs-and-patterns.md) for more details
+- There are two main strategies that can be used to unit test these components.
+
+  - Snapshots
+    [+] Quick and easy to write
+
+    [+] Pick up any changes to the output cloudformation (particularly useful for unintended side effects)
+
+    [-] A change to the component may cause many unrelated tests to also fail
+
+    [-] When testing different permutations of a component, a number of snapshots will be created, each of which contains a
+    certain amount of information which is irrelevant to the particular test. This adds some extra effort to understand what
+    is relevant to the test which you're looking at
+
+    [-] Snapshots are easy to update which, especially when multiple are affected by a change, makes it easy to accidentally
+    update them incorrectly. Further to this, as the snapshot (which is essentially the assertion) is stored in a different file,
+    it's not immediately obvious if the assertions are valid
+
+  - Direct Assertions
+
+    [+] Each test only contains the relevant assertions for the test, making it easier to understand the consequence of settings certain props
+
+    [+] Changes will only fail tests that cover that particular area
+
+    [-] More complex and time consuming to write
+
+## Positions
+
+<!--- What are the differing positions or proposals on this issue? -->
+
+- Use snapshots for everything
+- Use direct assertions for everything
+- Use a combination of both for everything
+- Use direct assertions for constructs and patterns for patterns (and stacks)
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+- Use direct assertions for constructs and patterns for patterns (and stacks)
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+
+- We have a consistent style for testing which makes it easier to decide how to test
+- It might take more effort if we commit to direct assertions for constructs

--- a/docs/architecture-decision-records/005-package-structure.md
+++ b/docs/architecture-decision-records/005-package-structure.md
@@ -1,5 +1,3 @@
-**TODO: Write this in full sentences**
-
 # Package Structure
 
 ## Status
@@ -12,29 +10,38 @@ proposed
 
 <!--- What is the issue that we're seeing that is motivating this decision or change? -->
 
-- We're building a big old library of components
-- As this continues to grow, it's important to have a sensible architecture both for development and usage.
+This project defines a library of components build on top of the AWS CDK and aiming to improve the user experience for managing infrastructure at the Guardian. As the library continues to grow, it is important that the library is structured sensibly, both for developers maintaining the library and those using it.
 
 ## Positions
 
 <!--- What are the differing positions or proposals on this issue? -->
 
-- We could follow the AWS CDK library setup
-  - This would make it easier for users as they can expect to find GuComponents in the same place they would get them from AWS.
-  - It also means we can just rely on the AWS CDK library deciding what a sensible structure is
-- We could define our own style
-  - We're not defining any where near the number of components that are in the AWS CDK so that might not be the most logical structure
-  - We're also going to have lots of Gu invocations of one cdk type (e.g. policy -> SSM policy, S3Artifact Policy) so where do we put those
+1. Match the structure of the different CDK libraries
+
+   AWS CDK is publishing as numerous individual libraries split by resource groups (e.g. `iam`, `ec2`). Although we are publishing as one library, we could mirror this structure in our directories. This would mean that a user who was familiar with the CDK would be able to take a good guess as to where a component lived in this project.
+
+   It also means that we don't have to make decisions about where components should live as we can just follow what AWS do.
+
+2. We could define our own style
+
+   This library doesn't contain anywhere near the full range of components that the AWS CDK provides. As such, following that structure may not be the best choice here.
+
+   While it does not provide the range of components, this library does provide multiple implementations of the same underlying resource (e.g. for the `Policy` construct, `GuLogShippingPolicy`, `GuSSMRunCommandPolicy`, `GuGetS3ObjectPolicy`).
 
 ## Decision
 
 <!-- What is the change that we're proposing and/or doing? -->
 
-- It should roughly replicate the structure of the cdk library at the top level (e.g. core, ec2)
-- Below that, what should we do?
+The top level directories with the `constructs` directory should mirror the AWS CDK library names.
+
+Each directory should contain an `index.ts` file which exports all of the classes within it.
+
+Files within these directories can either be at the top level or nested within directories. Where nested directories exist, they should only be used for grouping multiple implementations of the same underlying construct. For example, `GuLogShippingPolicy`, `GuSSMRunCommandPolicy`, `GuGetS3ObjectPolicy` could all be in seperate files within the `constrcuts/iam/policies` directory. These directories should also export all memebers in an `index.ts` file.
+
+Patterns can all be defined at the top level within the `patterns` directory. They should all be exported in the `index.ts` file so that they can all be imported from `@guardian/cdk`
 
 ## Consequences
 
 <!-- What becomes easier or more difficult to do because of this change? -->
 
-- Having a clearly defined project structure makes it easier to use
+Having a clearly defined project structure makes it easier for developers of the library to find, add and maintain components. It also makes for a more intuitive experience for users of the library as they know where to look and import components from.

--- a/docs/architecture-decision-records/005-package-structure.md
+++ b/docs/architecture-decision-records/005-package-structure.md
@@ -1,0 +1,40 @@
+**TODO: Write this in full sentences**
+
+# Package Structure
+
+## Status
+
+<!--- What is the status, such as proposed, accepted, rejected, deprecated, superseded, etc.? -->
+
+proposed
+
+## Context
+
+<!--- What is the issue that we're seeing that is motivating this decision or change? -->
+
+- We're building a big old library of components
+- As this continues to grow, it's important to have a sensible architecture both for development and usage.
+
+## Positions
+
+<!--- What are the differing positions or proposals on this issue? -->
+
+- We could follow the AWS CDK library setup
+  - This would make it easier for users as they can expect to find GuComponents in the same place they would get them from AWS.
+  - It also means we can just rely on the AWS CDK library deciding what a sensible structure is
+- We could define our own style
+  - We're not defining any where near the number of components that are in the AWS CDK so that might not be the most logical structure
+  - We're also going to have lots of Gu invocations of one cdk type (e.g. policy -> SSM policy, S3Artifact Policy) so where do we put those
+
+## Decision
+
+<!-- What is the change that we're proposing and/or doing? -->
+
+- It should roughly replicate the structure of the cdk library at the top level (e.g. core, ec2)
+- Below that, what should we do?
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+
+- Having a clearly defined project structure makes it easier to use


### PR DESCRIPTION
## What does this change?

This PR adds a `docs` dir with separate files for general usage, starting a new CDK project and migrating existing cloudformation to CDK. Grouping the docs into their own folder makes it easier to split the files out logically as we expand the documentation about the library. 

It also adds a folder of [Architecture Design Records (ADRs)](https://github.com/joelparkerhenderson/architecture_decision_record). These files are where we can document the decisions we make around any form of structure, architecture or approach. By documenting them in this way, we can preserve the thought process behind all of the decisions whilst also laying out formally the preferences for all developers working on the library. 

The folder contains a template and some initial ADRs covering decisions we've discussed to date. 

## Does this change require changes to existing projects or CDK CLI?

No.

## How can we measure success?

All of our design decisions are documented to remind future us why we thought something was a good idea at the time