### PR TITLE
Allow all parameters to be from SSM

### DIFF
--- a/src/constructs/core/parameters.test.ts
+++ b/src/constructs/core/parameters.test.ts
@@ -8,8 +8,8 @@ import {
   GuAmiParameter,
   GuArnParameter,
   GuInstanceTypeParameter,
+  GuParameter,
   GuS3ObjectArnParameter,
-  GuSSMParameter,
   GuStackParameter,
   GuStageParameter,
   GuStringParameter,
@@ -17,6 +17,57 @@ import {
   GuVpcParameter,
 } from "./parameters";
 import type { GuStack } from "./stack";
+
+describe("The GuParameter class", () => {
+  it("sets the type as passed through by default", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { type: "Boolean" });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toEqual({
+      Type: "Boolean",
+    });
+  });
+
+  it("wraps the type with SSM utility is fromSSM is true", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { type: "Boolean", fromSSM: true });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toEqual({
+      Type: "AWS::SSM::Parameter::Value<Boolean>",
+    });
+  });
+
+  it("defaults to string if SSM is true but no type provided", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { fromSSM: true });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toEqual({
+      Type: "AWS::SSM::Parameter::Value<String>",
+    });
+  });
+
+  it("passes through other values without modification", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { type: "Boolean", fromSSM: true, description: "This is a test" });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toEqual({
+      Type: "AWS::SSM::Parameter::Value<Boolean>",
+      Description: "This is a test",
+    });
+  });
+});
 
 describe("The GuStringParameter class", () => {
   it("should set the type to string", () => {
@@ -97,36 +148,6 @@ describe("The GuInstanceTypeParameter class", () => {
       Type: "Number",
       Description: "This is a test",
       Default: 1,
-    });
-  });
-});
-
-describe("The GuSSMParameter class", () => {
-  it("should combine default, override and prop values", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuSSMParameter(stack, "Parameter", { description: "This is a test" });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters.Parameter).toEqual({
-      NoEcho: true,
-      Type: "AWS::SSM::Parameter::Value<String>",
-      Description: "This is a test",
-    });
-  });
-
-  it("let's you override default props", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuSSMParameter(stack, "Parameter", { noEcho: false, description: "This is a test" });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters.Parameter).toEqual({
-      NoEcho: false,
-      Type: "AWS::SSM::Parameter::Value<String>",
-      Description: "This is a test",
     });
   });
 });

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -3,13 +3,18 @@ import { CfnParameter } from "@aws-cdk/core";
 import { RegexPattern, Stage, Stages } from "../../constants";
 import type { GuStack } from "./stack";
 
-export type GuParameterProps = CfnParameterProps;
+export interface GuParameterProps extends CfnParameterProps {
+  fromSSM?: boolean;
+}
 
 export type GuNoTypeParameterProps = Omit<GuParameterProps, "type">;
 
 export class GuParameter extends CfnParameter {
   constructor(scope: GuStack, id: string, props: GuParameterProps) {
-    super(scope, id, props);
+    super(scope, id, {
+      ...props,
+      type: props.fromSSM ? `AWS::SSM::Parameter::Value<${props.type ?? "String"}>` : props.type,
+    });
   }
 }
 
@@ -47,16 +52,6 @@ export class GuInstanceTypeParameter extends GuParameter {
       description: "EC2 Instance Type",
       default: "t3.small",
       ...props,
-    });
-  }
-}
-
-export class GuSSMParameter extends GuParameter {
-  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
-    super(scope, id, {
-      noEcho: true,
-      ...props,
-      type: "AWS::SSM::Parameter::Value<String>",
     });
   }
 }

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -1,6 +1,6 @@
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
-import { GuSSMParameter } from "../../core";
+import { GuStringParameter } from "../../core";
 import type { GuPolicyProps } from "./base-policy";
 import { GuPolicy } from "./base-policy";
 
@@ -8,9 +8,11 @@ export class GuLogShippingPolicy extends GuPolicy {
   constructor(scope: GuStack, id: string = "GuLogShippingPolicy", props?: GuPolicyProps) {
     super(scope, id, { ...props });
 
-    const loggingStreamNameParam = new GuSSMParameter(scope, "LoggingStreamName", {
+    const loggingStreamNameParam = new GuStringParameter(scope, "LoggingStreamName", {
       description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
       default: "/account/services/logging.stream.name",
+      fromSSM: true,
+      noEcho: true,
     });
 
     this.addStatements(

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -12,7 +12,6 @@ export class GuLogShippingPolicy extends GuPolicy {
       description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
       default: "/account/services/logging.stream.name",
       fromSSM: true,
-      noEcho: true,
     });
 
     this.addStatements(

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -223,7 +223,6 @@ Object {
     "LoggingStreamName": Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
-      "NoEcho": true,
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "Stack": Object {


### PR DESCRIPTION
## What does this change?

This PR updates the `GuParameter` to take a new `fromSSM` prop. If this prop is set to true then the `type` value will be wrapped with `AWS::SSM::Parameter::Value`. This means that all parameters extending the `GuParameter` can now be denoted as `fromSSM`. Due to the, the `GuSSMParameter` has been removed and the one case where it was used has been updated.

## Does this change require changes to existing projects or CDK CLI?

Yes. Anywhere that is currently using the `GuSSMParameter` will need to be updated to use another construct with the `fromSSM` value set to true.

## How to test

New unit tests have been added to cover the exact functionality. The `GuLogShippingPolicy` was using `GuSSMParameter` and has been refactored so you can also see that it still produces the same cloudformation.

## How can we measure success?

GuParameter constructs present a more consistent interface with regard to getting values from SSM.
