### PR TITLE
Add a custom eslint rule to check the constructors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,10 +10,11 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.eslint.json"],
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "custom-rules"],
   rules: {
     "@typescript-eslint/no-inferrable-types": 0,
     "import/no-namespace": 2,
+    "custom-rules/valid-constructors": 2,
   },
   root: true,
   ignorePatterns: ["**/*.js", "node_modules"],

--- a/eslint/README.md
+++ b/eslint/README.md
@@ -1,0 +1,7 @@
+# Custom ESLint Rules
+
+This directory defines any custom rules to be checked against the @guardian/cdk library.
+
+These rules should all have a corresponding [ADR](../docs/architecture-design-records).
+
+More information on building custom rules can be found on the [eslint site](https://eslint.org/docs/developer-guide/working-with-rules).

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "valid-constructors": require("./rules/valid-constructors"),
+  },
+};

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-plugin-custom-rules",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/eslint/rules/valid-constructors.js
+++ b/eslint/rules/valid-constructors.js
@@ -121,21 +121,21 @@ module.exports = {
             );
           }
 
-          // 10. Third parameter type should be custom
-          if (getStandardOrLeftProp(props, "typeAnnotation.typeAnnotation.type") !== "TSTypeReference") {
-            return context.report(
-              node,
-              getStandardOrLeftProp(props, "typeAnnotation.loc"),
-              `The third parameter in a construct or pattern contructor must be a custom type`
-            );
-          }
-
           // 8. If third parameter is present and non-optional then the second parameter should not be initialised
           if (props.type !== "AssignmentPattern" && !props.optional && id.type === "AssignmentPattern") {
             return context.report(
               node,
               id.loc,
               `The second parameter cannot be initialised if there is a non-optional third parameter`
+            );
+          }
+
+          // 10. Third parameter type should be custom
+          if (getStandardOrLeftProp(props, "typeAnnotation.typeAnnotation.type") !== "TSTypeReference") {
+            return context.report(
+              node,
+              getStandardOrLeftProp(props, "typeAnnotation.loc"),
+              `The third parameter in a construct or pattern contructor must be a custom type`
             );
           }
         }

--- a/eslint/rules/valid-constructors.js
+++ b/eslint/rules/valid-constructors.js
@@ -1,0 +1,141 @@
+// Rules
+// 1. Must be at least 2 parameters
+// 2. Can't be more than 3 parameters
+// 3. First parameter must be called scope
+// 4. First parameter must be of type GuStack
+// 5. Second parameter must be called id
+// 6. Second parameter must be of type string
+// 7. Third parameter (if exists) must called props
+// 8. If third parameter is present and non-optional then the second parameter should not be initialised
+// TODO: 9. If all values in third type are optional then parameter should be optional
+// 10. Third parameter type should be custom
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "ensure constructors conform with agreed pattern",
+      category: "Best Practices",
+      url: "https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/002-component-constuctors.md",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      MethodDefinition(node) {
+        if (node.kind !== "constructor") return null;
+
+        const params = node.value.params;
+
+        // 1. Must be at least 2 parameters
+        if (!Array.isArray(params) || params.length < 2) {
+          return context.report(
+            node,
+            params.loc,
+            "Construct or pattern constructors must take at least a scope and an id parameter"
+          );
+        }
+
+        // 2. Can't be more than 3 parameters
+        if (params.length > 3) {
+          return context.report(
+            node,
+            params.loc,
+            "Construct or pattern constructors can only take scope, id and props parameters"
+          );
+        }
+
+        const scope = params[0];
+
+        // 3. First parameter must be called scope
+        if (scope.name !== "scope") {
+          return context.report(
+            node,
+            scope.loc,
+            `The first parameter in a construct or pattern contructor must be called scope`
+          );
+        }
+
+        // 4. First parameter must be of type GuStack
+        if (scope.typeAnnotation.typeAnnotation.typeName.name !== "GuStack") {
+          return context.report(
+            node,
+            scope.typeAnnotation.typeAnnotation.typeName.loc,
+            `The first parameter in a construct or pattern contructor must be of type GuStack`
+          );
+        }
+
+        const id = params[1];
+
+        // 5. Second parameter must be called id
+        if (
+          (id.type === "Identifier" && id.name !== "id") ||
+          (id.type === "AssignmentPattern" && id.left.name !== "id")
+        ) {
+          return context.report(
+            node,
+            id.loc,
+            `The second parameter in a construct or pattern contructor must be called id`
+          );
+        }
+
+        // 6. Second parameter must be of type string
+        if (
+          (id.type === "Identifier" && id.typeAnnotation.typeAnnotation.type !== "TSStringKeyword") ||
+          (id.type === "AssignmentPattern" && id.left.typeAnnotation.typeAnnotation.type !== "TSStringKeyword")
+        ) {
+          return context.report(
+            node,
+            id.typeAnnotation.typeAnnotation.typeName.loc,
+            `The second parameter in a construct or pattern contructor must be of type string`
+          );
+        }
+
+        if (params.length === 3) {
+          const props = params[2];
+
+          // 7. Third parameter (if exists) must called props
+          if (
+            (props.type === "Identifier" && props.name !== "props") ||
+            (props.type === "AssignmentPattern" && props.left.name !== "props")
+          ) {
+            return context.report(
+              node,
+              props.loc,
+              `The third parameter in a construct or pattern contructor must be called props`
+            );
+          }
+
+          // 10. Third parameter type should be custom
+          if (
+            (props.type === "Identifier" && props.typeAnnotation.typeAnnotation.type !== "TSTypeReference") ||
+            (props.type === "AssignmentPattern" && props.left.typeAnnotation.typeAnnotation.type !== "TSTypeReference")
+          ) {
+            return context.report(
+              node,
+              props.loc,
+              `The third parameter in a construct or pattern contructor must be a custom type`
+            );
+          }
+        }
+
+        // 8. If third parameter is present and non-optional then the second parameter should not be initialised
+        if (
+          params.length === 3 &&
+          params[2].type !== "AssignmentPattern" &&
+          !params[2].optional &&
+          id.type === "AssignmentPattern"
+        ) {
+          return context.report(
+            node,
+            id.loc,
+            `The second parameter cannot be initialised if there is a non-optional third parameter`
+          );
+        }
+
+        return null;
+      },
+    };
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3520,6 +3520,10 @@
         }
       }
     },
