### PR TITLE
Update AMI parameter

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -30,7 +30,7 @@ describe("The GuAutoScalingGroup", () => {
 
     expect(json.Parameters.AMI).toEqual({
       Description: "AMI ID",
-      Type: "String",
+      Type: "AWS::EC2::Image::Id",
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -4,7 +4,7 @@ import type { ISecurityGroup, MachineImage, MachineImageConfig } from "@aws-cdk/
 import { InstanceType, OperatingSystemType, UserData } from "@aws-cdk/aws-ec2";
 import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
 import type { GuStack } from "../core";
-import { GuInstanceTypeParameter, GuStringParameter } from "../core";
+import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 
 // Since we want to override the types of what gets passed in for the below props,
 // we need to use Omit<T, U> to remove them from the interface this extends
@@ -21,7 +21,7 @@ export interface GuAutoScalingGroupProps
 
 export class GuAutoScalingGroup extends AutoScalingGroup {
   constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {
-    const imageId = new GuStringParameter(scope, "AMI", {
+    const imageId = new GuAmiParameter(scope, "AMI", {
       description: "AMI ID",
     });
 


### PR DESCRIPTION
## What does this change?

This PR updates the type of the parameter created auto-magically in the `GuAutoscalaingGroup` to be a `GuAMIParameter`. Using this parameter changes the `Type` value to `AWS::EC2::Image::Id` which will restrict the values that can be input, offering better validation.

## Does this change require changes to existing projects or CDK CLI?

This change will update the parameter anywhere it is currently used which will be seen at deploy time. Given that an invalid value would have caused the deploy to fail, this shouldn't have any effect.

## How to test

See the updated unit test and verify that it passes.

## How can we measure success?

Better validation of parameter values.