### PR TITLE
make `app` mandatory in a GuStack

### DIFF
--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -3,14 +3,14 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
 import { App } from "@aws-cdk/core";
+import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
 import type { SynthedStack } from "../../../test/utils/synthed-stack";
 import { Stage, Stages } from "../../constants";
 import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
   it("should have stack and stage parameters", () => {
-    const app = new App();
-    const stack = new GuStack(app);
+    const stack = simpleGuStackForTesting();
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
@@ -29,32 +29,7 @@ describe("The GuStack construct", () => {
     });
   });
 
-  it("should apply the stack and stage tags to resources added to it", () => {
-    const stack = new GuStack(new App());
-
-    new Role(stack, "MyRole", {
-      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-    });
-
-    expect(stack).toHaveResource("AWS::IAM::Role", {
-      Tags: [
-        {
-          Key: "Stack",
-          Value: {
-            Ref: "Stack",
-          },
-        },
-        {
-          Key: "Stage",
-          Value: {
-            Ref: "Stage",
-          },
-        },
-      ],
-    });
-  });
-
-  it("should apply the app tag to resources added to it if provided", () => {
+  it("should apply the stack, stage and app tags to resources added to it", () => {
     const stack = new GuStack(new App(), "Test", { app: "MyApp" });
 
     new Role(stack, "MyRole", {
@@ -87,10 +62,5 @@ describe("The GuStack construct", () => {
     const stack = new GuStack(new App(), "Test", { app: "MyApp" });
 
     expect(stack.app).toBe("MyApp");
-  });
-  it("should return an error when app is accessed and no app is set", () => {
-    const stack = new GuStack(new App(), "Test");
-
-    expect(() => stack.app).toThrowError("App is not set");
   });
 });

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -3,13 +3,15 @@ import { Stack, Tags } from "@aws-cdk/core";
 import { GuStackParameter, GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
-  app?: string;
+  // This limits a stack to a single app
+  // TODO understand how to support a multi-app stack
+  app: string;
 }
 
 export class GuStack extends Stack {
   private readonly _stage: GuStageParameter;
   private readonly _stack: GuStackParameter;
-  private readonly _app: string | undefined;
+  private readonly _app: string;
 
   get stage(): string {
     return this._stage.valueAsString;
@@ -20,31 +22,22 @@ export class GuStack extends Stack {
   }
 
   get app(): string {
-    if (this._app) {
-      return this._app;
-    } else {
-      // Throw an error here so that if you forget to set app and
-      // try to use it, your stack fails to generate
-      throw new Error("App is not set");
-    }
+    return this._app;
   }
 
   protected addTag(key: string, value: string, applyToLaunchedInstances: boolean = true): void {
     Tags.of(this).add(key, value, { applyToLaunchedInstances });
   }
 
-  constructor(app: App, id?: string, props?: GuStackProps) {
+  constructor(app: App, id: string, props: GuStackProps) {
     super(app, id, props);
 
     this._stage = new GuStageParameter(this);
     this._stack = new GuStackParameter(this);
+    this._app = props.app;
 
     this.addTag("Stack", this.stack);
     this.addTag("Stage", this.stage);
-
-    if (props?.app) {
-      this._app = props.app;
-      this.addTag("App", props.app);
-    }
+    this.addTag("App", props.app);
   }
 }

--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -93,6 +93,10 @@ Object {
         "Runtime": "nodejs12.x",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -137,6 +141,10 @@ Object {
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
           Object {
             "Key": "Stack",
             "Value": Object {
@@ -209,6 +217,10 @@ Object {
         "Name": "api2",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -224,7 +236,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "lambdaapi2ANYApiPermissionTestlambdaapi259EAFB9DANY48E96467": Object {
+    "lambdaapi2ANYApiPermissionTestTestlambdaapi29FEAC710ANYB2B37DB0": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -261,7 +273,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapi2ANYApiPermissionlambdaapi259EAFB9DANY6FDE4CEE": Object {
+    "lambdaapi2ANYApiPermissionTestlambdaapi29FEAC710ANY878BC567": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -389,6 +401,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -404,7 +420,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB9373147f6f95cb40b69dd906958d230d079f": Object {
+    "lambdaapi2Deployment4ECB93738ba48d7cb88b4c2b9ec5c442ee1c99e9": Object {
       "DependsOn": Array [
         "lambdaapi2proxyANY3F8E1D36",
         "lambdaapi2proxyE68FDFBC",
@@ -421,13 +437,17 @@ Object {
     "lambdaapi2DeploymentStageprodCC9E3016": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB9373147f6f95cb40b69dd906958d230d079f",
+          "Ref": "lambdaapi2Deployment4ECB93738ba48d7cb88b4c2b9ec5c442ee1c99e9",
         },
         "RestApiId": Object {
           "Ref": "lambdaapi239350ECC",
         },
         "StageName": "prod",
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
           Object {
             "Key": "Stack",
             "Value": Object {
@@ -484,7 +504,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaapi2proxyANYApiPermissionTestlambdaapi259EAFB9DANYproxy9E2764AE": Object {
+    "lambdaapi2proxyANYApiPermissionTestTestlambdaapi29FEAC710ANYproxy20D9E3C9": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -521,7 +541,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapi2proxyANYApiPermissionlambdaapi259EAFB9DANYproxyAD2B0773": Object {
+    "lambdaapi2proxyANYApiPermissionTestlambdaapi29FEAC710ANYproxy33429FF8": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -620,7 +640,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaapiANYApiPermissionTestlambdaapiC0087213ANY5E7CDADF": Object {
+    "lambdaapiANYApiPermissionTestTestlambdaapi0E958EEBANY3DF279D1": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -657,7 +677,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapiANYApiPermissionlambdaapiC0087213ANY629951AC": Object {
+    "lambdaapiANYApiPermissionTestlambdaapi0E958EEBANYA0BDE5E2": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -718,6 +738,10 @@ Object {
         "Name": "api",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -763,6 +787,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -778,7 +806,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B585cd631e09cd975e3e69d1ae39cb1f1c4c": Object {
+    "lambdaapiDeployment8E95B5854e05b687211f19a449136200fabf5846": Object {
       "DependsOn": Array [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -795,13 +823,17 @@ Object {
     "lambdaapiDeploymentStageprod9598BC2F": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B585cd631e09cd975e3e69d1ae39cb1f1c4c",
+          "Ref": "lambdaapiDeployment8E95B5854e05b687211f19a449136200fabf5846",
         },
         "RestApiId": Object {
           "Ref": "lambdaapiC1812993",
         },
         "StageName": "prod",
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
           Object {
             "Key": "Stack",
             "Value": Object {
@@ -858,7 +890,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaapiproxyANYApiPermissionTestlambdaapiC0087213ANYproxyB7FE8155": Object {
+    "lambdaapiproxyANYApiPermissionTestTestlambdaapi0E958EEBANYproxy716A4EB4": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -895,7 +927,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapiproxyANYApiPermissionlambdaapiC0087213ANYproxyAA2F1520": Object {
+    "lambdaapiproxyANYApiPermissionTestlambdaapi0E958EEBANYproxy81BB250D": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -85,6 +85,10 @@ describe("The GuDatabaseInstance class", () => {
       },
       Tags: [
         {
+          Key: "App",
+          Value: "testing",
+        },
+        {
           Key: "Stack",
           Value: {
             Ref: "Stack",

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -88,6 +88,10 @@ Object {
         "Path": "/",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
             "Key": "Stack",
             "Value": Object {
               "Ref": "Stack",
@@ -209,6 +213,10 @@ Object {
         },
         "Path": "/",
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
           Object {
             "Key": "Stack",
             "Value": Object {
@@ -370,6 +378,10 @@ Object {
         },
         "Path": "/",
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
           Object {
             "Key": "Stack",
             "Value": Object {

--- a/test/utils/simple-gu-stack.ts
+++ b/test/utils/simple-gu-stack.ts
@@ -1,4 +1,4 @@
 import { App } from "@aws-cdk/core";
 import { GuStack } from "../../src/constructs/core";
 
-export const simpleGuStackForTesting: () => GuStack = () => new GuStack(new App());
+export const simpleGuStackForTesting: () => GuStack = () => new GuStack(new App(), "Test", { app: "testing" });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

For now, we do not support a multi-app stack so make `app` mandatory for simplicity.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes, as the signature of GuStack's constructor has changed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler code, for now?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We'll need to support multi-app stacks at some point, so this might cause a massive diff later.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a

