### PR TITLE
Update EC2 tests

### DIFF
--- a/src/constructs/ec2/security-group.test.ts
+++ b/src/constructs/ec2/security-group.test.ts
@@ -157,14 +157,14 @@ describe("The GuWazuhAccess class", () => {
   });
 });
 
-describe("The GuSecurityGroup class", () => {
+describe("The GuPublicInternetAccessSecurityGroup class", () => {
   const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
     vpcId: "test",
     availabilityZones: [""],
     publicSubnetIds: [""],
   });
 
-  it("adds the ingresses passed in through props", () => {
+  it("adds global access on 443 by default", () => {
     const stack = simpleGuStackForTesting();
 
     new GuPublicInternetAccessSecurityGroup(stack, "InternetAccessGroup", {

--- a/src/constructs/ec2/vpc.test.ts
+++ b/src/constructs/ec2/vpc.test.ts
@@ -12,7 +12,7 @@ describe("The GuVpc class", () => {
 
       expect(subnet1.subnetId).toBe("subnet1");
       expect(subnet2.subnetId).toBe("subnet2");
-      
+
       // test that no extra subnets are defined
       expect(rest.length).toBe(0);
     });

--- a/src/constructs/ec2/vpc.test.ts
+++ b/src/constructs/ec2/vpc.test.ts
@@ -1,0 +1,43 @@
+import { SynthUtils } from "@aws-cdk/assert";
+import type { SynthedStack } from "../../../test/utils";
+import { simpleGuStackForTesting } from "../../../test/utils";
+import { GuVpc } from "./vpc";
+
+describe("The GuVpc class", () => {
+  describe("subnets method", () => {
+    test("returns an array of subnets with the correct ids", () => {
+      const stack = simpleGuStackForTesting();
+
+      const subnets = GuVpc.subnets(stack, ["subnet1", "subnet2"]);
+
+      expect(subnets[0].subnetId).toBe("subnet1");
+      expect(subnets[1].subnetId).toBe("subnet2");
+    });
+  });
+
+  describe("fromId method", () => {
+    test("returns a vpc with the correct id", () => {
+      const stack = simpleGuStackForTesting();
+
+      const vpc = GuVpc.fromId(stack, "Vpc", { vpcId: "test" });
+
+      expect(vpc.vpcId).toBe("test");
+    });
+  });
+
+  describe("fromIdParameter method", () => {
+    test("adds the vpc parameter", () => {
+      const stack = simpleGuStackForTesting();
+
+      GuVpc.fromIdParameter(stack, "Vpc");
+
+      const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+      expect(json.Parameters.VpcId).toEqual({
+        Default: "/account/vpc/primary/id",
+        Description: "Virtual Private Cloud to run EC2 instances within",
+        Type: "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+      });
+    });
+  });
+});

--- a/src/constructs/ec2/vpc.test.ts
+++ b/src/constructs/ec2/vpc.test.ts
@@ -8,10 +8,13 @@ describe("The GuVpc class", () => {
     test("returns an array of subnets with the correct ids", () => {
       const stack = simpleGuStackForTesting();
 
-      const subnets = GuVpc.subnets(stack, ["subnet1", "subnet2"]);
+      const [subnet1, subnet2, ...rest] = GuVpc.subnets(stack, ["subnet1", "subnet2"]);
 
-      expect(subnets[0].subnetId).toBe("subnet1");
-      expect(subnets[1].subnetId).toBe("subnet2");
+      expect(subnet1.subnetId).toBe("subnet1");
+      expect(subnet2.subnetId).toBe("subnet2");
+      
+      // test that no extra subnets are defined
+      expect(rest.length).toBe(0);
     });
   });
 


### PR DESCRIPTION
## What does this change?

This PR makes some small updates to the tests in `constructs/ec2`

* Add some basic tests of the `GuVpc` class
* Rename the tests for the `GuPublicInternetAccessSecurityGroup` class

## Does this change require changes to existing projects or CDK CLI?

No

## How to test

Run the updates test suite

## How can we measure success?

All constructs have relevant tests
