### PR TITLE
Provide sensible defaults for GuLambda memorySize and timeout

### DIFF
--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -84,6 +84,7 @@ Object {
           "S3Key": "folder/to/key",
         },
         "Handler": "handler.ts",
+        "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
             "lambdaServiceRole494E4CA6",

--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -110,6 +110,7 @@ Object {
             },
           },
         ],
+        "Timeout": 30,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -172,4 +172,33 @@ describe("The GuLambdaFunction class", () => {
       MemorySize: 1024,
     });
   });
+
+  it("should use the timeout provided via props when it is defined", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      code: { bucket: "bucket1", key: "folder/to/key" },
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+      timeout: Duration.seconds(60),
+    });
+
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Timeout: 60,
+    });
+  });
+
+  it("should add a sensible default timeout if none is provided", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      code: { bucket: "bucket1", key: "folder/to/key" },
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+    });
+
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Timeout: 30,
+    });
+  });
 });

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -143,4 +143,33 @@ describe("The GuLambdaFunction class", () => {
       },
     });
   });
+
+  it("should use the memorySize provided via props when it is defined", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      code: { bucket: "bucket1", key: "folder/to/key" },
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+      memorySize: 2048,
+    });
+
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      MemorySize: 2048,
+    });
+  });
+
+  it("should add a sensible default memorySize if none is provided", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      code: { bucket: "bucket1", key: "folder/to/key" },
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+    });
+
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      MemorySize: 1024,
+    });
+  });
 });

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -39,11 +39,10 @@ export class GuLambdaFunction extends Function {
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const bucket = Bucket.fromBucketName(scope, `${id}-bucket`, props.code.bucket);
     const code = Code.fromBucket(bucket, props.code.key);
-    const { memorySize, timeout, ...rest } = props;
     super(scope, id, {
-      ...rest,
-      memorySize: defaultMemorySize(props.runtime, memorySize),
-      timeout: props.timeout ? props.timeout : Duration.seconds(30),
+      ...props,
+      memorySize: defaultMemorySize(props.runtime, props.memorySize),
+      timeout: props.timeout ?? Duration.seconds(30),
       code,
     });
 

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -3,8 +3,8 @@ import { LambdaRestApi } from "@aws-cdk/aws-apigateway";
 import type { Schedule } from "@aws-cdk/aws-events";
 import { Rule } from "@aws-cdk/aws-events";
 import { LambdaFunction } from "@aws-cdk/aws-events-targets";
-import { Code, Function } from "@aws-cdk/aws-lambda";
-import type { FunctionProps } from "@aws-cdk/aws-lambda";
+import { Code, Function, RuntimeFamily } from "@aws-cdk/aws-lambda";
+import type { FunctionProps, Runtime } from "@aws-cdk/aws-lambda";
 import { Bucket } from "@aws-cdk/aws-s3";
 import type { GuStack } from "../core";
 
@@ -21,12 +21,27 @@ interface GuFunctionProps extends Omit<FunctionProps, "code"> {
   apis?: ApiProps[];
 }
 
+function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
+  if (memorySize) {
+    return memorySize;
+  } else {
+    switch (runtime.family) {
+      case RuntimeFamily.JAVA:
+        return 1024;
+      default:
+        return 512;
+    }
+  }
+}
+
 export class GuLambdaFunction extends Function {
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const bucket = Bucket.fromBucketName(scope, `${id}-bucket`, props.code.bucket);
     const code = Code.fromBucket(bucket, props.code.key);
+    const { memorySize, ...rest } = props;
     super(scope, id, {
-      ...props,
+      ...rest,
+      memorySize: defaultMemorySize(props.runtime, memorySize),
       code,
     });
 

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -6,6 +6,7 @@ import { LambdaFunction } from "@aws-cdk/aws-events-targets";
 import { Code, Function, RuntimeFamily } from "@aws-cdk/aws-lambda";
 import type { FunctionProps, Runtime } from "@aws-cdk/aws-lambda";
 import { Bucket } from "@aws-cdk/aws-s3";
+import { Duration } from "@aws-cdk/core";
 import type { GuStack } from "../core";
 
 interface ApiProps extends Omit<LambdaRestApiProps, "handler"> {
@@ -38,10 +39,11 @@ export class GuLambdaFunction extends Function {
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const bucket = Bucket.fromBucketName(scope, `${id}-bucket`, props.code.bucket);
     const code = Code.fromBucket(bucket, props.code.key);
-    const { memorySize, ...rest } = props;
+    const { memorySize, timeout, ...rest } = props;
     super(scope, id, {
       ...rest,
       memorySize: defaultMemorySize(props.runtime, memorySize),
+      timeout: props.timeout ? props.timeout : Duration.seconds(30),
       code,
     });
 


### PR DESCRIPTION
## What does this change?

Whilst testing https://github.com/guardian/cdk/pull/186, I noticed that `memorySize` and `timeout` are optional parameters for a `GuLambda`. If these values are omitted, CloudFormation defaults to [128MB](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize) and [3 seconds](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-timeout), respectively.

I don't think that these default values are particularly helpful for many of the Guardian use-cases that I've seen (they are especially unhelpful for Scala lambdas!), so I've tried to suggest something more appropriate.

## Does this change require changes to existing projects or CDK CLI?

There are no required changes, but some projects may automatically increase the memory or timeout values for lambda functions. This change would show up in a snapshot diff though, so people could set these low values again manually if they felt strongly about keeping them.

## How to test

I think this is adequately covered by unit tests added in this PR.

## How can we measure success?

When setting projects up from scratch developers should save time, as they are less likely to encounter timeouts or OOM errors immediately after deploying for the first time.

## Have we considered potential risks?

I suppose there is a small risk that this could incur unnecessary costs (due to the way that [lambda pricing](https://aws.amazon.com/lambda/pricing/) works).

There is also a risk that we will over or under provision lambdas due to my assumptions about what 'sensible' defaults are. An alternative approach would be to make these properties mandatory for a `GuLambda`. This would force developers to make these choices up-front, but at least it would avoid the annoying case where you end up with the super-low CloudFormation defaults!
