### PR TITLE
Add default health check values for GuTargetGroup

### DIFF
--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -107,6 +107,43 @@ describe("The GuApplicationTargetGroup class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources)).not.toContain("ApplicationTargetGroup");
   });
+
+  test("uses default health check properties", () => {
+    const stack = simpleGuStackForTesting();
+    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", {
+      vpc,
+    });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckIntervalSeconds: 30,
+      HealthCheckPath: "/healthcheck",
+      HealthCheckPort: "9000",
+      HealthCheckProtocol: "HTTP",
+      HealthCheckTimeoutSeconds: 10,
+      HealthyThresholdCount: 2,
+      UnhealthyThresholdCount: 5,
+    });
+  });
+
+  test("merges any health check properties provided", () => {
+    const stack = simpleGuStackForTesting();
+    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", {
+      vpc,
+      healthCheck: {
+        path: "/test",
+      },
+    });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckIntervalSeconds: 30,
+      HealthCheckPath: "/test",
+      HealthCheckPort: "9000",
+      HealthCheckProtocol: "HTTP",
+      HealthCheckTimeoutSeconds: 10,
+      HealthyThresholdCount: 2,
+      UnhealthyThresholdCount: 5,
+    });
+  });
 });
 
 describe("The GuApplicationListener class", () => {


### PR DESCRIPTION
## What does this change?

Following on from https://github.com/guardian/cdk/pull/184, this PR adds some default values for the `healthCheck` prop on the `GuTargetGroup` construct. For consistency, the default values are the same as defined for the `GuClassicLoadBalancer`. The default values are spread with any passed in so that you can do the following:

```ts
new GuTargetGroup(this, "TargetGroup", {
  ...
  healthCheck: {
    port: "3000"
  }
  ...
})
```

## Does this change require changes to existing projects or CDK CLI?

No changes are required but stacks the use the `GuTargetGroup` can reduce the number of props they have to pass in.

## How to test

Update an existing stack that implements the `GuTargetGroup` and remove any props that match the defaults. Run the snapshot test and confirm that it still passes.

## How can we measure success?

Stacks implementing the `GuTargetGroup` get sensible default health check values for free.

## Have we considered potential risks?

The default values provided may not the optimum.
