### PR TITLE
Create GuGetDistributablePolicy construct

### DIFF
--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -1,6 +1,6 @@
 import "@aws-cdk/assert/jest";
 import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
-import { GuGetS3ObjectPolicy } from "./s3-get-object";
+import { GuGetDistributablePolicy, GuGetS3ObjectPolicy } from "./s3-get-object";
 
 describe("The GuGetS3ObjectPolicy class", () => {
   it("sets default props", () => {
@@ -40,6 +40,38 @@ describe("The GuGetS3ObjectPolicy class", () => {
             Effect: "Allow",
             Resource: "arn:aws:s3:::test/*",
             Action: "s3:GetObject",
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("The GuGetDistributablePolicy construct", () => {
+  it("creates the correct policy", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuGetDistributablePolicy(stack));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyName: "GetDistributablePolicyC6B4A871",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "s3:GetObject",
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:s3:::",
+                  {
+                    Ref: "DistributionBucketName",
+                  },
+                  "/*",
+                ],
+              ],
+            },
           },
         ],
       },

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,4 +1,5 @@
 import type { GuStack } from "../../core";
+import { GuSSMParameter } from "../../core";
 import type { GuPolicyProps } from "./base-policy";
 import { GuAllowPolicy } from "./base-policy";
 
@@ -9,5 +10,16 @@ export interface GuGetS3ObjectPolicyProps extends GuPolicyProps {
 export class GuGetS3ObjectPolicy extends GuAllowPolicy {
   constructor(scope: GuStack, id: string, props: GuGetS3ObjectPolicyProps) {
     super(scope, id, { ...props, actions: ["s3:GetObject"], resources: [`arn:aws:s3:::${props.bucketName}/*`] });
+  }
+}
+
+export class GuGetDistributablePolicy extends GuGetS3ObjectPolicy {
+  constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuPolicyProps) {
+    const distributionBucketNameParam = new GuSSMParameter(scope, "DistributionBucketName", {
+      description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      default: "/account/services/artifact.bucket",
+    });
+
+    super(scope, id, { ...props, bucketName: distributionBucketNameParam.valueAsString });
   }
 }

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,9 +1,9 @@
 import type { GuStack } from "../../core";
 import { GuSSMParameter } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
+import type { GuNoStatementsPolicyProps } from "./base-policy";
 import { GuAllowPolicy } from "./base-policy";
 
-export interface GuGetS3ObjectPolicyProps extends GuPolicyProps {
+export interface GuGetS3ObjectPolicyProps extends GuNoStatementsPolicyProps {
   bucketName: string;
 }
 
@@ -14,7 +14,7 @@ export class GuGetS3ObjectPolicy extends GuAllowPolicy {
 }
 
 export class GuGetDistributablePolicy extends GuGetS3ObjectPolicy {
-  constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuPolicyProps) {
+  constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuNoStatementsPolicyProps) {
     const distributionBucketNameParam = new GuSSMParameter(scope, "DistributionBucketName", {
       description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
       default: "/account/services/artifact.bucket",

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,26 +1,13 @@
-import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
 import type { GuPolicyProps } from "./base-policy";
-import { GuPolicy } from "./base-policy";
+import { GuAllowPolicy } from "./base-policy";
 
 export interface GuGetS3ObjectPolicyProps extends GuPolicyProps {
   bucketName: string;
 }
 
-export const allowGetObjectPolicyStatement: (bucket: string) => { statements: PolicyStatement[] } = (
-  bucketName: string
-) => ({
-  statements: [
-    new PolicyStatement({
-      effect: Effect.ALLOW,
-      actions: ["s3:GetObject"],
-      resources: [`arn:aws:s3:::${bucketName}/*`],
-    }),
-  ],
-});
-
-export class GuGetS3ObjectPolicy extends GuPolicy {
+export class GuGetS3ObjectPolicy extends GuAllowPolicy {
   constructor(scope: GuStack, id: string, props: GuGetS3ObjectPolicyProps) {
-    super(scope, id, { ...allowGetObjectPolicyStatement(props.bucketName), ...props });
+    super(scope, id, { ...props, actions: ["s3:GetObject"], resources: [`arn:aws:s3:::${props.bucketName}/*`] });
   }
 }

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -3,6 +3,12 @@
 exports[`The InstanceRole construct should allow additional policies to be specified 1`] = `
 Object {
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "NoEcho": true,
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stack": Object {
       "Default": "deploy",
       "Description": "Name of this stack",
@@ -66,19 +72,30 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablesPolicy648EC38C": Object {
+    "GetDistributablePolicyC6B4A871": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::test/*",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "GetDistributablesPolicy648EC38C",
+        "PolicyName": "GetDistributablePolicyC6B4A871",
         "Roles": Array [
           Object {
             "Ref": "InstanceRole",
@@ -220,6 +237,12 @@ Object {
 exports[`The InstanceRole construct should create an additional logging policy if logging stream is specified 1`] = `
 Object {
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "NoEcho": true,
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "LoggingStreamName": Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
@@ -268,19 +291,30 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablesPolicy648EC38C": Object {
+    "GetDistributablePolicyC6B4A871": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::test/*",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "GetDistributablesPolicy648EC38C",
+        "PolicyName": "GetDistributablePolicyC6B4A871",
         "Roles": Array [
           Object {
             "Ref": "InstanceRole",
@@ -464,6 +498,12 @@ Object {
 exports[`The InstanceRole construct should create the correct resources with minimal config 1`] = `
 Object {
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "NoEcho": true,
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stack": Object {
       "Default": "deploy",
       "Description": "Name of this stack",
@@ -506,19 +546,30 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablesPolicy648EC38C": Object {
+    "GetDistributablePolicyC6B4A871": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::test/*",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "GetDistributablesPolicy648EC38C",
+        "PolicyName": "GetDistributablePolicyC6B4A871",
         "Roles": Array [
           Object {
             "Ref": "InstanceRole",

--- a/src/patterns/instance-role.test.ts
+++ b/src/patterns/instance-role.test.ts
@@ -7,7 +7,7 @@ import { InstanceRole } from "./instance-role";
 describe("The InstanceRole construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, "InstanceRole", { bucketName: "test", withoutLogShipping: true });
+    new InstanceRole(stack, "InstanceRole", { withoutLogShipping: true });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -16,7 +16,7 @@ describe("The InstanceRole construct", () => {
 
   it("should create an additional logging policy if logging stream is specified", () => {
     const stack = simpleGuStackForTesting();
-    new InstanceRole(stack, "InstanceRole", { bucketName: "test" });
+    new InstanceRole(stack);
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -27,7 +27,6 @@ describe("The InstanceRole construct", () => {
     const stack = simpleGuStackForTesting();
 
     new InstanceRole(stack, "InstanceRole", {
-      bucketName: "test",
       withoutLogShipping: true,
       additionalPolicies: [new GuGetS3ObjectPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
     });

--- a/src/patterns/instance-role.ts
+++ b/src/patterns/instance-role.ts
@@ -1,16 +1,16 @@
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../constructs/core";
-import type { GuGetS3ObjectPolicyProps, GuPolicy } from "../constructs/iam";
+import type { GuPolicy } from "../constructs/iam";
 import {
   GuDescribeEC2Policy,
-  GuGetS3ObjectPolicy,
+  GuGetDistributablePolicy,
   GuLogShippingPolicy,
   GuParameterStoreReadPolicy,
   GuRole,
   GuSSMRunCommandPolicy,
 } from "../constructs/iam";
 
-interface InstanceRoleProps extends GuGetS3ObjectPolicyProps {
+interface InstanceRoleProps {
   withoutLogShipping?: boolean; // optional to have log shipping added by default, you have to opt out
   additionalPolicies?: GuPolicy[];
 }
@@ -18,7 +18,7 @@ interface InstanceRoleProps extends GuGetS3ObjectPolicyProps {
 export class InstanceRole extends GuRole {
   private policies: GuPolicy[];
 
-  constructor(scope: GuStack, id: string, props: InstanceRoleProps) {
+  constructor(scope: GuStack, id: string = "InstanceRole", props?: InstanceRoleProps) {
     super(scope, id, {
       overrideId: true,
       path: "/",
@@ -27,11 +27,11 @@ export class InstanceRole extends GuRole {
 
     this.policies = [
       new GuSSMRunCommandPolicy(scope),
-      new GuGetS3ObjectPolicy(scope, "GetDistributablesPolicy", props),
+      new GuGetDistributablePolicy(scope),
       new GuDescribeEC2Policy(scope),
       new GuParameterStoreReadPolicy(scope),
-      ...(props.withoutLogShipping ? [] : [new GuLogShippingPolicy(scope)]),
-      ...(props.additionalPolicies ? props.additionalPolicies : []),
+      ...(props?.withoutLogShipping ? [] : [new GuLogShippingPolicy(scope)]),
+      ...(props?.additionalPolicies ? props.additionalPolicies : []),
     ];
 
     this.policies.forEach((p) => p.attachToRole(this));


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The changes in https://github.com/guardian/cdk/pull/137 were quite nice, this PR applies the same methodology to the policy that allows GETting a object from S3.

Creates a new `GuGetDistributablePolicy` construct to create an IAM policy allowing S3 GET from a distribution bucket. This construct also brings with it a SSM Parameter for the name of the bucket, defaulting to `/account/services/artifact.bucket`. This simplifies the props for `InstanceRole`, removing `bucketName`.

This PR also changes `GuGetS3ObjectPolicy` to extend from `GuAllowPolicy` which yields simpler code.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. Now an `InstanceRole` is simpler to instantiate (`new InstanceRole(scope)` is sufficient).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler interfaces.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a