### PR TITLE
Add GuHttpsClassicLoadBalancer

### DIFF
--- a/src/constructs/loadbalancing/clb.ts
+++ b/src/constructs/loadbalancing/clb.ts
@@ -1,7 +1,13 @@
-import type { CfnLoadBalancer, HealthCheck, LoadBalancerProps } from "@aws-cdk/aws-elasticloadbalancing";
+import type {
+  CfnLoadBalancer,
+  HealthCheck,
+  LoadBalancerListener,
+  LoadBalancerProps,
+} from "@aws-cdk/aws-elasticloadbalancing";
 import { LoadBalancer, LoadBalancingProtocol } from "@aws-cdk/aws-elasticloadbalancing";
 import { Duration } from "@aws-cdk/core";
 import type { GuStack } from "../core";
+import { GuArnParameter } from "../core";
 
 enum RemoveableProperties {
   SCHEME = "Scheme",
@@ -46,5 +52,36 @@ export class GuClassicLoadBalancer extends LoadBalancer {
 
     mergedProps.propertiesToOverride &&
       Object.entries(mergedProps.propertiesToOverride).forEach(([key, value]) => cfnLb.addPropertyOverride(key, value));
+  }
+}
+
+interface GuHttpsClassicLoadBalancerProps extends Omit<GuClassicLoadBalancerProps, "listeners"> {
+  listener?: Partial<LoadBalancerListener>;
+}
+
+export class GuHttpsClassicLoadBalancer extends GuClassicLoadBalancer {
+  static DefaultListener: LoadBalancerListener = {
+    internalPort: 9000,
+    externalPort: 443,
+    internalProtocol: LoadBalancingProtocol.HTTP,
+    externalProtocol: LoadBalancingProtocol.HTTPS,
+  };
+
+  constructor(scope: GuStack, id: string, props: GuHttpsClassicLoadBalancerProps) {
+    const listenerProps = { ...GuHttpsClassicLoadBalancer.DefaultListener, ...props.listener };
+
+    if (!listenerProps.sslCertificateId) {
+      const certificateId = new GuArnParameter(scope, "CertificateARN", {
+        description: "Certificate ARN for ELB",
+      });
+      listenerProps.sslCertificateId = certificateId.valueAsString;
+    }
+
+    const mergedProps = {
+      ...props,
+      listeners: [listenerProps],
+    };
+
+    super(scope, id, mergedProps);
   }
 }


### PR DESCRIPTION
## What does this change?

This PR adds a new `GuHttpsClassicLoadBalancer` construct which sets defaults for the load balancer listener. It restricts the number of listeners to one with the following defaults:

```ts
InstancePort: "9000",
InstanceProtocol: "http",
LoadBalancerPort: "443",
Protocol: "https",
```

If a value for the `sslCertificateId` prop is not provided, it also creates a new parameter and sets the output of that as the prop value.

## Does this change require changes to existing projects or CDK CLI?

No changes are required but stacks which implement the `GuClassLoadBalancer` and have an HTTPS listener can reduce the number of props they provide.

## How to test

Migrate an existing stack to use the `GuHttpsClassLoadBalancer` and run the snapshot test to confirm that nothing has changed.

## How can we measure success?

Stacks can define fewer props to get a standard load balancer which listens for HTTPS traffic
