### PR TITLE
Add DynamoDB read and write policies

### DIFF
--- a/src/constructs/iam/policies/base-policy.ts
+++ b/src/constructs/iam/policies/base-policy.ts
@@ -1,5 +1,5 @@
 import type { CfnPolicy, PolicyProps } from "@aws-cdk/aws-iam";
-import { Policy } from "@aws-cdk/aws-iam";
+import { Effect, Policy, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
 
 export interface GuPolicyProps extends PolicyProps {
@@ -14,5 +14,39 @@ export abstract class GuPolicy extends Policy {
       const child = this.node.defaultChild as CfnPolicy;
       child.overrideLogicalId(id);
     }
+  }
+}
+
+export interface GuAllowPolicyProps extends GuPolicyProps {
+  actions: string[];
+  resources: string[];
+}
+export type GuDenyPolicyProps = GuAllowPolicyProps;
+
+export class GuAllowPolicy extends GuPolicy {
+  constructor(scope: GuStack, id: string, props: GuAllowPolicyProps) {
+    super(scope, id, props);
+
+    this.addStatements(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        resources: props.resources,
+        actions: props.actions,
+      })
+    );
+  }
+}
+
+export class GuDenyPolicy extends GuPolicy {
+  constructor(scope: GuStack, id: string, props: GuDenyPolicyProps) {
+    super(scope, id, props);
+
+    this.addStatements(
+      new PolicyStatement({
+        effect: Effect.DENY,
+        resources: props.resources,
+        actions: props.actions,
+      })
+    );
   }
 }

--- a/src/constructs/iam/policies/dynamodb.test.ts
+++ b/src/constructs/iam/policies/dynamodb.test.ts
@@ -1,0 +1,81 @@
+import "@aws-cdk/assert/jest";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
+import { GuDynamoDBReadPolicy, GuDynamoDBWritePolicy } from "./dynamodb";
+
+describe("The GuDynamoDBReadPolicy construct", () => {
+  it("creates the correct policy", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuDynamoDBReadPolicy(stack, "ReadMyTablePolicy", { tableName: "MyTable" }));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyName: "ReadMyTablePolicyBE0064AB",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: [
+              "dynamodb:BatchGetItem",
+              "dynamodb:GetItem",
+              "dynamodb:Scan",
+              "dynamodb:Query",
+              "dynamodb:GetRecords",
+            ],
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:dynamodb:",
+                  {
+                    Ref: "AWS::Region",
+                  },
+                  ":",
+                  {
+                    Ref: "AWS::AccountId",
+                  },
+                  ":table/MyTable",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("The GuDynamoDBWritePolicy construct", () => {
+  it("creates the correct policy", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuDynamoDBWritePolicy(stack, "WriteMyTablePolicy", { tableName: "MyTable" }));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyName: "WriteMyTablePolicy7D2601F8",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: ["dynamodb:BatchWriteItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:UpdateItem"],
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:dynamodb:",
+                  {
+                    Ref: "AWS::Region",
+                  },
+                  ":",
+                  {
+                    Ref: "AWS::AccountId",
+                  },
+                  ":table/MyTable",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/dynamodb.ts
+++ b/src/constructs/iam/policies/dynamodb.ts
@@ -1,0 +1,32 @@
+import type { GuStack } from "../../core";
+import type { GuPolicyProps } from "./base-policy";
+import { GuAllowPolicy } from "./base-policy";
+
+interface GuDynamoDBPolicyProps {
+  tableName: string;
+}
+
+interface GuDynamoDBPolicyPropsWithActions extends GuPolicyProps, GuDynamoDBPolicyProps {
+  actions: string[];
+}
+
+abstract class GuDynamoDBPolicy extends GuAllowPolicy {
+  protected constructor(scope: GuStack, id: string, props: GuDynamoDBPolicyPropsWithActions) {
+    super(scope, id, {
+      actions: props.actions.map((action) => `dynamodb:${action}`),
+      resources: [`arn:aws:dynamodb:${scope.region}:${scope.account}:table/${props.tableName}`],
+    });
+  }
+}
+
+export class GuDynamoDBReadPolicy extends GuDynamoDBPolicy {
+  constructor(scope: GuStack, id: string, props: GuDynamoDBPolicyProps) {
+    super(scope, id, { ...props, actions: ["BatchGetItem", "GetItem", "Scan", "Query", "GetRecords"] });
+  }
+}
+
+export class GuDynamoDBWritePolicy extends GuDynamoDBPolicy {
+  constructor(scope: GuStack, id: string, props: GuDynamoDBPolicyProps) {
+    super(scope, id, { ...props, actions: ["BatchWriteItem", "PutItem", "DeleteItem", "UpdateItem"] });
+  }
+}

--- a/src/constructs/iam/policies/index.ts
+++ b/src/constructs/iam/policies/index.ts
@@ -1,5 +1,6 @@
 export * from "./base-policy";
 export * from "./describe-ec2";
+export * from "./dynamodb";
 export * from "./log-shipping";
 export * from "./parameter-store-read";
 export * from "./s3-get-object";


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds two DynamoDB policies using a different (and possibly simpler) format from existing policy constructs.

In https://github.com/guardian/cdk/pull/77 we made `GuPolicy` abstract to discourage usage of it. In that PR we noted that if one wanted to create a custom policy they still could by extending `GuPolicy`. In this PR we make that process easier with the addition of `GuAllowPolicy` and `GuDenyPolicy` constructs.

These new constructs have a super simple interface and the dynamodb constructs added in this PR demonstrate their usage.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No, but it would mean a load of refactoring of existing constructs to extend from `GuAllowPolicy`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI. I've only added tests to the dynamo constructs as new policy constructs get tested implicitly as a result.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

- A simpler interface to create policies
- A dynamodb read and write policy

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a
