### PR TITLE
add more permissions to InstanceRole as standard, take 2

### DIFF
--- a/script/test
+++ b/script/test
@@ -2,10 +2,18 @@
 
 set -e
 
+EXTRA_ARGS=""
+if [[ $# -gt 0 ]] ; then
+  # npm requires `--` for argument passing
+  # see https://docs.npmjs.com/cli/v6/commands/npm-run-script
+  EXTRA_ARGS="-- $*"
+fi
+
 # only install dependencies when running in CI (currently GitHub Actions)
 # see https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
 if [ $CI ] ; then
   npm ci
 fi
 
-npm run test
+# shellcheck disable=SC2086
+npm run test $EXTRA_ARGS

--- a/src/constructs/iam/policies/describe-ec2.test.ts
+++ b/src/constructs/iam/policies/describe-ec2.test.ts
@@ -1,0 +1,32 @@
+import "@aws-cdk/assert/jest";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
+import { GuDescribeEC2Policy } from "./describe-ec2";
+
+describe("DescribeEC2Policy", () => {
+  it("can accept a custom policy name", () => {
+    const stack = simpleGuStackForTesting();
+
+    const policy = new GuDescribeEC2Policy(stack, "DescribeEC2Policy", { policyName: "my-awesome-policy" });
+
+    attachPolicyToTestRole(stack, policy);
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyName: "my-awesome-policy",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: [
+              "autoscaling:DescribeAutoScalingInstances",
+              "autoscaling:DescribeAutoScalingGroups",
+              "ec2:DescribeTags",
+              "ec2:DescribeInstances",
+            ],
+            Effect: "Allow",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/describe-ec2.ts
+++ b/src/constructs/iam/policies/describe-ec2.ts
@@ -1,0 +1,29 @@
+import type { PolicyProps } from "@aws-cdk/aws-iam";
+import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import type { GuStack } from "../../core";
+import type { GuPolicyProps } from "./base-policy";
+import { GuPolicy } from "./base-policy";
+
+export class GuDescribeEC2Policy extends GuPolicy {
+  private static getDefaultProps(): PolicyProps {
+    return {
+      policyName: "describe-ec2-policy",
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            "autoscaling:DescribeAutoScalingInstances",
+            "autoscaling:DescribeAutoScalingGroups",
+            "ec2:DescribeTags",
+            "ec2:DescribeInstances",
+          ],
+          resources: ["*"],
+        }),
+      ],
+    };
+  }
+
+  constructor(scope: GuStack, id: string = "DescribeEC2Policy", props?: GuPolicyProps) {
+    super(scope, id, { ...GuDescribeEC2Policy.getDefaultProps(), ...props });
+  }
+}

--- a/src/constructs/iam/policies/index.ts
+++ b/src/constructs/iam/policies/index.ts
@@ -1,5 +1,6 @@
 export * from "./base-policy";
 export * from "./describe-ec2";
 export * from "./log-shipping";
+export * from "./parameter-store-read";
 export * from "./s3-get-object";
 export * from "./ssm";

--- a/src/constructs/iam/policies/index.ts
+++ b/src/constructs/iam/policies/index.ts
@@ -1,4 +1,5 @@
 export * from "./base-policy";
+export * from "./describe-ec2";
 export * from "./log-shipping";
 export * from "./s3-get-object";
 export * from "./ssm";

--- a/src/constructs/iam/policies/parameter-store-read.test.ts
+++ b/src/constructs/iam/policies/parameter-store-read.test.ts
@@ -1,0 +1,52 @@
+import "@aws-cdk/assert/jest";
+import { App } from "@aws-cdk/core";
+import { attachPolicyToTestRole } from "../../../../test/utils";
+import { GuStack } from "../../core";
+import { GuParameterStoreReadPolicy } from "./parameter-store-read";
+
+describe("ParameterStoreReadPolicy", () => {
+  it("should constrain the policy to the patch of a stack's identity", () => {
+    const stack = new GuStack(new App(), "my-app", { app: "MyApp" });
+
+    const policy = new GuParameterStoreReadPolicy(stack);
+
+    attachPolicyToTestRole(stack, policy);
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyName: "parameter-store-read-policy",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "ssm:GetParametersByPath",
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:ssm:",
+                  {
+                    Ref: "AWS::Region",
+                  },
+                  ":",
+                  {
+                    Ref: "AWS::AccountId",
+                  },
+                  ":parameter/",
+                  {
+                    Ref: "Stage",
+                  },
+                  "/",
+                  {
+                    Ref: "Stack",
+                  },
+                  "/MyApp",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -1,0 +1,26 @@
+import type { PolicyProps } from "@aws-cdk/aws-iam";
+import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import type { GuStack } from "../../core";
+import type { GuPolicyProps } from "./base-policy";
+import { GuPolicy } from "./base-policy";
+
+export class GuParameterStoreReadPolicy extends GuPolicy {
+  private static getDefaultProps(scope: GuStack): PolicyProps {
+    return {
+      policyName: "parameter-store-read-policy",
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["ssm:GetParametersByPath"],
+          resources: [
+            `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/${scope.app}`,
+          ],
+        }),
+      ],
+    };
+  }
+
+  constructor(scope: GuStack, id: string = "ParameterStoreRead", props?: GuPolicyProps) {
+    super(scope, id, { ...GuParameterStoreReadPolicy.getDefaultProps(scope), ...props });
+  }
+}

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -133,6 +133,50 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "ParameterStoreRead9D2F4FAB": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/",
+                    Object {
+                      "Ref": "Stack",
+                    },
+                    "/testing",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -324,6 +368,50 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "ParameterStoreRead9D2F4FAB": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/",
+                    Object {
+                      "Ref": "Stack",
+                    },
+                    "/testing",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -475,6 +563,50 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "ParameterStoreRead9D2F4FAB": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/",
+                    Object {
+                      "Ref": "Stack",
+                    },
+                    "/testing",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -19,6 +19,32 @@ Object {
     },
   },
   "Resources": Object {
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "GetConfigPolicy6F934A1C": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -166,6 +192,32 @@ Object {
     },
   },
   "Resources": Object {
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "GetDistributablesPolicy648EC38C": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -331,6 +383,32 @@ Object {
     },
   },
   "Resources": Object {
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "GetDistributablesPolicy648EC38C": Object {
       "Properties": Object {
         "PolicyDocument": Object {

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -11,7 +11,7 @@ describe("The InstanceRole construct", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
-    expect(stack).toCountResources("AWS::IAM::Policy", 2);
+    expect(stack).toCountResources("AWS::IAM::Policy", 3);
   });
 
   it("should create an additional logging policy if logging stream is specified", () => {
@@ -20,7 +20,7 @@ describe("The InstanceRole construct", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
-    expect(stack).toCountResources("AWS::IAM::Policy", 3);
+    expect(stack).toCountResources("AWS::IAM::Policy", 4);
   });
 
   it("should allow additional policies to be specified", () => {
@@ -33,6 +33,6 @@ describe("The InstanceRole construct", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
-    expect(stack).toCountResources("AWS::IAM::Policy", 3);
+    expect(stack).toCountResources("AWS::IAM::Policy", 4);
   });
 });

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -11,7 +11,7 @@ describe("The InstanceRole construct", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
-    expect(stack).toCountResources("AWS::IAM::Policy", 3);
+    expect(stack).toCountResources("AWS::IAM::Policy", 4);
   });
 
   it("should create an additional logging policy if logging stream is specified", () => {
@@ -20,7 +20,7 @@ describe("The InstanceRole construct", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
-    expect(stack).toCountResources("AWS::IAM::Policy", 4);
+    expect(stack).toCountResources("AWS::IAM::Policy", 5);
   });
 
   it("should allow additional policies to be specified", () => {
@@ -33,6 +33,6 @@ describe("The InstanceRole construct", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
-    expect(stack).toCountResources("AWS::IAM::Policy", 4);
+    expect(stack).toCountResources("AWS::IAM::Policy", 5);
   });
 });

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -5,6 +5,7 @@ import {
   GuDescribeEC2Policy,
   GuGetS3ObjectPolicy,
   GuLogShippingPolicy,
+  GuParameterStoreReadPolicy,
   GuRole,
   GuSSMRunCommandPolicy,
 } from "../constructs/iam";
@@ -27,6 +28,7 @@ export class InstanceRole extends GuRole {
       new GuSSMRunCommandPolicy(scope),
       new GuGetS3ObjectPolicy(scope, "GetDistributablesPolicy", props),
       new GuDescribeEC2Policy(scope),
+      new GuParameterStoreReadPolicy(scope),
       ...(props.loggingStreamName
         ? [new GuLogShippingPolicy(scope, "LogShippingPolicy", props as GuLogShippingPolicyProps)]
         : []),

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -1,7 +1,13 @@
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../constructs/core";
 import type { GuGetS3ObjectPolicyProps, GuLogShippingPolicyProps, GuPolicy } from "../constructs/iam";
-import { GuGetS3ObjectPolicy, GuLogShippingPolicy, GuRole, GuSSMRunCommandPolicy } from "../constructs/iam";
+import {
+  GuDescribeEC2Policy,
+  GuGetS3ObjectPolicy,
+  GuLogShippingPolicy,
+  GuRole,
+  GuSSMRunCommandPolicy,
+} from "../constructs/iam";
 
 interface InstanceRoleProps extends GuGetS3ObjectPolicyProps, Partial<GuLogShippingPolicyProps> {
   additionalPolicies?: GuPolicy[];
@@ -20,6 +26,7 @@ export class InstanceRole extends GuRole {
     this.policies = [
       new GuSSMRunCommandPolicy(scope),
       new GuGetS3ObjectPolicy(scope, "GetDistributablesPolicy", props),
+      new GuDescribeEC2Policy(scope),
       ...(props.loggingStreamName
         ? [new GuLogShippingPolicy(scope, "LogShippingPolicy", props as GuLogShippingPolicyProps)]
         : []),


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

https://github.com/guardian/cdk/pull/66 but w/out the `Try` as its not needed since https://github.com/guardian/cdk/pull/69.

Updates the standard permissions given to `InstanceRole`, adding:
- Permissions to read instance and ASG state - applications read these at launch for service or config discovery
- Permissions to read from parameter store, for config

This is after observing the verbosity within the [new Typerigther stack](https://github.com/guardian/typerighter/compare/setup-rule-manager-infrastructure). cc @jonathonherbert @SHession 

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes, the stacks can be thinned out as more things come as standard.

- [ ] [Prism](https://github.com/guardian/deploy-tools-platform/blob/c7d687d3e9a370cad04aaae7efc7bacd952ab97b/cdk/lib/prism/prism-stack.ts#L59-L68)
- [ ] [Grafana](https://github.com/guardian/deploy-tools-platform/blob/c7d687d3e9a370cad04aaae7efc7bacd952ab97b/cdk/lib/grafana/grafana-stack.ts#L147-L159)
- [ ] [AMIable](https://github.com/guardian/deploy-tools-platform/blob/c7d687d3e9a370cad04aaae7efc7bacd952ab97b/cdk/lib/amiable/amiable.ts#L93-L98)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See unit tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Reducing the boilerplate needed to define a CDK stack.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a