### PR TITLE
adds GuPublicInternetAccessSecurityGroup construct

### DIFF
--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -1,5 +1,6 @@
 import type { CfnSecurityGroup, IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { Peer, Port, SecurityGroup } from "@aws-cdk/aws-ec2";
+import { transformToCidrIngress } from "../../utils";
 import type { GuStack } from "../core";
 
 export interface CidrIngress {
@@ -56,6 +57,16 @@ export class GuWazuhAccess extends GuSecurityGroup {
     super(scope, id, {
       ...GuWazuhAccess.getDefaultProps(),
       ...props,
+    });
+  }
+}
+
+export class GuPublicInternetAccessSecurityGroup extends GuSecurityGroup {
+  constructor(scope: GuStack, id: string, props: SecurityGroupProps) {
+    super(scope, id, {
+      ...props,
+      ingresses: transformToCidrIngress(Object.entries({ GLOBAL_ACCESS: "0.0.0.0/0" })),
+      description: `Allows internet access on ${GuPublicInternetAccessSecurityGroup.defaultIngressPort.toString()}`,
     });
   }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A simple construct to abstract away a common requirement of open access to port 443.

This would mean [this](https://github.com/guardian/typerighter/blob/fc029ed8d493a782d9d658be1fbfa0418ffc9a51/cdk/lib/rule-manager/rule-manager.ts#L84-L93) can be removed.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - [Typerighter](https://github.com/guardian/typerighter/blob/fc029ed8d493a782d9d658be1fbfa0418ffc9a51/cdk/lib/rule-manager/rule-manager.ts#L84-L93) becomes a bit thinner.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

One more common construct provided by this library.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a