### PR TITLE
Add GuClassicLoadBalancer

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@aws-cdk/aws-autoscaling": "~1.74.0",
     "@aws-cdk/aws-ec2": "~1.74.0",
     "@aws-cdk/aws-apigateway": "~1.74.0",
+    "@aws-cdk/aws-elasticloadbalancing": "~1.74.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "~1.74.0",
     "@aws-cdk/aws-events-targets": "~1.74.0",
     "@aws-cdk/aws-iam": "~1.74.0",

--- a/src/constructs/loadbalancing/clb.test.ts
+++ b/src/constructs/loadbalancing/clb.test.ts
@@ -1,0 +1,31 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
+import { Vpc } from "@aws-cdk/aws-ec2";
+import { Stack } from "@aws-cdk/core";
+import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
+import type { SynthedStack } from "../../../test/utils/synthed-stack";
+import { GuClassicLoadBalancer } from "../loadbalancing";
+
+describe("The GuClassicLoadBalancer class", () => {
+  const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
+    vpcId: "test",
+    availabilityZones: [""],
+    publicSubnetIds: [""],
+  });
+
+  test("overrides the id with the overrideId prop", () => {
+    const stack = simpleGuStackForTesting();
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { vpc, overrideId: true });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).toContain("ClassicLoadBalancer");
+  });
+
+  test("has an auto-generated ID by default", () => {
+    const stack = simpleGuStackForTesting();
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { vpc });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("ClassicLoadBalancer");
+  });
+});

