### PR TITLE
Add migrated prop to GuStack

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -6,7 +6,7 @@ export interface GuStackProps extends StackProps {
   // This limits GuStack to supporting a single app.
   // In the future, support for stacks with multiple apps may be required
   app: string;
-  migrated?: boolean;
+  migratedFromCloudFormation?: boolean;
 }
 
 export class GuStack extends Stack {
@@ -26,7 +26,7 @@ export class GuStack extends Stack {
     return this._app;
   }
 
-  migrated: boolean;
+  migratedFromCloudFormation: boolean;
 
   protected addTag(key: string, value: string, applyToLaunchedInstances: boolean = true): void {
     Tags.of(this).add(key, value, { applyToLaunchedInstances });
@@ -36,7 +36,7 @@ export class GuStack extends Stack {
   constructor(app: App, id: string, props: GuStackProps) {
     super(app, id, props);
 
-    this.migrated = !!props.migrated;
+    this.migratedFromCloudFormation = !!props.migratedFromCloudFormation;
 
     this._stage = new GuStageParameter(this);
     this._stack = new GuStackParameter(this);

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -6,6 +6,7 @@ export interface GuStackProps extends StackProps {
   // This limits GuStack to supporting a single app.
   // In the future, support for stacks with multiple apps may be required
   app: string;
+  migrated?: boolean;
 }
 
 export class GuStack extends Stack {
@@ -25,6 +26,8 @@ export class GuStack extends Stack {
     return this._app;
   }
 
+  migrated: boolean;
+
   protected addTag(key: string, value: string, applyToLaunchedInstances: boolean = true): void {
     Tags.of(this).add(key, value, { applyToLaunchedInstances });
   }
@@ -32,6 +35,8 @@ export class GuStack extends Stack {
   // eslint-disable-next-line custom-rules/valid-constructors -- GuStack is the exception as it must take an App
   constructor(app: App, id: string, props: GuStackProps) {
     super(app, id, props);
+
+    this.migrated = !!props.migrated;
 
     this._stage = new GuStageParameter(this);
     this._stack = new GuStackParameter(this);

--- a/src/constructs/loadbalancing/clb.test.ts
+++ b/src/constructs/loadbalancing/clb.test.ts
@@ -30,6 +30,22 @@ describe("The GuClassicLoadBalancer class", () => {
     expect(Object.keys(json.Resources)).not.toContain("ClassicLoadBalancer");
   });
 
+  test("overrides the id if the stack migrated value is true", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { vpc });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).toContain("ClassicLoadBalancer");
+  });
+
+  test("does not override the id if the stack migrated value is true but the override id value is false", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { vpc, overrideId: false });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("ClassicLoadBalancer");
+  });
+
   test("deletes any provided properties", () => {
     const stack = simpleGuStackForTesting();
     new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {

--- a/src/constructs/loadbalancing/clb.test.ts
+++ b/src/constructs/loadbalancing/clb.test.ts
@@ -31,7 +31,7 @@ describe("The GuClassicLoadBalancer class", () => {
   });
 
   test("overrides the id if the stack migrated value is true", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { vpc });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -39,7 +39,7 @@ describe("The GuClassicLoadBalancer class", () => {
   });
 
   test("does not override the id if the stack migrated value is true but the override id value is false", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { vpc, overrideId: false });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;

--- a/src/constructs/loadbalancing/clb.ts
+++ b/src/constructs/loadbalancing/clb.ts
@@ -20,7 +20,8 @@ export class GuClassicLoadBalancer extends LoadBalancer {
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 
-    if (props.overrideId || (scope.migrated && props.overrideId !== false)) cfnLb.overrideLogicalId(id);
+    if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false))
+      cfnLb.overrideLogicalId(id);
 
     props.propertiesToRemove?.forEach((key) => {
       cfnLb.addPropertyDeletionOverride(key);

--- a/src/constructs/loadbalancing/clb.ts
+++ b/src/constructs/loadbalancing/clb.ts
@@ -20,7 +20,7 @@ export class GuClassicLoadBalancer extends LoadBalancer {
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 
-    if (props.overrideId) cfnLb.overrideLogicalId(id);
+    if (props.overrideId || (scope.migrated && props.overrideId !== false)) cfnLb.overrideLogicalId(id);
 
     props.propertiesToRemove?.forEach((key) => {
       cfnLb.addPropertyDeletionOverride(key);

--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -91,6 +91,22 @@ describe("The GuApplicationTargetGroup class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources)).not.toContain("ApplicationTargetGroup");
   });
+
+  test("overrides the id if the stack migrated value is true", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { vpc });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).toContain("ApplicationTargetGroup");
+  });
+
+  test("does not override the id if the stack migrated value is true but the override id value is false", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { vpc, overrideId: false });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("ApplicationTargetGroup");
+  });
 });
 
 describe("The GuApplicationListener class", () => {
@@ -131,6 +147,45 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       loadBalancer,
+      defaultAction: ListenerAction.forward([targetGroup]),
+      certificates: [{ certificateArn: "" }],
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("ApplicationListener");
+  });
+
+  test("overrides the id if the stack migrated value is true", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+
+    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
+    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
+      vpc: vpc,
+      protocol: ApplicationProtocol.HTTP,
+    });
+
+    new GuApplicationListener(stack, "ApplicationListener", {
+      loadBalancer,
+      defaultAction: ListenerAction.forward([targetGroup]),
+      certificates: [{ certificateArn: "" }],
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).toContain("ApplicationListener");
+  });
+
+  test("does not override the id if the stack migrated value is true but the override id value is false", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+
+    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
+    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
+      vpc: vpc,
+      protocol: ApplicationProtocol.HTTP,
+    });
+
+    new GuApplicationListener(stack, "ApplicationListener", {
+      loadBalancer,
+      overrideId: false,
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
     });

