### PR TITLE
Add doc with default SSM paths

### DIFF
--- a/docs/005-default-parameter-store-locations.md
+++ b/docs/005-default-parameter-store-locations.md
@@ -1,0 +1,9 @@
+# Default Parameter Store Locations
+
+A number of constructs from the library define parameters to get configuration from Parameter Store. Each of these parameters configures a default path. The below table lists those paths, the parameter that sets them, the expected value type and which construct the parameter is defined within.
+
+| Path                                  | Parameter              | Type              | Construct                |
+| ------------------------------------- | ---------------------- | ----------------- | ------------------------ |
+| /account/vpc/primary/id               | VpcId                  | AWS::EC2::VPC::Id | GuVpc.fromIdParameter    |
+| /account/services/artifact.bucket     | DistributionBucketName | String            | GuGetDistributablePolicy |
+| /account/services/logging.stream.name | LoggingStreamName      | String            | GuLogShippingPolicy      |


### PR DESCRIPTION
## What does this change?

A number of constructs now "bring their own" parameters and read from "standard" locations in parameter store. To make it easier for a user to see all of the default paths, this PR adds a new file to the docs which contains a table listing them.

(See discussion thread: https://github.com/guardian/cdk/discussions/175#discussioncomment-293101)

## Does this change require changes to existing projects or CDK CLI?

No.

## How can we measure success?

The account configuration required to use constructs from the library is explained clearly in documentation.
