### PR TITLE
ASG adds instanceType and AMI parameters

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -18,28 +18,45 @@ describe("The GuAutoScalingGroup", () => {
   });
   const defaultProps: GuAutoScalingGroupProps = {
     vpc,
-    imageId: "123",
-    instanceType: "t3.macro", // Use a value that doesn't exist to ensure that we haven't matched a default
     userData: "user data",
   };
 
-  test("correctly sets the machine image using props and calling getImage", () => {
+  test("adds the AMI parameter", () => {
     const stack = simpleGuStackForTesting();
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, osType: 1 });
 
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.AMI).toEqual({
+      Description: "AMI ID",
+      Type: "String",
+    });
+
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
-      ImageId: "123",
+      ImageId: {
+        Ref: "AMI",
+      },
     });
   });
 
-  test("correctly sets instance type using prop", () => {
+  test("adds the instanceType parameter", () => {
     const stack = simpleGuStackForTesting();
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", defaultProps);
 
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.InstanceType).toEqual({
+      Type: "String",
+      Description: "EC2 Instance Type",
+      Default: "t3.small",
+    });
+
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
-      InstanceType: "t3.macro",
+      InstanceType: {
+        Ref: "InstanceType",
+      },
     });
   });
 


### PR DESCRIPTION
## What does this change?

This PR updates the `GuAutoscalingGroup` class to follow the bring-your-own-parameter pattern by adding the `InstanceType` and `AMI` parameters within the constructor.

## Does this change require changes to existing projects or CDK CLI?

Yes. Existing stacks that use the `GuAutoscalingGroup` will be able to remove the manually configured parameters. Where parameter names differ, this will have to be updated.

## How to test

Update an existing stack to use the new `GuAutoscalingGroup` and run the snapshot tests. This should general no or minimal changes.

## How can we measure success?

Less code is required to configure constructs that always require parameters.

