### PR TITLE
update GuRole import in instance role

### DIFF
--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -8,7 +8,7 @@ import {
   GuParameterStoreReadPolicy,
   GuSSMRunCommandPolicy,
 } from "../policies";
-import { GuRole } from "../roles";
+import { GuRole } from "./roles";
 
 interface GuInstanceRoleProps {
   withoutLogShipping?: boolean; // optional to have log shipping added by default, you have to opt out


### PR DESCRIPTION
## What does this change?

This PR updates the import of `GuRole` in the `instance-role.ts` file to import directly from the `roles.ts` file rather than the `index.ts` in the `roles` directory as this was causing an error when importing anything from `@guardian/cdk/lib/constructs/iam`. 

## Does this change require changes to existing projects or CDK CLI?

Any projects importing `GuInstanceRole` or `GuRole` from their specific file will now be able to get them from the `@guardian/cdk/lib/constructs/iam` path.

## How to test

Bump to the latest version and try importing the `GuInstanceRole` construct from `@guardian/cdk/lib/constructs/iam`

## How can we measure success?

All imports work as expected.
