### PR TITLE
Add deletion protection by default

### DIFF
--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -37,6 +37,20 @@ describe("The GuApplicationLoadBalancer class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources.ApplicationLoadBalancer.Properties)).not.toContain("Type");
   });
+
+  test("sets the deletion protection value to true by default", () => {
+    const stack = simpleGuStackForTesting();
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      LoadBalancerAttributes: [
+        {
+          Key: "deletion_protection.enabled",
+          Value: "true",
+        },
+      ],
+    });
+  });
 });
 
 describe("The GuApplicationTargetGroup class", () => {

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -14,17 +14,13 @@ import {
 } from "@aws-cdk/aws-elasticloadbalancingv2";
 import type { GuStack } from "../core";
 
-// TODO: By default, an application load balancer has deletion protection set to false.
-//  We probably want to protect this load balancer as much as possible
-//  should we set it to true instead?
-
 interface GuApplicationLoadBalancerProps extends ApplicationLoadBalancerProps {
   overrideId?: boolean;
 }
 
 export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
   constructor(scope: GuStack, id: string, props: GuApplicationLoadBalancerProps) {
-    super(scope, id, props);
+    super(scope, id, { deletionProtection: true, ...props });
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -134,4 +134,19 @@ describe("The GuDatabaseInstance class", () => {
 
     expect(Object.keys(json.Resources)).not.toContain("DatabaseInstance");
   });
+
+  test("sets the deletion protection value to true by default", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_11_8,
+      }),
+    });
+
+    expect(stack).toHaveResource("AWS::RDS::DBInstance", {
+      DeletionProtection: true,
+    });
+  });
 });

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -28,6 +28,7 @@ export class GuDatabaseInstance extends DatabaseInstance {
     }
 
     super(scope, id, {
+      deletionProtection: true,
       ...props,
       instanceType,
       ...(parameterGroup && { parameterGroup }),


### PR DESCRIPTION
## What does this change?

This PR sets the `deletionProtection` value to true by default for the `GuDatabaseInstance` and `GuApplicationLoadBalancer` constructs. 

## Does this change require changes to existing projects or CDK CLI?

This change updates a default value which will have an effect on existing projects (once the version of the library is bumped). For most projects, this new default value should be a sensible change however in some cases, it may be necessary to override it. 

## How to test

Two new unit tests cover the change. It could also be tested by applying it to a previously migrated stack.

## How can we measure success?

Components which are risky to remove have deletion protection enabled by default.

## Have we considered potential risks?

There is a risk that this isn't a sensible default and either it is mistakenly set in many cases causing extra developer effort or it requires overriding in many cases. 