### PR TITLE
Tidy up default props

### DIFF
--- a/src/constructs/iam/policies/base-policy.ts
+++ b/src/constructs/iam/policies/base-policy.ts
@@ -7,10 +7,8 @@ export interface GuPolicyProps extends PolicyProps {
 }
 
 export class GuPolicy extends Policy {
-  static defaultProps: Partial<GuPolicyProps> = {};
-
   constructor(scope: GuStack, id: string, props: GuPolicyProps) {
-    super(scope, id, { ...GuPolicy.defaultProps, ...props });
+    super(scope, id, props);
 
     if (props.overrideId) {
       const child = this.node.defaultChild as CfnPolicy;

--- a/src/constructs/iam/roles.ts
+++ b/src/constructs/iam/roles.ts
@@ -7,12 +7,10 @@ export interface GuRoleProps extends RoleProps {
 }
 
 export class GuRole extends Role {
-  private static defaultProps: Partial<GuRoleProps> = {};
-
   private child: CfnRole;
 
   constructor(scope: GuStack, id: string, props: GuRoleProps) {
-    super(scope, id, { ...GuRole.defaultProps, ...props });
+    super(scope, id, props);
 
     this.child = this.node.defaultChild as CfnRole;
     if (props.overrideId) {

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -51,13 +51,8 @@ export interface GuApplicationListenerProps extends ApplicationListenerProps {
 }
 
 export class GuApplicationListener extends ApplicationListener {
-  static defaultProps: Partial<GuApplicationListenerProps> = {
-    port: 443,
-    protocol: ApplicationProtocol.HTTPS,
-  };
-
   constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
-    super(scope, id, { ...GuApplicationListener.defaultProps, ...props });
+    super(scope, id, { port: 443, protocol: ApplicationProtocol.HTTPS, ...props });
 
     if (props.overrideId) (this.node.defaultChild as CfnListener).overrideLogicalId(id);
   }


### PR DESCRIPTION
## What does this change?

This PR makes two changes to simplify the code around default parameters:

1) Empty default parameter objects have been removed as they don't do anything
2) The `defaultParameters` object of the `GuApplicationListener ` has been removed in favour of including the params in the call to `super`. This reduces the number of ways that we do default props to two. See #79 for further discussion of how we should do default props.

## Does this change require changes to existing projects or CDK CLI?

No.

## How to test

Run the test suite and see that nothing has changed.

## How can we measure success?

We don't have redundant code and have fewer ways of including default props
