### PR TITLE
Add a test helper for policy tests

### DIFF
--- a/src/constructs/iam/policies/base-policy.test.ts
+++ b/src/constructs/iam/policies/base-policy.test.ts
@@ -1,8 +1,8 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
-import { Effect, PolicyStatement, Role, ServicePrincipal } from "@aws-cdk/aws-iam";
-import { simpleGuStackForTesting } from "../../../../test/utils/simple-gu-stack";
-import type { SynthedStack } from "../../../../test/utils/synthed-stack";
+import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import type { SynthedStack } from "../../../../test/utils";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
 import { GuPolicy } from "./base-policy";
 
 describe("The GuPolicy", () => {
@@ -19,11 +19,7 @@ describe("The GuPolicy", () => {
       ],
     });
 
-    policy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, policy);
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
@@ -42,11 +38,7 @@ describe("The GuPolicy", () => {
       ],
     });
 
-    policy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, policy);
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 

--- a/src/constructs/iam/policies/log-shipping.test.ts
+++ b/src/constructs/iam/policies/log-shipping.test.ts
@@ -1,6 +1,5 @@
 import "@aws-cdk/assert/jest";
-import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
-import { simpleGuStackForTesting } from "../../../../test/utils/simple-gu-stack";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
 import { GuLogShippingPolicy } from "./log-shipping";
 
 describe("The GuLogShippingPolicy class", () => {
@@ -9,12 +8,7 @@ describe("The GuLogShippingPolicy class", () => {
 
     const logShippingPolicy = new GuLogShippingPolicy(stack, "LogShippingPolicy", { loggingStreamName: "test" });
 
-    // IAM Policies need to be attached to a role, group or user to be created in a stack
-    logShippingPolicy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, logShippingPolicy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "log-shipping-policy",
@@ -54,12 +48,7 @@ describe("The GuLogShippingPolicy class", () => {
       policyName: "test",
     });
 
-    // IAM Policies need to be attached to a role, group or user to be created in a stack
-    logShippingPolicy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, logShippingPolicy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "test",

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -1,6 +1,5 @@
 import "@aws-cdk/assert/jest";
-import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
-import { simpleGuStackForTesting } from "../../../../test/utils/simple-gu-stack";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
 import { GuGetS3ObjectPolicy } from "./s3-get-object";
 
 describe("The GuGetS3ObjectPolicy class", () => {
@@ -9,12 +8,7 @@ describe("The GuGetS3ObjectPolicy class", () => {
 
     const s3Policy = new GuGetS3ObjectPolicy(stack, "S3Policy", { bucketName: "test" });
 
-    // IAM Policies need to be attached to a role, group or user to be created in a stack
-    s3Policy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, s3Policy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyDocument: {
@@ -35,12 +29,7 @@ describe("The GuGetS3ObjectPolicy class", () => {
 
     const s3Policy = new GuGetS3ObjectPolicy(stack, "S3Policy", { bucketName: "test", policyName: "test" });
 
-    // IAM Policies need to be attached to a role, group or user to be created in a stack
-    s3Policy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, s3Policy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "test",

--- a/src/constructs/iam/policies/ssm.test.ts
+++ b/src/constructs/iam/policies/ssm.test.ts
@@ -1,6 +1,5 @@
 import "@aws-cdk/assert/jest";
-import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
-import { simpleGuStackForTesting } from "../../../../test/utils/simple-gu-stack";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
 import { GuSSMRunCommandPolicy } from "./ssm";
 
 describe("The GuSSMRunCommandPolicy class", () => {
@@ -9,12 +8,7 @@ describe("The GuSSMRunCommandPolicy class", () => {
 
     const ssmPolicy = new GuSSMRunCommandPolicy(stack, "SSMRunCommandPolicy", {});
 
-    // IAM Policies need to be attached to a role, group or user to be created in a stack
-    ssmPolicy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, ssmPolicy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "ssm-run-command-policy",
@@ -53,12 +47,7 @@ describe("The GuSSMRunCommandPolicy class", () => {
       policyName: "test",
     });
 
-    // IAM Policies need to be attached to a role, group or user to be created in a stack
-    ssmPolicy.attachToRole(
-      new Role(stack, "TestRole", {
-        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      })
-    );
+    attachPolicyToTestRole(stack, ssmPolicy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "test",

--- a/test/utils/attach-policy-to-test-role.ts
+++ b/test/utils/attach-policy-to-test-role.ts
@@ -1,0 +1,12 @@
+import type { Policy } from "@aws-cdk/aws-iam";
+import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
+import type { Stack } from "@aws-cdk/core";
+
+// IAM Policies need to be attached to a role, group or user to be created in a stack
+export const attachPolicyToTestRole = (stack: Stack, policy: Policy): void => {
+  policy.attachToRole(
+    new Role(stack, "TestRole", {
+      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+    })
+  );
+};

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,0 +1,3 @@
+export * from "./simple-gu-stack";
+export * from "./synthed-stack";
+export * from "./attach-policy-to-test-role";


### PR DESCRIPTION
## What does this change?

This PR adds a helper function which can be used when testing policies to add the policy to a test role. This is required as policies that are not added to roles do not get included in the stacks and therefore can't be tested. Providing a test helper means that each test does not have to create the role itself, reducing the amount of duplicated code.

## Does this change require changes to existing projects or CDK CLI?

No.

## How to test

Run the test suite and ensure everything still passes

## How can we measure success?

Less repeated code between tests