### PR TITLE
update the GH Action trigger

### DIFF
--- a/.github/workflows/cd-docs.yaml
+++ b/.github/workflows/cd-docs.yaml
@@ -1,7 +1,8 @@
-name: Deploy Documentation on new release
+name: Deploy documentation on new tag
 on:
-  release:
-    types: [created]
+  create:
+    tags:
+      - 'v*'
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following https://github.com/guardian/cdk/pull/148, it looks like releases and tags are different concepts in GitHub, even though, confusingly, tags show up on https://github.com/guardian/cdk/releases.

It looks like our release process is currently only creating tags and NOT creating releases. As a result, this change tweaks the GH Action to update docs on _tag_ creation.

We'll likely add semantic-release to this library, which does in fact create releases, but this is a little far away.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Docs are updated automatically when a tag is created.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a