### PR TITLE
Add overrideId prop to GuAutoScalingGroup and refactor for TODOs

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -114,19 +114,29 @@ describe("The GuAutoScalingGroup", () => {
   test("does not include the UpdatePolicy property", () => {
     const app = new App();
     const stack = new GuStack(app);
-    new GuAutoScalingGroup(stack, "AutoscalingGroup", defaultProps);
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, overrideId: true });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources.AutoscalingGroup)).not.toContain("UpdatePolicy");
   });
 
-  test("overrides the id to remove the 8 digit value added automagically", () => {
+  test("overrides the id with the overrideId prop set to true", () => {
+    const app = new App();
+    const stack = new GuStack(app);
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, overrideId: true });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(Object.keys(json.Resources)).toContain("AutoscalingGroup");
+  });
+
+  test("does not override the id by default", () => {
     const app = new App();
     const stack = new GuStack(app);
     new GuAutoScalingGroup(stack, "AutoscalingGroup", defaultProps);
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
-    expect(Object.keys(json.Resources)).toContain("AutoscalingGroup");
+    expect(Object.keys(json.Resources)).not.toContain("AutoscalingGroup");
   });
 });

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -20,6 +20,7 @@ export interface GuAutoScalingGroupProps
   userData: string;
   securityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
+  overrideId: boolean;
 }
 
 export class GuAutoScalingGroup extends AutoScalingGroup {
@@ -51,7 +52,9 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
     // leaves it to the default value, which is actually false.
     // { UpdatePolicy: { autoScalingScheduledAction: { IgnoreUnmodifiedGroupSizeProperties: true }}
     cfnAsg.addDeletionOverride("UpdatePolicy");
-    // TODO: I think this should be behind an option prop
-    cfnAsg.overrideLogicalId(id);
+
+    if (props.overrideId) {
+      cfnAsg.overrideLogicalId(id);
+    }
   }
 }

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -20,7 +20,7 @@ export interface GuAutoScalingGroupProps
   userData: string;
   securityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
-  overrideId: boolean;
+  overrideId?: boolean;
 }
 
 export class GuAutoScalingGroup extends AutoScalingGroup {

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -53,8 +53,6 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
     // { UpdatePolicy: { autoScalingScheduledAction: { IgnoreUnmodifiedGroupSizeProperties: true }}
     cfnAsg.addDeletionOverride("UpdatePolicy");
 
-    if (props.overrideId) {
-      cfnAsg.overrideLogicalId(id);
-    }
+    if (props.overrideId) cfnAsg.overrideLogicalId(id);
   }
 }

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -40,8 +40,6 @@ export class GuStackParameter extends GuParameter {
   }
 }
 
