### PR TITLE
feat: add parameter helper functions on GuStack

### DIFF
--- a/src/constructs/core/parameters.test.ts
+++ b/src/constructs/core/parameters.test.ts
@@ -1,22 +1,17 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../test/utils";
 import type { SynthedStack } from "../../../test/utils";
-import { Stage, Stages } from "../../constants";
 import {
   GuAmiParameter,
   GuArnParameter,
   GuInstanceTypeParameter,
   GuParameter,
   GuS3ObjectArnParameter,
-  GuStackParameter,
-  GuStageParameter,
   GuStringParameter,
   GuSubnetListParameter,
   GuVpcParameter,
 } from "./parameters";
-import type { GuStack } from "./stack";
 
 describe("The GuParameter class", () => {
   it("sets the type as passed through by default", () => {
@@ -80,39 +75,6 @@ describe("The GuStringParameter class", () => {
     expect(json.Parameters.Parameter).toEqual({
       Type: "String",
       Description: "This is a test",
-    });
-  });
-});
-
-describe("The GuStageParameter class", () => {
-  it("should set the values as required", () => {
-    const stack = new Stack() as GuStack;
-
-    new GuStageParameter(stack);
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters.Stage).toEqual({
-      Type: "String",
-      Description: "Stage name",
-      AllowedValues: Stages,
-      Default: Stage.CODE,
-    });
-  });
-});
-
-describe("The GuStackParameter class", () => {
-  it("should set the values as required", () => {
-    const stack = new Stack() as GuStack;
-
-    new GuStackParameter(stack);
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters.Stack).toEqual({
-      Type: "String",
-      Description: "Name of this stack",
-      Default: "deploy",
     });
   });
 });

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -30,7 +30,8 @@ export class GuStringParameter extends GuParameter {
 }
 
 export class GuStageParameter extends GuParameter {
-  constructor(scope: GuStack, id: string = "Stage") {
+  public static readonly defaultId = "Stage";
+  constructor(scope: GuStack, id: string = GuStageParameter.defaultId) {
     super(scope, id, {
       type: "String",
       description: "Stage name",
@@ -41,7 +42,8 @@ export class GuStageParameter extends GuParameter {
 }
 
 export class GuStackParameter extends GuParameter {
-  constructor(scope: GuStack, id: string = "Stack") {
+  public static readonly defaultId = "Stack";
+  constructor(scope: GuStack, id: string = GuStackParameter.defaultId) {
     super(scope, id, {
       type: "String",
       description: "Name of this stack",

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -10,11 +10,16 @@ export interface GuParameterProps extends CfnParameterProps {
 export type GuNoTypeParameterProps = Omit<GuParameterProps, "type">;
 
 export class GuParameter extends CfnParameter {
+  public readonly id: string;
+
   constructor(scope: GuStack, id: string, props: GuParameterProps) {
     super(scope, id, {
       ...props,
       type: props.fromSSM ? `AWS::SSM::Parameter::Value<${props.type ?? "String"}>` : props.type,
     });
+
+    this.id = id;
+    scope.setParam(this);
   }
 }
 

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -7,6 +7,7 @@ import { alphabeticalTags, simpleGuStackForTesting } from "../../../test/utils";
 import type { SynthedStack } from "../../../test/utils";
 import { Stage, Stages } from "../../constants";
 import { TrackingTag } from "../../constants/library-info";
+import { GuParameter } from "./parameters";
 import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
@@ -62,5 +63,22 @@ describe("The GuStack construct", () => {
     const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
 
     expect(stack.app).toBe("MyApp");
+  });
+
+  it("should return a parameter that exists", () => {
+    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
+    const testParam = new GuParameter(stack, "MyTestParam", {});
+    stack.setParam(testParam);
+
+    const actual = stack.getParam<GuParameter>("MyTestParam");
+    expect(actual).toBe(testParam);
+  });
+
+  it("should throw on attempt to get a parameter that doesn't exist", () => {
+    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
+
+    expect(() => stack.getParam<GuParameter>("i-do-not-exist")).toThrowError(
+      "Attempting to read parameter i-do-not-exist which does not exist"
+    );
   });
 });

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -40,7 +40,6 @@ export interface GuStackProps extends StackProps {
  * ```
  */
 export class GuStack extends Stack {
-  private readonly _stage: GuStageParameter;
   private readonly _stack: string;
   private readonly _app: string;
 
@@ -49,7 +48,7 @@ export class GuStack extends Stack {
   public readonly migratedFromCloudFormation: boolean;
 
   get stage(): string {
-    return this._stage.valueAsString;
+    return this.getParam(GuStageParameter.defaultId).valueAsString;
   }
 
   get stack(): string {
@@ -96,7 +95,7 @@ export class GuStack extends Stack {
 
     this.params = new Map<string, GuParameter>();
 
-    this._stage = new GuStageParameter(this);
+    new GuStageParameter(this);
     this._stack = props.stack;
     this._app = props.app;
 

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,6 +1,7 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { TrackingTag } from "../../constants/library-info";
+import type { GuParameter } from "./parameters";
 import { GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
@@ -43,6 +44,8 @@ export class GuStack extends Stack {
   private readonly _stack: string;
   private readonly _app: string;
 
+  private params: Map<string, GuParameter>;
+
   public readonly migratedFromCloudFormation: boolean;
 
   get stage(): string {
@@ -73,11 +76,25 @@ export class GuStack extends Stack {
     Tags.of(this).add(key, value, { applyToLaunchedInstances });
   }
 
+  setParam(value: GuParameter): void {
+    this.params.set(value.id, value);
+  }
+
+  getParam<T extends GuParameter>(key: string): T {
+    if (!this.params.has(key)) {
+      throw new Error(`Attempting to read parameter ${key} which does not exist`);
+    }
+
+    return this.params.get(key) as T;
+  }
+
   // eslint-disable-next-line custom-rules/valid-constructors -- GuStack is the exception as it must take an App
   constructor(app: App, id: string, props: GuStackProps) {
     super(app, id, props);
 
     this.migratedFromCloudFormation = !!props.migratedFromCloudFormation;
+
+    this.params = new Map<string, GuParameter>();
 
     this._stage = new GuStageParameter(this);
     this._stack = props.stack;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

https://github.com/guardian/cdk/pull/65, but for parameters.

Helper functions to get/set parameters on the GuStack. An `Error` is thrown when getting a parameter that hasn't been set; this is to catch the error at compile time.

This is useful for when a construct reads from a parameter but isn't responsible for adding the parameter. For example, reading the `DistributionBucketName` param in the user data, where `DistributionBucketName` is added by [`GuGetDistributablePolicy`](https://github.com/guardian/cdk/blob/390a734dbfe228028581b172f1e920b3e223862e/src/constructs/iam/policies/s3-get-object.ts#L16) via [`GuInstanceRole`](https://github.com/guardian/cdk/blob/390a734dbfe228028581b172f1e920b3e223862e/src/constructs/iam/roles/instance-role.ts#L30). One such example can be seen [here](https://github.com/guardian/deploy-tools-platform/pull/375).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is simpler to share parameters across constructs.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a