### PR TITLE
Add subnetsFromParameter method

### DIFF
--- a/docs/005-default-parameter-store-locations.md
+++ b/docs/005-default-parameter-store-locations.md
@@ -2,8 +2,10 @@
 
 A number of constructs from the library define parameters to get configuration from Parameter Store. Each of these parameters configures a default path. The below table lists those paths, the parameter that sets them, the expected value type and which construct the parameter is defined within.
 
-| Path                                  | Parameter              | Type              | Construct                |
-| ------------------------------------- | ---------------------- | ----------------- | ------------------------ |
-| /account/vpc/primary/id               | VpcId                  | AWS::EC2::VPC::Id | GuVpc.fromIdParameter    |
-| /account/services/artifact.bucket     | DistributionBucketName | String            | GuGetDistributablePolicy |
-| /account/services/logging.stream.name | LoggingStreamName      | String            | GuLogShippingPolicy      |
+| Path                                  | Parameter              | Type                         | Construct                  |
+| ------------------------------------- | ---------------------- | ---------------------------- | -------------------------- |
+| /account/vpc/primary/id               | VpcId                  | AWS::EC2::VPC::Id            | GuVpc.fromIdParameter      |
+| /account/vpc/primary/subnets/public   | PublicSubnets          | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
+| /account/vpc/primary/subnets/private  | PrivateSubnets         | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
+| /account/services/artifact.bucket     | DistributionBucketName | String                       | GuGetDistributablePolicy   |
+| /account/services/logging.stream.name | LoggingStreamName      | String                       | GuLogShippingPolicy        |

--- a/src/constructs/ec2/vpc.test.ts
+++ b/src/constructs/ec2/vpc.test.ts
@@ -1,7 +1,7 @@
 import { SynthUtils } from "@aws-cdk/assert";
 import type { SynthedStack } from "../../../test/utils";
 import { simpleGuStackForTesting } from "../../../test/utils";
-import { GuVpc } from "./vpc";
+import { GuVpc, SubnetType } from "./vpc";
 
 describe("The GuVpc class", () => {
   describe("subnets method", () => {
@@ -15,6 +15,36 @@ describe("The GuVpc class", () => {
 
       // test that no extra subnets are defined
       expect(rest.length).toBe(0);
+    });
+  });
+
+  describe("subnetsFromParameter method", () => {
+    test("adds the parameter with default type as private", () => {
+      const stack = simpleGuStackForTesting();
+
+      GuVpc.subnetsfromParameter(stack);
+
+      const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+      expect(json.Parameters.PrivateSubnets).toEqual({
+        Default: "/account/vpc/primary/subnets/private",
+        Description: "A list of private subnets",
+        Type: "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+      });
+    });
+
+    test("adds a public subnets parameter if the type is public", () => {
+      const stack = simpleGuStackForTesting();
+
+      GuVpc.subnetsfromParameter(stack, { type: SubnetType.PUBLIC });
+
+      const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+      expect(json.Parameters.PublicSubnets).toEqual({
+        Default: "/account/vpc/primary/subnets/public",
+        Description: "A list of public subnets",
+        Type: "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+      });
     });
   });
 

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -1,7 +1,7 @@
 import type { ISubnet, IVpc, VpcAttributes } from "@aws-cdk/aws-ec2";
 import { Subnet, Vpc } from "@aws-cdk/aws-ec2";
 import type { GuStack } from "../core";
-import { GuVpcParameter } from "../core";
+import { GuSubnetListParameter, GuVpcParameter } from "../core";
 
 interface VpcFromIdProps extends Omit<VpcAttributes, "availabilityZones"> {
   availabilityZones?: string[];
@@ -9,9 +9,30 @@ interface VpcFromIdProps extends Omit<VpcAttributes, "availabilityZones"> {
 
 type VpcFromIdParameterProps = Omit<VpcFromIdProps, "vpcId">;
 
+export enum SubnetType {
+  PUBLIC = "Public",
+  PRIVATE = "Private",
+}
+
+export interface GuSubnetProps {
+  type?: SubnetType;
+}
+
 export class GuVpc {
   static subnets(scope: GuStack, subnets: string[]): ISubnet[] {
     return subnets.map((subnetId) => Subnet.fromSubnetId(scope, `subnet-${subnetId}`, subnetId));
+  }
+
+  static subnetsfromParameter(scope: GuStack, props?: GuSubnetProps): ISubnet[] {
+    const type = props?.type ?? SubnetType.PRIVATE;
+
+    const subnets = new GuSubnetListParameter(scope, `${type}Subnets`, {
+      description: `A list of ${type.toLowerCase()} subnets`,
+      default: `/account/vpc/primary/subnets/${type.toLowerCase()}`,
+      fromSSM: true,
+    });
+
+    return GuVpc.subnets(scope, subnets.valueAsList);
   }
 
   static fromId(scope: GuStack, id: string, props: VpcFromIdProps): IVpc {


### PR DESCRIPTION
## What does this change?

This PR adds a new `subnetsFromParameters` method to the `GuVpc` class which follows the bring-your-own-parameter pattern. The function takes a props object which contains an optional type to denote whether the subnets are public or private. The parameter is set accordingly.

## Does this change require changes to existing projects or CDK CLI?

No change is required but stacks using the `subnets` method and defining the parameter explicitly can now update.

## How to test

Implement this in place of the `subnets` function in an existing stack.

## How can we measure success?

More constructs bring their own parameters, reducing the amount of code required to define a stack.