--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -30,6 +30,22 @@ describe("The GuApplicationLoadBalancer class", () => {
     expect(Object.keys(json.Resources)).not.toContain("ApplicationLoadBalancer");
   });
 
+  test("overrides the id if the stack migrated value is true", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).toContain("ApplicationLoadBalancer");
+  });
+
+  test("does not override the id if the stack migrated value is true but the override id value is false", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, overrideId: false });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("ApplicationLoadBalancer");
+  });
+
   test("deletes the Type property", () => {
     const stack = simpleGuStackForTesting();
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, overrideId: true });

--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -31,7 +31,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   test("overrides the id if the stack migrated value is true", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -39,7 +39,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   test("does not override the id if the stack migrated value is true but the override id value is false", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, overrideId: false });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -93,7 +93,7 @@ describe("The GuApplicationTargetGroup class", () => {
   });
 
   test("overrides the id if the stack migrated value is true", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { vpc });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -101,7 +101,7 @@ describe("The GuApplicationTargetGroup class", () => {
   });
 
   test("does not override the id if the stack migrated value is true but the override id value is false", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { vpc, overrideId: false });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -156,7 +156,7 @@ describe("The GuApplicationListener class", () => {
   });
 
   test("overrides the id if the stack migrated value is true", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
     const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
@@ -175,7 +175,7 @@ describe("The GuApplicationListener class", () => {
   });
 
   test("does not override the id if the stack migrated value is true but the override id value is false", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
     const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -38,7 +38,8 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
   constructor(scope: GuStack, id: string, props: GuApplicationTargetGroupProps) {
     super(scope, id, props);
 
-    if (props.overrideId) (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
+    if (props.overrideId || (scope.migrated && props.overrideId !== false))
+      (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
   }
 }
 
@@ -50,6 +51,7 @@ export class GuApplicationListener extends ApplicationListener {
   constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
     super(scope, id, { port: 443, protocol: ApplicationProtocol.HTTPS, ...props });
 
-    if (props.overrideId) (this.node.defaultChild as CfnListener).overrideLogicalId(id);
+    if (props.overrideId || (scope.migrated && props.overrideId !== false))
+      (this.node.defaultChild as CfnListener).overrideLogicalId(id);
   }
 }

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -24,7 +24,7 @@ export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 
-    if (props.overrideId) cfnLb.overrideLogicalId(id);
+    if (props.overrideId || (scope.migrated && props.overrideId !== false)) cfnLb.overrideLogicalId(id);
 
     cfnLb.addPropertyDeletionOverride("Type");
   }

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -24,7 +24,8 @@ export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 
-    if (props.overrideId || (scope.migrated && props.overrideId !== false)) cfnLb.overrideLogicalId(id);
+    if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false))
+      cfnLb.overrideLogicalId(id);
 
     cfnLb.addPropertyDeletionOverride("Type");
   }
@@ -38,7 +39,7 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
   constructor(scope: GuStack, id: string, props: GuApplicationTargetGroupProps) {
     super(scope, id, props);
 
-    if (props.overrideId || (scope.migrated && props.overrideId !== false))
+    if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false))
       (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
   }
 }
