### PR TITLE
Update Policy Props

### DIFF
--- a/src/constructs/iam/policies/assume-role.ts
+++ b/src/constructs/iam/policies/assume-role.ts
@@ -1,9 +1,9 @@
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
+import type { GuNoStatementsPolicyProps } from "./base-policy";
 import { GuPolicy } from "./base-policy";
 
-export interface GuAssumeRolePolicyProps extends Omit<GuPolicyProps, "statements"> {
+export interface GuAssumeRolePolicyProps extends GuNoStatementsPolicyProps {
   resources: string[];
 }
 

--- a/src/constructs/iam/policies/base-policy.ts
+++ b/src/constructs/iam/policies/base-policy.ts
@@ -6,6 +6,8 @@ export interface GuPolicyProps extends PolicyProps {
   overrideId?: boolean;
 }
 
+export type GuNoStatementsPolicyProps = Omit<GuPolicyProps, "statements">;
+
 export abstract class GuPolicy extends Policy {
   protected constructor(scope: GuStack, id: string, props: GuPolicyProps) {
     super(scope, id, props);
@@ -17,7 +19,7 @@ export abstract class GuPolicy extends Policy {
   }
 }
 
-export interface GuAllowPolicyProps extends GuPolicyProps {
+export interface GuAllowPolicyProps extends GuNoStatementsPolicyProps {
   actions: string[];
   resources: string[];
 }

--- a/src/constructs/iam/policies/dynamodb.ts
+++ b/src/constructs/iam/policies/dynamodb.ts
@@ -1,12 +1,12 @@
 import type { GuStack } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
+import type { GuNoStatementsPolicyProps } from "./base-policy";
 import { GuAllowPolicy } from "./base-policy";
 
 interface GuDynamoDBPolicyProps {
   tableName: string;
 }
 
-interface GuDynamoDBPolicyPropsWithActions extends GuPolicyProps, GuDynamoDBPolicyProps {
+interface GuDynamoDBPolicyPropsWithActions extends GuNoStatementsPolicyProps, GuDynamoDBPolicyProps {
   actions: string[];
 }
 

--- a/src/constructs/iam/policies/dynamodb.ts
+++ b/src/constructs/iam/policies/dynamodb.ts
@@ -13,6 +13,7 @@ interface GuDynamoDBPolicyPropsWithActions extends GuPolicyProps, GuDynamoDBPoli
 abstract class GuDynamoDBPolicy extends GuAllowPolicy {
   protected constructor(scope: GuStack, id: string, props: GuDynamoDBPolicyPropsWithActions) {
     super(scope, id, {
+      ...props,
       actions: props.actions.map((action) => `dynamodb:${action}`),
       resources: [`arn:aws:dynamodb:${scope.region}:${scope.account}:table/${props.tableName}`],
     });


### PR DESCRIPTION
## What does this change?

This PR update the `GuDynamoDBPolicy` class to pass through any additional props in the super call. It also omits the `statements` prop from the signature to prevent additional statements being added. As this same signature is used elsewhere, an new type is defined and used in both places.

## Does this change require changes to existing projects or CDK CLI?

No.

## How to test

This can be tested by implementing in existing stacks and seeing that the snapshot tests still pass.

## How can we measure success?

Policy constructs pass through additional props but don't allow additional statements to be added.
