### PR TITLE
feat: Add `X-Gu-CDK-Version` tag to GuStack

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
+  setupFilesAfterEnv: ["./jest.setup.js"],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+jest.mock("./src/constants/library-info");

--- a/src/constants/__mocks__/library-info.ts
+++ b/src/constants/__mocks__/library-info.ts
@@ -1,0 +1,8 @@
+export const LibraryInfo = {
+  VERSION: "TEST",
+};
+
+export const TrackingTag = {
+  Key: "X-Gu-CDK-Version",
+  Value: LibraryInfo.VERSION,
+};

--- a/src/constants/library-info.ts
+++ b/src/constants/library-info.ts
@@ -1,0 +1,10 @@
+import { version } from "../../package.json";
+
+export const LibraryInfo = {
+  VERSION: version,
+};
+
+export const TrackingTag = {
+  Key: "X-Gu-CDK-Version",
+  Value: LibraryInfo.VERSION,
+};

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -55,6 +55,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
         "Timeout": 30,
       },
@@ -104,6 +108,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -57,7 +57,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
         "Timeout": 30,
@@ -111,7 +111,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -3,9 +3,10 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
 import { App } from "@aws-cdk/core";
-import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
-import type { SynthedStack } from "../../../test/utils/synthed-stack";
+import { simpleGuStackForTesting } from "../../../test/utils";
+import type { SynthedStack } from "../../../test/utils";
 import { Stage, Stages } from "../../constants";
+import { TrackingTag } from "../../constants/library-info";
 import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
@@ -54,6 +55,7 @@ describe("The GuStack construct", () => {
             Ref: "Stage",
           },
         },
