### PR TITLE
tweak private properties of GuStack

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -7,8 +7,9 @@ export interface GuStackProps extends StackProps {
 }
 
 export class GuStack extends Stack {
-  protected _stage: GuStageParameter;
-  protected _stack: GuStackParameter;
+  private readonly _stage: GuStageParameter;
+  private readonly _stack: GuStackParameter;
+  private readonly _app: string | undefined;
 
   get stage(): string {
     return this._stage.valueAsString;
@@ -17,8 +18,6 @@ export class GuStack extends Stack {
   get stack(): string {
     return this._stack.valueAsString;
   }
-
-  private _app: string | undefined;
 
   get app(): string {
     if (this._app) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The compiler hinted at this and it makes sense. No impact to anything as nothing is using the fields in their current `protected` state.