-// TODO: Is there a way of removing default props if they weren't implemented before?
-//       Should that be allowed even if it is possible?
 export class GuInstanceTypeParameter extends GuParameter {
   constructor(scope: GuStack, id: string = "InstanceType", props: GuParameterProps = {}) {
     super(scope, id, {

--- a/src/constructs/iam/policies.ts
+++ b/src/constructs/iam/policies.ts
@@ -79,8 +79,7 @@ export class GuSSMRunCommandPolicy extends GuPolicy {
     };
   }
 
-  // TODO: It's not possible to use the default id as props are required. Should we change this?
-  constructor(scope: GuStack, id: string = "SSMRunCommandPolicy", props: GuPolicyProps) {
+  constructor(scope: GuStack, id: string, props: GuPolicyProps) {
     super(scope, id, {
       ...GuSSMRunCommandPolicy.getDefaultProps(),
       ...props,

--- a/src/constructs/iam/policies.ts
+++ b/src/constructs/iam/policies.ts
@@ -48,34 +48,32 @@ export class GuLogShippingPolicy extends GuPolicy {
   }
 }
 
+export const allowSSMRunCommandPolicyStatement = new PolicyStatement({
+  effect: Effect.ALLOW,
+  actions: [
+    "ec2messages:AcknowledgeMessage",
+    "ec2messages:DeleteMessage",
+    "ec2messages:FailMessage",
+    "ec2messages:GetEndpoint",
+    "ec2messages:GetMessages",
+    "ec2messages:SendReply",
+    "ssm:UpdateInstanceInformation",
+    "ssm:ListInstanceAssociations",
+    "ssm:DescribeInstanceProperties",
+    "ssm:DescribeDocumentParameters",
+    "ssmmessages:CreateControlChannel",
+    "ssmmessages:CreateDataChannel",
+    "ssmmessages:OpenControlChannel",
+    "ssmmessages:OpenDataChannel",
+  ],
+  resources: ["*"],
+});
+
 export class GuSSMRunCommandPolicy extends GuPolicy {
-  // TODO: Is it worth extracting some of these defaults to make them easier to use
-  //       in their own right elsewhere
   private static getDefaultProps(): Partial<PolicyProps> {
     return {
       policyName: "ssm-run-command-policy",
-      statements: [
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: [
-            "ec2messages:AcknowledgeMessage",
-            "ec2messages:DeleteMessage",
-            "ec2messages:FailMessage",
-            "ec2messages:GetEndpoint",
-            "ec2messages:GetMessages",
-            "ec2messages:SendReply",
-            "ssm:UpdateInstanceInformation",
-            "ssm:ListInstanceAssociations",
-            "ssm:DescribeInstanceProperties",
-            "ssm:DescribeDocumentParameters",
-            "ssmmessages:CreateControlChannel",
-            "ssmmessages:CreateDataChannel",
-            "ssmmessages:OpenControlChannel",
-            "ssmmessages:OpenDataChannel",
-          ],
-          resources: ["*"],
-        }),
-      ],
+      statements: [allowSSMRunCommandPolicyStatement],
     };
   }
 
@@ -91,20 +89,20 @@ export interface GuGetS3ObjectPolicyProps extends GuPolicyProps {
   bucket: string;
 }
 
+export const allowGetObjectPolicyStatement = (bucket: string) => ({
+  statements: [
+    new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["s3:GetObject"],
+      resources: [`arn:aws:s3:::${bucket}/*`],
+    }),
+  ],
+});
+
 export class GuGetS3ObjectPolicy extends GuPolicy {
   constructor(scope: GuStack, id: string, props: GuGetS3ObjectPolicyProps) {
     // TODO validate `props.bucket` based on the rules defined here https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
 
-    const policy = {
-      statements: [
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: ["s3:GetObject"],
-          resources: [`arn:aws:s3:::${props.bucket}/*`],
-        }),
-      ],
-    };
-
-    super(scope, id, { ...policy, ...props });
+    super(scope, id, { ...allowGetObjectPolicyStatement(props.bucket), ...props });
   }
 }


### PR DESCRIPTION
## What does this change?

This addresses a number of TODOs in the repository, specifically:

1. Adds an `overrideId` prop to `GuAutoScalingGroup`, rather than overriding by default
2. Extracts the SSM run command policy statement to its own variable so it can be used elsewhere in the future
3. Extracts the allowGetObjectPolicyStatement to its own variable for same reasons as above

## Does this change require changes to existing projects or CDK CLI?

Yes, it looks like [a few repositories](https://github.com/search?q=new+GuAutoScalingGroup+user%3Aguardian&type=code) will need to be updated in order to take the GuAutoScalingGroup change into account.

## How to test

`yarn test` from root of the repository.

## How can we measure success?

The repository is cleaner (and littered with fewer TODOs) and our `GuAutoScalingGroup` construct is more consistent with the rest of the constructs.

## Have we considered potential risks?

We need to make sure we migrate the affected repositories successfully, as this could cause add/removes for the existing ASGs if not. However, it shouldn't be too hard as we'd just need to bump the version and add the `overrideId: true` prop to the usages.