@@ -51,7 +52,7 @@ export class GuApplicationListener extends ApplicationListener {
   constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
     super(scope, id, { port: 443, protocol: ApplicationProtocol.HTTPS, ...props });
 
-    if (props.overrideId || (scope.migrated && props.overrideId !== false))
+    if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false))
       (this.node.defaultChild as CfnListener).overrideLogicalId(id);
   }
 }

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -136,7 +136,7 @@ describe("The GuDatabaseInstance class", () => {
   });
 
   it("overrides the id if the stack migrated value is true", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuDatabaseInstance(stack, "DatabaseInstance", {
       vpc,
       instanceType: "t3.small",
@@ -151,7 +151,7 @@ describe("The GuDatabaseInstance class", () => {
   });
 
   it("does not override the id if the stack migrated value is true but the override id value is false", () => {
-    const stack = simpleGuStackForTesting({ migrated: true });
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuDatabaseInstance(stack, "DatabaseInstance", {
       vpc,
       overrideId: false,

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -135,6 +135,37 @@ describe("The GuDatabaseInstance class", () => {
     expect(Object.keys(json.Resources)).not.toContain("DatabaseInstance");
   });
 
+  it("overrides the id if the stack migrated value is true", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_11_8,
+      }),
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(Object.keys(json.Resources)).toContain("DatabaseInstance");
+  });
+
+  it("does not override the id if the stack migrated value is true but the override id value is false", () => {
+    const stack = simpleGuStackForTesting({ migrated: true });
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      overrideId: false,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_11_8,
+      }),
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(Object.keys(json.Resources)).not.toContain("DatabaseInstance");
+  });
+
   test("sets the deletion protection value to true by default", () => {
     const stack = simpleGuStackForTesting();
     new GuDatabaseInstance(stack, "DatabaseInstance", {

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -34,7 +34,7 @@ export class GuDatabaseInstance extends DatabaseInstance {
       ...(parameterGroup && { parameterGroup }),
     });
 
-    if (props.overrideId || (scope.migrated && props.overrideId !== false)) {
+    if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false)) {
       (this.node.defaultChild as CfnDBInstance).overrideLogicalId(id);
     }
   }

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -34,7 +34,7 @@ export class GuDatabaseInstance extends DatabaseInstance {
       ...(parameterGroup && { parameterGroup }),
     });
 
-    if (props.overrideId) {
+    if (props.overrideId || (scope.migrated && props.overrideId !== false)) {
       (this.node.defaultChild as CfnDBInstance).overrideLogicalId(id);
     }
   }

--- a/test/utils/simple-gu-stack.ts
+++ b/test/utils/simple-gu-stack.ts
@@ -1,4 +1,6 @@
 import { App } from "@aws-cdk/core";
+import type { GuStackProps } from "../../src/constructs/core";
 import { GuStack } from "../../src/constructs/core";
 
-export const simpleGuStackForTesting: () => GuStack = () => new GuStack(new App(), "Test", { app: "testing" });
+export const simpleGuStackForTesting: (props?: Partial<GuStackProps>) => GuStack = (props?: Partial<GuStackProps>) =>
+  new GuStack(new App(), "Test", { app: "testing", ...props });


### PR DESCRIPTION
## What does this change?

This PR adds a new `migrated`  prop to the `GuStack`. This prop can be set to true to denote that a stack has been migrated from a cloudformation template. Other constructs can then modify their behaviour where that is the case. 

Currently, the only implementation is in the `GuApplicationLoadBalancer`, `GuApplicationListener`, `GuApplicationTargetGroup`, `GuClassicLoadBalancer` and `GuDatabaseInstance` constructs. If the `migrated` value is true and the override id prop is _not_ false then the override id logic will be invoked. The overrideId prop has been left for cases outside of the default where the id still needs to be constant. Including the `&& props.overrideId !== false` condition means that it is also possible to explicitly override the default behaviour for a migrated stack if required. 

Credit to @jacobwinch for the idea! 👏 

## Does this change require changes to existing projects or CDK CLI?

No changes are required but migrated stacks can use the new prop in place of passing the `overrideId` prop to each construct.

## How to test

New units tests cover the new functionality. Trying adding the `migrated` prop to a migrated stack. Removing the relevant `overrideId` props should cause no change. 

## How can we measure success?

Migrating existing stacks is simpler and requires fewer lines of code.

