### PR TITLE
add an email sender policy

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
+export * from "./regex-pattern";
 export * from "./stage";

--- a/src/constants/regex-pattern.test.ts
+++ b/src/constants/regex-pattern.test.ts
@@ -1,0 +1,16 @@
+import { RegexPattern } from "./regex-pattern";
+
+describe("the regex patterns", () => {
+  it("should successfully regex against valid ARNs", () => {
+    const regex = new RegExp(RegexPattern.ARN);
+    expect(regex.test("fooooo")).toBeFalsy();
+    expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeTruthy();
+  });
+
+  it("should successfully regex against valid s3 ARNs only", () => {
+    const regex = new RegExp(RegexPattern.S3ARN);
+    expect(regex.test("fooooo")).toBeFalsy();
+    expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeFalsy();
+    expect(regex.test("arn:aws:s3:::examplebucket/my-data/sales-export-2019-q4.json")).toBeTruthy();
+  });
+});

--- a/src/constants/regex-pattern.test.ts
+++ b/src/constants/regex-pattern.test.ts
@@ -13,4 +13,16 @@ describe("the regex patterns", () => {
     expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeFalsy();
     expect(regex.test("arn:aws:s3:::examplebucket/my-data/sales-export-2019-q4.json")).toBeTruthy();
   });
+
+  it("should successfully regex against valid emails only", () => {
+    const regex = new RegExp(RegexPattern.GUARDIAN_EMAIL);
+    expect(regex.test("email.address.com")).toBeFalsy();
+    expect(regex.test("email@gmail.com")).toBeFalsy();
+
+    expect(regex.test("email@theguardian.com")).toBeTruthy();
+    expect(regex.test("another.email@theguardian.com")).toBeTruthy();
+
+    expect(regex.test("another.@theguardian.com")).toBeFalsy();
+    expect(regex.test("another1@theguardian.com")).toBeFalsy();
+  });
 });

--- a/src/constants/regex-pattern.ts
+++ b/src/constants/regex-pattern.ts
@@ -1,0 +1,9 @@
+const arnRegex = "arn:aws:[a-z0-9]*:[a-z0-9\\-]*:[0-9]{12}:.*";
+
+const s3BucketRegex = "(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\\.[a-z0-9])?)*$(?<!\\-))";
+const s3ArnRegex = `arn:aws:s3:::${s3BucketRegex}*`;
+
+export const RegexPattern = {
+  ARN: arnRegex,
+  S3ARN: s3ArnRegex,
+};

--- a/src/constants/regex-pattern.ts
+++ b/src/constants/regex-pattern.ts
@@ -3,7 +3,10 @@ const arnRegex = "arn:aws:[a-z0-9]*:[a-z0-9\\-]*:[0-9]{12}:.*";
 const s3BucketRegex = "(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\\.[a-z0-9])?)*$(?<!\\-))";
 const s3ArnRegex = `arn:aws:s3:::${s3BucketRegex}*`;
 
+const emailRegex = "^[a-zA-Z]+(\\.[a-zA-Z]+)*@theguardian.com$";
+
 export const RegexPattern = {
   ARN: arnRegex,
   S3ARN: s3ArnRegex,
+  GUARDIAN_EMAIL: emailRegex,
 };

--- a/src/constructs/core/parameters.test.ts
+++ b/src/constructs/core/parameters.test.ts
@@ -1,11 +1,10 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import { Stack } from "@aws-cdk/core";
-import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
-import type { SynthedStack } from "../../../test/utils/synthed-stack";
+import { simpleGuStackForTesting } from "../../../test/utils";
+import type { SynthedStack } from "../../../test/utils";
 import { Stage, Stages } from "../../constants";
 import {
-  arnRegex,
   GuAmiParameter,
   GuArnParameter,
   GuInstanceTypeParameter,
@@ -16,7 +15,6 @@ import {
   GuStringParameter,
   GuSubnetListParameter,
   GuVpcParameter,
-  s3ArnRegex,
 } from "./parameters";
 import type { GuStack } from "./stack";
 
@@ -193,12 +191,6 @@ describe("The GuArnParameter class", () => {
       ConstraintDescription: "Must be a valid ARN, eg: arn:partition:service:region:account-id:resource-id",
     });
   });
-
-  it("should successfully regex against valid ARNs", () => {
-    const regex = new RegExp(arnRegex);
-    expect(regex.test("fooooo")).toBeFalsy();
-    expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeTruthy();
-  });
 });
 
 describe("The GuS3ObjectArnParameter class", () => {
@@ -216,12 +208,5 @@ describe("The GuS3ObjectArnParameter class", () => {
       ConstraintDescription:
         "Must be a valid S3 ARN, see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html",
     });
-  });
-
-  it("should successfully regex against valid s3 ARNs only", () => {
-    const regex = new RegExp(s3ArnRegex);
-    expect(regex.test("fooooo")).toBeFalsy();
-    expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeFalsy();
-    expect(regex.test("arn:aws:s3:::examplebucket/my-data/sales-export-2019-q4.json")).toBeTruthy();
   });
 });

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -105,3 +105,13 @@ export class GuS3ObjectArnParameter extends GuStringParameter {
     });
   }
 }
