### PR TITLE
Add GuAssumeRolePolicy

### DIFF
--- a/src/constructs/iam/policies/assume-role.test.ts
+++ b/src/constructs/iam/policies/assume-role.test.ts
@@ -1,0 +1,51 @@
+import "@aws-cdk/assert/jest";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
+import { GuAssumeRolePolicy } from "./assume-role";
+
+describe("The GuAssumeRolePolicy class", () => {
+  it("sets default props", () => {
+    const stack = simpleGuStackForTesting();
+
+    const policy = new GuAssumeRolePolicy(stack, "GuAssumeRolePolicy", { resources: ["test"] });
+
+    attachPolicyToTestRole(stack, policy);
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Resource: "test",
+          },
+        ],
+      },
+    });
+  });
+
+  it("merges defaults and passed in props", () => {
+    const stack = simpleGuStackForTesting();
+
+    const policy = new GuAssumeRolePolicy(stack, "GuAssumeRolePolicy", {
+      resources: ["test"],
+      policyName: "test-policy",
+    });
+
+    attachPolicyToTestRole(stack, policy);
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyName: "test-policy",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "sts:AssumeRole",
+            Effect: "Allow",
+            Resource: "test",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/assume-role.ts
+++ b/src/constructs/iam/policies/assume-role.ts
@@ -1,0 +1,23 @@
+import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import type { GuStack } from "../../core";
+import type { GuPolicyProps } from "./base-policy";
+import { GuPolicy } from "./base-policy";
+
+export interface GuAssumeRolePolicyProps extends Omit<GuPolicyProps, "statements"> {
+  resources: string[];
+}
+
+export class GuAssumeRolePolicy extends GuPolicy {
+  constructor(scope: GuStack, id: string, props: GuAssumeRolePolicyProps) {
+    super(scope, id, {
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["sts:AssumeRole"],
+          resources: props.resources,
+        }),
+      ],
+      ...props,
+    });
+  }
+}


### PR DESCRIPTION
## What does this change?

This PR adds a new `GuAssumeRolePolicy` which takes `resources` as a prop. This reduces the amount of code required to provide assume role permissions. 

## Does this change require changes to existing projects or CDK CLI?

No changes are required but existing stacks where a Policy grants assume role permissions may wish to migrate to this. 

## How to test

Unit tests cover the new construct. Implementing it in place of a policy which grants this permissions in an existing stack shouldn't cause any changes when running the snapshot tests.

## How can we measure success?

Fewer lines of code are required to define common policies.
