### PR TITLE
Add default health check values for CLB

### DIFF
--- a/src/constructs/loadbalancing/clb.test.ts
+++ b/src/constructs/loadbalancing/clb.test.ts
@@ -78,4 +78,41 @@ describe("The GuClassicLoadBalancer class", () => {
       },
     });
   });
+
+  test("uses default health check properties", () => {
+    const stack = simpleGuStackForTesting();
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
+      vpc,
+    });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancing::LoadBalancer", {
+      HealthCheck: {
+        HealthyThreshold: "2",
+        Interval: "30",
+        Target: "HTTP:9000/healthcheck",
+        Timeout: "10",
+        UnhealthyThreshold: "5",
+      },
+    });
+  });
+
+  test("merges any health check properties provided", () => {
+    const stack = simpleGuStackForTesting();
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
+      vpc,
+      healthCheck: {
+        path: "/test",
+      },
+    });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancing::LoadBalancer", {
+      HealthCheck: {
+        HealthyThreshold: "2",
+        Interval: "30",
+        Target: "HTTP:9000/test",
+        Timeout: "10",
+        UnhealthyThreshold: "5",
+      },
+    });
+  });
 });


### PR DESCRIPTION
## What does this change?

This PR introduces a static `DefaultHealthCheck` object to the `GuClassicLoadBalancer` which is merged with the provided props. This allows either the entire object or individual values to be omitted (see new test cases for examples). 

## Does this change require changes to existing projects or CDK CLI?

No changes are required however stacks that implement the `GuClassicLoadBalancer` can reduce the number of props they pass in. 

## How to test

Upgrade an existing stack and remove an healthCheck values which are the same as the default value. The snapshot tests should still pass, confirming that nothing in the output has changed.

## How can we measure success?

Fewer lines of code are required to define load balancers and best practice around CLB health checks comes for free.