+
+export class GuGuardianEmailSenderParameter extends GuStringParameter {
+  constructor(scope: GuStack, id: string = "EmailSenderAddress", props?: GuNoTypeParameterProps) {
+    super(scope, id, {
+      ...props,
+      allowedPattern: RegexPattern.GUARDIAN_EMAIL,
+      constraintDescription: "Must be an @theguardian.com email address",
+    });
+  }
+}

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -1,6 +1,6 @@
 import type { CfnParameterProps } from "@aws-cdk/core";
 import { CfnParameter } from "@aws-cdk/core";
-import { Stage, Stages } from "../../constants";
+import { RegexPattern, Stage, Stages } from "../../constants";
 import type { GuStack } from "./stack";
 
 export type GuParameterProps = CfnParameterProps;
@@ -85,26 +85,21 @@ export class GuAmiParameter extends GuParameter {
   }
 }
 
-export const arnRegex = "arn:aws:[a-z0-9]*:[a-z0-9\\-]*:[0-9]{12}:.*";
-
 export class GuArnParameter extends GuStringParameter {
   constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {
       ...props,
-      allowedPattern: arnRegex,
+      allowedPattern: RegexPattern.ARN,
       constraintDescription: "Must be a valid ARN, eg: arn:partition:service:region:account-id:resource-id",
     });
   }
 }
 
-const s3BucketRegex = "(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\\.[a-z0-9])?)*$(?<!\\-))";
-export const s3ArnRegex = `arn:aws:s3:::${s3BucketRegex}*`;
-
 export class GuS3ObjectArnParameter extends GuStringParameter {
   constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {
       ...props,
-      allowedPattern: s3ArnRegex,
+      allowedPattern: RegexPattern.S3ARN,
       constraintDescription:
         "Must be a valid S3 ARN, see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html",
     });

--- a/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GuSESSenderPolicy should add a parameter to the stack for the sending email address 1`] = `
+Object {
+  "Parameters": Object {
+    "EmailSenderAddress": Object {
+      "AllowedPattern": "^[a-zA-Z]+(\\\\.[a-zA-Z]+)*@theguardian.com$",
+      "ConstraintDescription": "Must be an @theguardian.com email address",
+      "Type": "String",
+    },
+    "Stack": Object {
+      "Default": "deploy",
+      "Description": "Name of this stack",
+      "Type": "String",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "GuSESSenderPolicy2E2A75A2": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ses:SendEmail",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ses:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":identity/",
+                    Object {
+                      "Ref": "EmailSenderAddress",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuSESSenderPolicy2E2A75A2",
+        "Roles": Array [
+          Object {
+            "Ref": "TestRole6C9272DF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TestRole6C9272DF": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": Object {
+              "Ref": "Stack",
+            },
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;

--- a/src/constructs/iam/policies/ses.test.ts
+++ b/src/constructs/iam/policies/ses.test.ts
@@ -1,0 +1,48 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
+import { GuSESSenderPolicy } from "./ses";
+
+describe("GuSESSenderPolicy", () => {
+  it("should have a policy that reads from a parameter", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuSESSenderPolicy(stack));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "ses:SendEmail",
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:ses:",
+                  {
+                    Ref: "AWS::Region",
+                  },
+                  ":",
+                  {
+                    Ref: "AWS::AccountId",
+                  },
+                  ":identity/",
+                  {
+                    Ref: "EmailSenderAddress",
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("should add a parameter to the stack for the sending email address", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuSESSenderPolicy(stack));
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+});

--- a/src/constructs/iam/policies/ses.ts
+++ b/src/constructs/iam/policies/ses.ts
@@ -1,0 +1,22 @@
+import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import type { GuStack } from "../../core";
+import { GuGuardianEmailSenderParameter } from "../../core";
+import type { GuPolicyProps } from "./base-policy";
+import { GuPolicy } from "./base-policy";
+
+export class GuSESSenderPolicy extends GuPolicy {
+  constructor(scope: GuStack, id: string = "GuSESSenderPolicy", props?: GuPolicyProps) {
+    super(scope, id, { ...props });
+
+    const emailSenderParam = new GuGuardianEmailSenderParameter(scope);
+
+    this.addStatements(
+      // see https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ["ses:SendEmail"],
+        resources: [`arn:aws:ses:${scope.region}:${scope.account}:identity/${emailSenderParam.valueAsString}`],
+      })
+    );
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds a new `GuSESSenderPolicy` construct which will:
- Add an `EmailSenderAddress` parameter to a `GuStack`
- Add an IAM policy to allow `ses:SendEmail` on that address

We have a few stacks that have this permission, each declare the policy in varying ways from [no restriction](https://github.com/guardian/anghammarad/blob/c919ebed337cb9be8653ac5ebf71ff2a6aa6990f/cloudformation/anghammarad.template.yaml#L40-L44) to [resource restricted](https://github.com/guardian/deploy-tools-platform/blob/1db44220323083ed89ef3fd03f8e1f27cfe2d390/cdk/lib/amiable/amiable.ts#L86-L92) to [condition restricted](https://github.com/guardian/editorial-tools-platform/blob/855ca76de244c9400c18a2ed9a34d428c99886fd/cloudformation/media-service-account/media-atom-maker/media-atom-maker.yaml#L786-L798).

After reading [this](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html), for our existing use cases it looks like a resource constraint and a condition amount to the same thing? So went with resource constraining as it was first in the docs.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes, it simplifies the AMIable stack.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run unit tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Providing more standard constructs and a standard way to declare this policy.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a