### PR TITLE
Add BYO pattern to GuVpc

### DIFF
--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -21,7 +21,7 @@ export class GuVpc {
     });
   }
 
-  static fromIdParameter(scope: GuStack, id: string, props: VpcFromIdParameterProps): IVpc {
+  static fromIdParameter(scope: GuStack, id: string, props?: VpcFromIdParameterProps): IVpc {
     const vpc = new GuVpcParameter(scope, "VpcId", {
       description: "Virtual Private Cloud to run EC2 instances within",
       default: "/account/services/default.vpc",

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -1,17 +1,33 @@
 import type { ISubnet, IVpc, VpcAttributes } from "@aws-cdk/aws-ec2";
 import { Subnet, Vpc } from "@aws-cdk/aws-ec2";
 import type { GuStack } from "../core";
+import { GuVpcParameter } from "../core";
+
+interface VpcFromIdProps extends Omit<VpcAttributes, "availabilityZones"> {
+  availabilityZones?: string[];
+}
+
+type VpcFromIdParameterProps = Omit<VpcFromIdProps, "vpcId">;
 
 export class GuVpc {
   static subnets(scope: GuStack, subnets: string[]): ISubnet[] {
     return subnets.map((subnetId) => Subnet.fromSubnetId(scope, `subnet-${subnetId}`, subnetId));
   }
 
-  static fromId(scope: GuStack, id: string, vpcId: string, props?: Partial<VpcAttributes>): IVpc {
+  static fromId(scope: GuStack, id: string, props: VpcFromIdProps): IVpc {
     return Vpc.fromVpcAttributes(scope, id, {
-      vpcId: vpcId,
       availabilityZones: scope.availabilityZones,
       ...props,
     });
+  }
+
+  static fromIdParameter(scope: GuStack, id: string, props: VpcFromIdParameterProps): IVpc {
+    const vpc = new GuVpcParameter(scope, "VpcId", {
+      description: "Virtual Private Cloud to run EC2 instances within",
+      default: "/account/services/default.vpc",
+      fromSSM: true,
+    });
+
+    return GuVpc.fromId(scope, id, { ...props, vpcId: vpc.valueAsString });
   }
 }


### PR DESCRIPTION
## What does this change?

This PR adds a new `fromIdParameter` method to the `GuVpc` class. This method will create a new parameter for the VpcId and use this to return the reference to the VPC to be used throughout the stack.

## Does this change require changes to existing projects or CDK CLI?

No changes are required but existing stack may migrate to the new method to reduce the amount of code required.

## How to test

Migrate an existing stack to the method and run the snapshot tests.

## How can we measure success?

Fewer parameters have to be defined manually.