+        TrackingTag,
       ],
     });
   });

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,5 +1,6 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
+import { TrackingTag } from "../../constants/library-info";
 import { GuStackParameter, GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
@@ -41,6 +42,8 @@ export class GuStack extends Stack {
     this._stage = new GuStageParameter(this);
     this._stack = new GuStackParameter(this);
     this._app = props.app;
+
+    this.addTag(TrackingTag.Key, TrackingTag.Value);
 
     this.addTag("Stack", this.stack);
     this.addTag("Stage", this.stage);

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -10,6 +10,33 @@ export interface GuStackProps extends StackProps {
   migratedFromCloudFormation?: boolean;
 }
 
+/**
+ * GuStack provides the `stack` and `stage` parameters to a template.
+ * It also takes the `app` in the constructor.
+ *
+ * GuStack will add the Stack, Stage and App tags to all resources.
+ *
+ * GuStack also adds the tag `X-Gu-CDK-Version`.
+ * This tag allows us to measure adoption of this library.
+ * It's value is the version of guardian/cdk being used, as defined in `package.json`.
+ * As a result, the change sets between version numbers will be fairly noisy,
+ * as all resources receive a tag update.
+ * It is recommended to upgrade the version of @guardian/cdk being used in two steps:
+ *   1. Bump the library, apply the tag updates
+ *   2. Make any other stack changes
+ *
+ * Typical usage is to extend GuStack:
+ *
+ * ```typescript
+ * class MyStack extends GuStack {
+ *   constructor(scope: App, id: string, props: GuStackProps) {
+ *     super(scope, id, props)
+ *   }
+ *
+ *   // add resources here
+ * }
+ * ```
+ */
 export class GuStack extends Stack {
   private readonly _stage: GuStageParameter;
   private readonly _stack: GuStackParameter;
@@ -29,6 +56,13 @@ export class GuStack extends Stack {
 
   migratedFromCloudFormation: boolean;
 
+  /**
+   * A helper function to add a tag to all resources in a stack.
+   * @param key the tag name
+   * @param value the value of the tag
+   * @param applyToLaunchedInstances whether or not to apply the tag to instances launched in an ASG.
+   * @protected
+   */
   protected addTag(key: string, value: string, applyToLaunchedInstances: boolean = true): void {
     Tags.of(this).add(key, value, { applyToLaunchedInstances });
   }

--- a/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
@@ -104,6 +104,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::IAM::Role",

--- a/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
@@ -106,7 +106,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -145,6 +145,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::IAM::Role",
@@ -404,6 +408,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::IAM::Role",
@@ -615,6 +623,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -147,7 +147,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -410,7 +410,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -626,7 +626,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },

--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -111,7 +111,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
         "Timeout": 30,
@@ -165,7 +165,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -244,7 +244,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -432,13 +432,13 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB937324608a148e4c74ee74e20f580623b2d9": Object {
+    "lambdaapi2Deployment4ECB937340ba28821c4d87686bb600192997b7b2": Object {
       "DependsOn": Array [
         "lambdaapi2proxyANY3F8E1D36",
         "lambdaapi2proxyE68FDFBC",
@@ -455,7 +455,7 @@ Object {
     "lambdaapi2DeploymentStageprodCC9E3016": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB937324608a148e4c74ee74e20f580623b2d9",
+          "Ref": "lambdaapi2Deployment4ECB937340ba28821c4d87686bb600192997b7b2",
         },
         "RestApiId": Object {
           "Ref": "lambdaapi239350ECC",
@@ -480,7 +480,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -777,7 +777,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -830,13 +830,13 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B585b22be554088fbcc2c63fc037a54e995d": Object {
+    "lambdaapiDeployment8E95B58515e203156872c143be11756a3c89fbba": Object {
       "DependsOn": Array [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -853,7 +853,7 @@ Object {
     "lambdaapiDeploymentStageprod9598BC2F": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B585b22be554088fbcc2c63fc037a54e995d",
+          "Ref": "lambdaapiDeployment8E95B58515e203156872c143be11756a3c89fbba",
         },
         "RestApiId": Object {
           "Ref": "lambdaapiC1812993",
@@ -878,7 +878,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },

--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -109,6 +109,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
         "Timeout": 30,
       },
@@ -158,6 +162,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },
@@ -233,6 +241,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },
@@ -418,11 +430,15 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB93738ba48d7cb88b4c2b9ec5c442ee1c99e9": Object {
+    "lambdaapi2Deployment4ECB937324608a148e4c74ee74e20f580623b2d9": Object {
       "DependsOn": Array [
         "lambdaapi2proxyANY3F8E1D36",
         "lambdaapi2proxyE68FDFBC",
@@ -439,7 +455,7 @@ Object {
     "lambdaapi2DeploymentStageprodCC9E3016": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB93738ba48d7cb88b4c2b9ec5c442ee1c99e9",
+          "Ref": "lambdaapi2Deployment4ECB937324608a148e4c74ee74e20f580623b2d9",
         },
         "RestApiId": Object {
           "Ref": "lambdaapi239350ECC",
@@ -461,6 +477,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },
@@ -755,6 +775,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::ApiGateway::RestApi",
@@ -804,11 +828,15 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B5854e05b687211f19a449136200fabf5846": Object {
+    "lambdaapiDeployment8E95B585b22be554088fbcc2c63fc037a54e995d": Object {
       "DependsOn": Array [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -825,7 +853,7 @@ Object {
     "lambdaapiDeploymentStageprod9598BC2F": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B5854e05b687211f19a449136200fabf5846",
+          "Ref": "lambdaapiDeployment8E95B585b22be554088fbcc2c63fc037a54e995d",
         },
         "RestApiId": Object {
           "Ref": "lambdaapiC1812993",
@@ -847,6 +875,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -3,8 +3,9 @@ import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import { Vpc } from "@aws-cdk/aws-ec2";
 import { DatabaseInstanceEngine, ParameterGroup, PostgresEngineVersion } from "@aws-cdk/aws-rds";
 import { Stack } from "@aws-cdk/core";
-import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
-import type { SynthedStack } from "../../../test/utils/synthed-stack";
+import { simpleGuStackForTesting } from "../../../test/utils";
+import type { SynthedStack } from "../../../test/utils";
+import { TrackingTag } from "../../constants/library-info";
 import { GuDatabaseInstance } from "./instance";
 
 describe("The GuDatabaseInstance class", () => {
@@ -100,6 +101,7 @@ describe("The GuDatabaseInstance class", () => {
             Ref: "Stage",
           },
         },
+        TrackingTag,
       ],
     });
   });

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -56,6 +56,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
         "Timeout": 30,
       },
@@ -155,6 +159,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -58,7 +58,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
         "Timeout": 30,
@@ -162,7 +162,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -48,6 +48,10 @@ Object {
               "Ref": "Stage",
             },
           },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
+          },
         ],
       },
       "Type": "AWS::SNS::Topic",
@@ -88,6 +92,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
         "Timeout": 30,
@@ -204,6 +212,10 @@ Object {
             "Value": Object {
               "Ref": "Stage",
             },
+          },
+          Object {
+            "Key": "X-Gu-CDK-Version",
+            "Value": "0.31.0",
           },
         ],
       },

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -50,7 +50,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },
@@ -95,7 +95,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
         "Timeout": 30,
@@ -215,7 +215,7 @@ Object {
           },
           Object {
             "Key": "X-Gu-CDK-Version",
-            "Value": "0.31.0",
+            "Value": "TEST",
           },
         ],
       },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "typeRoots": ["./node_modules/@types"],
-    "outDir": "lib"
+    "outDir": "lib",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "src/**/*.test.ts", "src/**/__snapshots__/**"]


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds `X-Gu-CDK-Version` tag to `GuStack`. We can use this to track which stacks have been created using the library, and with which version. Adding the tag to `GuStack` means it'll get applied to all resources.

The absence of this tag suggests the stack hasn't been created with the cdk library. Using the version number allows us to track how up to date stacks are too.

We mock the library version in tests to remove having to update snapshots whenever we publish a new version of the library, which, among other things, would make automated publishing difficult! The mock is applied globally for simplicity.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes! The change is small though, it should be a matter of bumping the version of this library being used.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe existing tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We know what version of this library was used to create a stack, if any.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

~The version number is retrieved from the `package.json`. Does this resolve the the correct value once published? That is, if we use the library in a project, is the version number that of guardian/cdk or of the consuming project?~ Update: this is fine. The import path is relative so will always resolve to this package's `package.json` file.

