### PR TITLE
update GuLogShippingPolicy to bring it's own parameter

### DIFF
--- a/src/constructs/iam/policies/log-shipping.test.ts
+++ b/src/constructs/iam/policies/log-shipping.test.ts
@@ -6,12 +6,12 @@ describe("The GuLogShippingPolicy class", () => {
   it("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const logShippingPolicy = new GuLogShippingPolicy(stack, "LogShippingPolicy", { loggingStreamName: "test" });
+    const logShippingPolicy = new GuLogShippingPolicy(stack);
 
     attachPolicyToTestRole(stack, logShippingPolicy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
-      PolicyName: "log-shipping-policy",
+      PolicyName: "GuLogShippingPolicy981BFE5A",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [
@@ -30,7 +30,10 @@ describe("The GuLogShippingPolicy class", () => {
                   {
                     Ref: "AWS::AccountId",
                   },
-                  ":stream/test",
+                  ":stream/",
+                  {
+                    Ref: "LoggingStreamName",
+                  },
                 ],
               ],
             },
@@ -44,7 +47,6 @@ describe("The GuLogShippingPolicy class", () => {
     const stack = simpleGuStackForTesting();
 
     const logShippingPolicy = new GuLogShippingPolicy(stack, "LogShippingPolicy", {
-      loggingStreamName: "test",
       policyName: "test",
     });
 
@@ -70,7 +72,10 @@ describe("The GuLogShippingPolicy class", () => {
                   {
                     Ref: "AWS::AccountId",
                   },
-                  ":stream/test",
+                  ":stream/",
+                  {
+                    Ref: "LoggingStreamName",
+                  },
                 ],
               ],
             },

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -220,6 +220,12 @@ Object {
 exports[`The InstanceRole construct should create an additional logging policy if logging stream is specified 1`] = `
 Object {
   "Parameters": Object {
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "NoEcho": true,
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stack": Object {
       "Default": "deploy",
       "Description": "Name of this stack",
@@ -283,6 +289,48 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "InstanceRole": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
@@ -328,45 +376,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "LogShippingPolicyBCA13F45": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:kinesis:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/my-logging-stream",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "log-shipping-policy",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRole",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "ParameterStoreRead9D2F4FAB": Object {
       "Properties": Object {

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -1,13 +1,13 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
-import { simpleGuStackForTesting } from "../../test/utils/simple-gu-stack";
+import { simpleGuStackForTesting } from "../../test/utils";
 import { GuGetS3ObjectPolicy } from "../constructs/iam";
 import { InstanceRole } from "./instance-role";
 
 describe("The InstanceRole construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, "InstanceRole", { bucketName: "test" });
+    new InstanceRole(stack, "InstanceRole", { bucketName: "test", includeLogShipping: false });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -16,7 +16,7 @@ describe("The InstanceRole construct", () => {
 
   it("should create an additional logging policy if logging stream is specified", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, "InstanceRole", { bucketName: "test", loggingStreamName: "my-logging-stream" });
+    new InstanceRole(stack, "InstanceRole", { bucketName: "test", includeLogShipping: true });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -28,6 +28,7 @@ describe("The InstanceRole construct", () => {
 
     new InstanceRole(stack, "InstanceRole", {
       bucketName: "test",
+      includeLogShipping: false,
       additionalPolicies: [new GuGetS3ObjectPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
     });
 

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -7,7 +7,7 @@ import { InstanceRole } from "./instance-role";
 describe("The InstanceRole construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, "InstanceRole", { bucketName: "test", includeLogShipping: false });
+    new InstanceRole(stack, "InstanceRole", { bucketName: "test", withoutLogShipping: true });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -16,7 +16,7 @@ describe("The InstanceRole construct", () => {
 
   it("should create an additional logging policy if logging stream is specified", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, "InstanceRole", { bucketName: "test", includeLogShipping: true });
+    new InstanceRole(stack, "InstanceRole", { bucketName: "test" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -28,7 +28,7 @@ describe("The InstanceRole construct", () => {
 
     new InstanceRole(stack, "InstanceRole", {
       bucketName: "test",
-      includeLogShipping: false,
+      withoutLogShipping: true,
       additionalPolicies: [new GuGetS3ObjectPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
     });
 

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -11,7 +11,7 @@ import {
 } from "../constructs/iam";
 
 interface InstanceRoleProps extends GuGetS3ObjectPolicyProps {
-  includeLogShipping: boolean;
+  withoutLogShipping?: boolean; // optional to have log shipping added by default, you have to opt out
   additionalPolicies?: GuPolicy[];
 }
 
@@ -30,7 +30,7 @@ export class InstanceRole extends GuRole {
       new GuGetS3ObjectPolicy(scope, "GetDistributablesPolicy", props),
       new GuDescribeEC2Policy(scope),
       new GuParameterStoreReadPolicy(scope),
-      ...(props.includeLogShipping ? [new GuLogShippingPolicy(scope)] : []),
+      ...(props.withoutLogShipping ? [] : [new GuLogShippingPolicy(scope)]),
       ...(props.additionalPolicies ? props.additionalPolicies : []),
     ];
 

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -1,6 +1,6 @@
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../constructs/core";
-import type { GuGetS3ObjectPolicyProps, GuLogShippingPolicyProps, GuPolicy } from "../constructs/iam";
+import type { GuGetS3ObjectPolicyProps, GuPolicy } from "../constructs/iam";
 import {
   GuDescribeEC2Policy,
   GuGetS3ObjectPolicy,
@@ -10,7 +10,8 @@ import {
   GuSSMRunCommandPolicy,
 } from "../constructs/iam";
 
-interface InstanceRoleProps extends GuGetS3ObjectPolicyProps, Partial<GuLogShippingPolicyProps> {
+interface InstanceRoleProps extends GuGetS3ObjectPolicyProps {
+  includeLogShipping: boolean;
   additionalPolicies?: GuPolicy[];
 }
 
@@ -29,9 +30,7 @@ export class InstanceRole extends GuRole {
       new GuGetS3ObjectPolicy(scope, "GetDistributablesPolicy", props),
       new GuDescribeEC2Policy(scope),
       new GuParameterStoreReadPolicy(scope),
-      ...(props.loggingStreamName
-        ? [new GuLogShippingPolicy(scope, "LogShippingPolicy", props as GuLogShippingPolicyProps)]
-        : []),
+      ...(props.includeLogShipping ? [new GuLogShippingPolicy(scope)] : []),
       ...(props.additionalPolicies ? props.additionalPolicies : []),
     ];
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We've established best practice for accounts/stacks to define the kinesis stream to send logs to to be a SSM Parameter called `/account/services/logging.stream.name`.

This updates `GuLogShippingPolicy` to add the parameter to the stack within that construct. The construct is bringing its own resources with it, rather than being passed in as props. This makes it more self contained.

This builds on the BYO* pattern introduced in https://github.com/guardian/cdk/pull/91.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes! The signature of `InstanceRole` has changed to no longer require a stream name, but simply a `includeLogShipping` boolean.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Observe CI?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler interface to `InstanceRole` and more self contained constructs.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a