+    "eslint-plugin-custom-rules": {
+      "version": "file:eslint",
+      "dev": true
+    },
     "eslint-plugin-eslint-comments": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
@@ -4269,7 +4273,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -6769,6 +6774,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -8292,7 +8298,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -9117,7 +9124,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.0",
+    "eslint-plugin-custom-rules": "file:eslint",
     "jest": "^26.4.2",
     "np": "^7.0.0",
     "prettier": "^2.2.1",

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -20,8 +20,8 @@ export class GuStringParameter extends GuParameter {
 }
 
 export class GuStageParameter extends GuParameter {
-  constructor(scope: GuStack) {
-    super(scope, "Stage", {
+  constructor(scope: GuStack, id: string = "Stage") {
+    super(scope, id, {
       type: "String",
       description: "Stage name",
       allowedValues: Stages,
@@ -31,8 +31,8 @@ export class GuStageParameter extends GuParameter {
 }
 
 export class GuStackParameter extends GuParameter {
-  constructor(scope: GuStack) {
-    super(scope, "Stack", {
+  constructor(scope: GuStack, id: string = "Stack") {
+    super(scope, id, {
       type: "String",
       description: "Name of this stack",
       default: "deploy",

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -29,6 +29,7 @@ export class GuStack extends Stack {
     Tags.of(this).add(key, value, { applyToLaunchedInstances });
   }
 
+  // eslint-disable-next-line custom-rules/valid-constructors -- GuStack is the exception as it must take an App
   constructor(app: App, id: string, props: GuStackProps) {
     super(app, id, props);
 

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -52,7 +52,7 @@ export class GuWazuhAccess extends GuSecurityGroup {
     };
   }
 
-  constructor(scope: GuStack, id: string = "WazuhSecurityGroup", props: GuSecurityGroupProps) {
+  constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
     super(scope, id, {
       ...GuWazuhAccess.getDefaultProps(),
       ...props,

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -22,7 +22,7 @@ export class GuLogShippingPolicy extends GuPolicy {
     };
   }
 
-  constructor(scope: GuStack, id: string = "LogShippingPolicy", props: GuLogShippingPolicyProps) {
+  constructor(scope: GuStack, id: string, props: GuLogShippingPolicyProps) {
     super(scope, id, {
       ...GuLogShippingPolicy.getDefaultProps(scope, props),
       ...props,

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -7,7 +7,7 @@ import { InstanceRole } from "./instance-role";
 describe("The InstanceRole construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, { bucketName: "test" });
+    new InstanceRole(stack, "InstanceRole", { bucketName: "test" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -16,7 +16,7 @@ describe("The InstanceRole construct", () => {
 
   it("should create an additional logging policy if logging stream is specified", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, { bucketName: "test", loggingStreamName: "my-logging-stream" });
+    new InstanceRole(stack, "InstanceRole", { bucketName: "test", loggingStreamName: "my-logging-stream" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -26,7 +26,7 @@ describe("The InstanceRole construct", () => {
   it("should allow additional policies to be specified", () => {
     const stack = simpleGuStackForTesting();
 
-    new InstanceRole(stack, {
+    new InstanceRole(stack, "InstanceRole", {
       bucketName: "test",
       additionalPolicies: [new GuGetS3ObjectPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
     });

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -17,8 +17,8 @@ interface InstanceRoleProps extends GuGetS3ObjectPolicyProps, Partial<GuLogShipp
 export class InstanceRole extends GuRole {
   private policies: GuPolicy[];
 
-  constructor(scope: GuStack, props: InstanceRoleProps) {
-    super(scope, "InstanceRole", {
+  constructor(scope: GuStack, id: string, props: InstanceRoleProps) {
+    super(scope, id, {
       overrideId: true,
       path: "/",
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),


### PR DESCRIPTION
## What does this change?

This PR creates a custom ESLint rule which is used to check that the constructors of all constructs and patterns follow the best practice laid out in the [ADR](https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/002-component-constuctors.md).

Any constructs breaking those rules have been updated. In all cases except one, this change is non-breaking.

The InstanceRole pattern has had an `id` parameter added which means that any stacks implementing it will need to be updated.

## Does this change require changes to existing projects or CDK CLI?

Yes! The InstanceRole pattern has now had an `id` parameter added to conform to the style guide. This means that any stacks implementing it will need to be updated.

## How to test

Run the lint command to see if any errors are detected. Check a deliberate violation to see it catch things. 

## How can we measure success?

The best practice agreed around component constructors is verified by an automated check rather than relying on peer reviews to catch any violations.

## Have we considered potential risks?

The rule will either fail to catch violations or detect numerous false positives. 