### PR TITLE
Update default VPC parameter path

### DIFF
--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -24,7 +24,7 @@ export class GuVpc {
   static fromIdParameter(scope: GuStack, id: string, props?: VpcFromIdParameterProps): IVpc {
     const vpc = new GuVpcParameter(scope, "VpcId", {
       description: "Virtual Private Cloud to run EC2 instances within",
-      default: "/account/services/default.vpc",
+      default: "/account/vpc/primary/id",
       fromSSM: true,
     });
 


### PR DESCRIPTION
## What does this change?

This PR updates the default path of the VPC parameter created by the `fromIdParameter` to be `/account/vpc/primary/id` to discourage the use of the default VPC. 

See thread here: https://github.com/guardian/cdk/pull/149#discussion_r558843564

## Does this change require changes to existing projects or CDK CLI?

Any stacks using this method already will have the ensure the value is set at the new path. Although, to my knowledge, nothing is using it yet.

## How to test

Implement this method in an existing stack and view that changes by running the snapshot test.

## How can we measure success?

People are discouraged from using the default VPC.