### PR TITLE
Make overrideId optional for GuApplicationLoadBalancer

### DIFF
--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -14,19 +14,28 @@ describe("The GuApplicationLoadBalancer class", () => {
     publicSubnetIds: [""],
   });
 
-  test("overrides the id", () => {
+  test("overrides the id with the overrideId prop", () => {
     const app = new App();
     const stack = new GuStack(app);
-    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, overrideId: true });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources)).toContain("ApplicationLoadBalancer");
   });
 
-  test("deletes the Type property", () => {
+  test("has an auto-generated ID by default", () => {
     const app = new App();
     const stack = new GuStack(app);
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("ApplicationLoadBalancer");
+  });
+
+  test("deletes the Type property", () => {
+    const app = new App();
+    const stack = new GuStack(app);
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, overrideId: true });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources.ApplicationLoadBalancer.Properties)).not.toContain("Type");

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -15,17 +15,20 @@ import {
 import type { GuStack } from "../core";
 
 // TODO: By default, an application load balancer has deletion protection set to false.
-// We probably want to protect this load balancer as much as possible
-// should we set it to true instead?
+//  We probably want to protect this load balancer as much as possible
+//  should we set it to true instead?
+
+interface GuApplicationLoadBalancerProps extends ApplicationLoadBalancerProps {
+  overrideId?: boolean;
+}
 
 export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
-  constructor(scope: GuStack, id: string, props: ApplicationLoadBalancerProps) {
+  constructor(scope: GuStack, id: string, props: GuApplicationLoadBalancerProps) {
     super(scope, id, props);
 
-    // TODO: Maybe we should put these behind an option(s) so that the user
-    // can decide if they want/need it
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
-    cfnLb.overrideLogicalId(id);
+
+    if (props.overrideId) cfnLb.overrideLogicalId(id);
 
     cfnLb.addPropertyDeletionOverride("Type");
   }
@@ -39,9 +42,7 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
   constructor(scope: GuStack, id: string, props: GuApplicationTargetGroupProps) {
     super(scope, id, props);
 
-    if (props.overrideId) {
-      (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
-    }
+    if (props.overrideId) (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
   }
 }
 
@@ -58,8 +59,6 @@ export class GuApplicationListener extends ApplicationListener {
   constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
     super(scope, id, { ...GuApplicationListener.defaultProps, ...props });
 
-    if (props.overrideId) {
-      (this.node.defaultChild as CfnListener).overrideLogicalId(id);
-    }
+    if (props.overrideId) (this.node.defaultChild as CfnListener).overrideLogicalId(id);
   }
 }


### PR DESCRIPTION
## What does this change?

This PR adds an `overrideId` prop to `GuApplicationLoadBalancer `, rather than overriding by default.

## Does this change require changes to existing projects or CDK CLI?

Yes, it looks like just the [one](https://github.com/guardian/deploy-tools-platform/blob/14d392c29405ef53a0a9d0ad930090442e92400b/cdk/lib/grafana/grafana-stack.ts#L191) usage needs to be updated.

## How to test

`yarn test` from root of the repository.

## How can we measure success?

The repository is cleaner and our `GuApplicationLoadBalancer` construct is more consistent with the rest of the constructs.
