### PR TITLE
echo GuSSMParameter values by default

### DIFF
--- a/src/constructs/core/parameters.test.ts
+++ b/src/constructs/core/parameters.test.ts
@@ -110,6 +110,19 @@ describe("The GuSSMParameter class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Parameters.Parameter).toEqual({
+      Type: "AWS::SSM::Parameter::Value<String>",
+      Description: "This is a test",
+    });
+  });
+
+  it("should allow noEcho to be specified", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuSSMParameter(stack, "Parameter", { description: "This is a test", noEcho: true });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toEqual({
       NoEcho: true,
       Type: "AWS::SSM::Parameter::Value<String>",
       Description: "This is a test",

--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -54,7 +54,6 @@ export class GuInstanceTypeParameter extends GuParameter {
 export class GuSSMParameter extends GuParameter {
   constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {
-      noEcho: true,
       ...props,
       type: "AWS::SSM::Parameter::Value<String>",
     });

--- a/src/patterns/__snapshots__/instance-role.test.ts.snap
+++ b/src/patterns/__snapshots__/instance-role.test.ts.snap
@@ -223,7 +223,6 @@ Object {
     "LoggingStreamName": Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
-      "NoEcho": true,
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "Stack": Object {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The value of GuSSMParameter will be the path into parameter store. This isn't private, so setting noEcho should not be the default.

I observed this whilst applying https://github.com/guardian/deploy-tools-platform/pull/323. The value of `LoggingStreamName` is defaulted and with `noEcho` set to `true`, it caused for an interesting CFN update as had to triple check the redacted value.

It is still possible to set `noEcho` and have added a test to demonstrate this.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Tests have been added.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Better default behaviour of the `GuSSMParameter`.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a