### PR TITLE
Fixes 2 warnings from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.23.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "repository": "github:guardian/cdk",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src test --ext .ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc -w",
     "test": "jest --detectOpenHandles --runInBand",
     "test:dev": "jest --detectOpenHandles --runInBand --watch",
-    "prepublish": "tsc",
+    "prepare": "tsc",
     "release": "np minor --no-yarn --branch main",
     "release:docs": "rm -rf target && typedoc && gh-pages -d target -u \"github-actions-bot <support+actions@github.com>\"",
     "serve:docs": "rm -rf target && typedoc && serve target"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Recently ran `./script/setup` and saw a few warnings (see below). This fixes the `prepublish` deprecation warning and the missing repository field warning. There's a third warning about a missing license field, but I'm not sure what license we need.

I vaguely remember us having issues with `prepare` in the past, however I think that when we were installing directly from GitHub rather than NPM, so this should be ok.

<details>
  <summary>Original terminal output</summary>

```console
➜ ./script/setup
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> @guardian/cdk@0.23.0 prepublish /Users/akash_askoolum/code/cdk
> tsc

npm WARN @guardian/cdk@0.23.0 No repository field.
npm WARN @guardian/cdk@0.23.0 No license field.

added 61 packages from 29 contributors, removed 17 packages, updated 26 packages and audited 1159 packages in 12.345s

98 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
</details>

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fewer warnings from NPM.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Prepare might run at a different lifecycle point, however [the docs](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts) suggests `prepublish` is:

> **prepublish** (DEPRECATED)
> Same as `prepare`

🤞🏽 