--- a/src/constructs/loadbalancing/clb.test.ts
+++ b/src/constructs/loadbalancing/clb.test.ts
@@ -35,7 +35,7 @@ describe("The GuClassicLoadBalancer class", () => {
     new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
       vpc,
       overrideId: true,
-      deletionOverrideProperties: [GuClassicLoadBalancer.DeletionOverrideProperties.SCHEME],
+      propertiesToRemove: [GuClassicLoadBalancer.RemoveableProperties.SCHEME],
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -47,7 +47,7 @@ describe("The GuClassicLoadBalancer class", () => {
     new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
       vpc,
       overrideId: true,
-      overrideProperties: {
+      propertiesToOverride: {
         AccessLoggingPolicy: {
           EmitInterval: 5,
           Enabled: true,

--- a/src/constructs/loadbalancing/clb.ts
+++ b/src/constructs/loadbalancing/clb.ts
@@ -1,0 +1,17 @@
+import type { CfnLoadBalancer, LoadBalancerProps } from "@aws-cdk/aws-elasticloadbalancing";
+import { LoadBalancer } from "@aws-cdk/aws-elasticloadbalancing";
+import type { GuStack } from "../core";
+
+interface GuClassicLoadBalancerProps extends LoadBalancerProps {
+  overrideId?: boolean;
+}
+
+export class GuClassicLoadBalancer extends LoadBalancer {
+  constructor(scope: GuStack, id: string, props: GuClassicLoadBalancerProps) {
+    super(scope, id, props);
+
+    const cfnLb = this.node.defaultChild as CfnLoadBalancer;
+
+    if (props.overrideId) cfnLb.overrideLogicalId(id);
+  }
+}

--- a/src/constructs/loadbalancing/clb.ts
+++ b/src/constructs/loadbalancing/clb.ts
@@ -2,16 +2,31 @@ import type { CfnLoadBalancer, LoadBalancerProps } from "@aws-cdk/aws-elasticloa
 import { LoadBalancer } from "@aws-cdk/aws-elasticloadbalancing";
 import type { GuStack } from "../core";
 
+enum DeletionOverrideProperties {
+  SCHEME = "Scheme",
+}
+
 interface GuClassicLoadBalancerProps extends LoadBalancerProps {
   overrideId?: boolean;
+  deletionOverrideProperties?: DeletionOverrideProperties[];
+  overrideProperties?: Record<string, unknown>;
 }
 
 export class GuClassicLoadBalancer extends LoadBalancer {
+  static DeletionOverrideProperties = DeletionOverrideProperties;
+
   constructor(scope: GuStack, id: string, props: GuClassicLoadBalancerProps) {
     super(scope, id, props);
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 
     if (props.overrideId) cfnLb.overrideLogicalId(id);
+
+    props.deletionOverrideProperties?.forEach((key) => {
+      cfnLb.addPropertyDeletionOverride(key);
+    });
+
+    props.overrideProperties &&
+      Object.entries(props.overrideProperties).forEach(([key, value]) => cfnLb.addPropertyOverride(key, value));
   }
 }

--- a/src/constructs/loadbalancing/clb.ts
+++ b/src/constructs/loadbalancing/clb.ts
@@ -2,18 +2,18 @@ import type { CfnLoadBalancer, LoadBalancerProps } from "@aws-cdk/aws-elasticloa
 import { LoadBalancer } from "@aws-cdk/aws-elasticloadbalancing";
 import type { GuStack } from "../core";
 
-enum DeletionOverrideProperties {
+enum RemoveableProperties {
   SCHEME = "Scheme",
 }
 
 interface GuClassicLoadBalancerProps extends LoadBalancerProps {
   overrideId?: boolean;
-  deletionOverrideProperties?: DeletionOverrideProperties[];
-  overrideProperties?: Record<string, unknown>;
+  propertiesToRemove?: RemoveableProperties[];
+  propertiesToOverride?: Record<string, unknown>;
 }
 
 export class GuClassicLoadBalancer extends LoadBalancer {
-  static DeletionOverrideProperties = DeletionOverrideProperties;
+  static RemoveableProperties = RemoveableProperties;
 
   constructor(scope: GuStack, id: string, props: GuClassicLoadBalancerProps) {
     super(scope, id, props);
@@ -22,11 +22,11 @@ export class GuClassicLoadBalancer extends LoadBalancer {
 
     if (props.overrideId) cfnLb.overrideLogicalId(id);
 
-    props.deletionOverrideProperties?.forEach((key) => {
+    props.propertiesToRemove?.forEach((key) => {
       cfnLb.addPropertyDeletionOverride(key);
     });
 
-    props.overrideProperties &&
-      Object.entries(props.overrideProperties).forEach(([key, value]) => cfnLb.addPropertyOverride(key, value));
+    props.propertiesToOverride &&
+      Object.entries(props.propertiesToOverride).forEach(([key, value]) => cfnLb.addPropertyOverride(key, value));
   }
 }

--- a/src/constructs/loadbalancing/index.ts
+++ b/src/constructs/loadbalancing/index.ts
@@ -1,1 +1,2 @@
+export * from "./clb";
 export * from "./elb";


### PR DESCRIPTION
## What does this change?

This PR adds a new `GuClassicLoadBalancer` component which extends the `LoadBalancer` construct provided by the `@aws-cdk/aws-elasticloadbalancing` library. 

It adds three main pieces of functionality:

* A boolean value can be passed to the `overrideId` prop to remove the 8 digit hash added to the end of the logical id
* An array of values can be provided to the `deletionOverrideProperties` prop which will be passed to the `addPropertyDeletionOverride` method on the underlying `CfnLoadBalancer`. An enum is defined containing the acceptable values. This allows for properties to be remove to match existing implementations more easily
* An object of property names and values can be passed to the `overrideProperties` prop which will each be passed to the `addPropertyOverride` method on the underlying `CfnLoadBalancer`. This allows properties to be overwritten more easily.

## Does this change require changes to existing projects or CDK CLI?

This is not a breaking change but any existing stacks using the `LoadBalancer` construct directly can be updated to make use of this new construct.

## How to test

Implement this construct in any stacks which are using the `LoadBalancer` construct directly and check that the snapshot tests still pass (indicating that nothing has changed)

## How can we measure success?

Stacks using the `LoadBalancer` construct directly can now use this shared component and make use of the extra props provided.
