### PR TITLE
Allow imageId and instanceType to be passed into ASG

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -1,6 +1,6 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import { Vpc } from "@aws-cdk/aws-ec2";
+import { InstanceType, Vpc } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
@@ -40,7 +40,7 @@ describe("The GuAutoScalingGroup", () => {
     });
   });
 
-  test("adds the instanceType parameter", () => {
+  test("adds the instanceType parameter if none provided", () => {
     const stack = simpleGuStackForTesting();
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", defaultProps);
@@ -57,6 +57,20 @@ describe("The GuAutoScalingGroup", () => {
       InstanceType: {
         Ref: "InstanceType",
       },
+    });
+  });
+
+  test("does not create the instanceType parameter if value is provided", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, instanceType: new InstanceType("t3.small") });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(Object.keys(json.Parameters)).not.toContain(InstanceType);
+
+    expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
+      InstanceType: "t3.small",
     });
   });
 

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -21,7 +21,7 @@ describe("The GuAutoScalingGroup", () => {
     userData: "user data",
   };
 
-  test("adds the AMI parameter", () => {
+  test("adds the AMI parameter if no imageId prop provided", () => {
     const stack = simpleGuStackForTesting();
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, osType: 1 });
@@ -37,6 +37,20 @@ describe("The GuAutoScalingGroup", () => {
       ImageId: {
         Ref: "AMI",
       },
+    });
+  });
+
+  test("does not add the AMI parameter if an imageId prop provided", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, osType: 1, imageId: "123" });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(Object.keys(json.Parameters)).not.toContain("AMI");
+
+    expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
+      ImageId: "123",
     });
   });
 

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -12,7 +12,7 @@ import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 export interface GuAutoScalingGroupProps
   extends Omit<AutoScalingGroupProps, "imageId" | "osType" | "machineImage" | "instanceType" | "userData"> {
   instanceType?: InstanceType;
-  imageId?: string;
+  imageId?: GuAmiParameter;
   osType?: OperatingSystemType;
   machineImage?: MachineImage;
   userData: string;
@@ -31,7 +31,7 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
         osType: props.osType ?? OperatingSystemType.LINUX,
         userData: UserData.custom(props.userData),
         imageId:
-          props.imageId ??
+          props.imageId?.valueAsString ??
           new GuAmiParameter(scope, "AMI", {
             description: "AMI ID",
           }).valueAsString,

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -11,6 +11,7 @@ import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 // https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys
 export interface GuAutoScalingGroupProps
   extends Omit<AutoScalingGroupProps, "imageId" | "osType" | "machineImage" | "instanceType" | "userData"> {
+  instanceType?: InstanceType;
   osType?: OperatingSystemType;
   machineImage?: MachineImage;
   userData: string;
@@ -24,8 +25,6 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
     const imageId = new GuAmiParameter(scope, "AMI", {
       description: "AMI ID",
     });
-
-    const instanceType = new GuInstanceTypeParameter(scope);
 
     // We need to override getImage() so that we can pass in the AMI as a parameter
     // Otherwise, MachineImage.lookup({ name: 'some str' }) would work as long
@@ -41,7 +40,7 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
     const mergedProps = {
       ...props,
       machineImage: { getImage: getImage },
-      instanceType: new InstanceType(instanceType.valueAsString),
+      instanceType: props.instanceType ?? new InstanceType(new GuInstanceTypeParameter(scope).valueAsString),
       userData: UserData.custom(props.userData),
     };
 

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -12,6 +12,7 @@ import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 export interface GuAutoScalingGroupProps
   extends Omit<AutoScalingGroupProps, "imageId" | "osType" | "machineImage" | "instanceType" | "userData"> {
   instanceType?: InstanceType;
+  imageId?: string;
   osType?: OperatingSystemType;
   machineImage?: MachineImage;
   userData: string;
@@ -22,10 +23,6 @@ export interface GuAutoScalingGroupProps
 
 export class GuAutoScalingGroup extends AutoScalingGroup {
   constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {
-    const imageId = new GuAmiParameter(scope, "AMI", {
-      description: "AMI ID",
-    });
-
     // We need to override getImage() so that we can pass in the AMI as a parameter
     // Otherwise, MachineImage.lookup({ name: 'some str' }) would work as long
     // as the name is hard-coded
@@ -33,7 +30,11 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
       return {
         osType: props.osType ?? OperatingSystemType.LINUX,
         userData: UserData.custom(props.userData),
-        imageId: imageId.valueAsString,
+        imageId:
+          props.imageId ??
+          new GuAmiParameter(scope, "AMI", {
+            description: "AMI ID",
+          }).valueAsString,
       };
     }
 


### PR DESCRIPTION
## What does this change?

Currently the `GuAutoscalingGroup` creates parameters for the `imageId` (`AMI`) and `instanceType` values and omits the props. This PR adds the props back in as optional and only creates the parameters if no value is passed. This maintains the BYO pattern as the default behaviour but allows flexibility where required.

## Does this change require changes to existing projects or CDK CLI?

No

## How to test

New unit tests have been written to cover the change in behaviour.

## How can we measure success?

The default behaviour of our constructs makes them easy to use but also allows for flexibility.