### PR TITLE
fix: package layout and content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -919,7 +919,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -1093,8 +1092,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-      "dev": true
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
     },
     "@babel/helpers": {
       "version": "7.12.5",
@@ -1111,7 +1109,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
       "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
@@ -1122,7 +1119,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -1131,7 +1127,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1142,7 +1137,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -1150,20 +1144,17 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -1961,8 +1952,7 @@
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-      "dev": true
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -3785,7 +3775,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -3829,8 +3818,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.3",
@@ -4058,6 +4046,36 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
         }
       }
     },
@@ -4728,8 +4746,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -5058,7 +5075,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5159,8 +5175,7 @@
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -5667,8 +5682,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -5694,7 +5708,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
       "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -6637,8 +6650,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -6705,8 +6717,7 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
@@ -6889,8 +6900,7 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-      "dev": true
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "listr": {
       "version": "0.14.3",
@@ -7135,6 +7145,17 @@
         "parse-json": "^2.2.0",
         "pify": "^2.0.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        }
       }
     },
     "locate-path": {
@@ -7906,7 +7927,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -7917,8 +7937,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -8982,12 +9001,14 @@
       "dev": true
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "requires": {
-        "error-ex": "^1.2.0"
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "parse5": {
@@ -9029,8 +9050,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "2.2.1",
@@ -9331,35 +9351,76 @@
       }
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
         }
       }
     },
     "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        }
       }
     },
     "readable-stream": {
@@ -9565,7 +9626,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
       "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
@@ -10504,7 +10564,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -10513,14 +10572,12 @@
     "spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -10529,8 +10586,7 @@
     "spdx-license-ids": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
-      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
-      "dev": true
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
     },
     "split": {
       "version": "1.0.1",
@@ -11062,8 +11118,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -11327,7 +11382,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   },
   "dependencies": {
     "@aws-cdk/assert": "1.86.0",
+    "@aws-cdk/aws-apigateway": "1.86.0",
     "@aws-cdk/aws-autoscaling": "1.86.0",
     "@aws-cdk/aws-cloudwatch-actions": "1.86.0",
     "@aws-cdk/aws-ec2": "1.86.0",
-    "@aws-cdk/aws-apigateway": "1.86.0",
     "@aws-cdk/aws-elasticloadbalancing": "1.86.0",
     "@aws-cdk/aws-elasticloadbalancingv2": "1.86.0",
     "@aws-cdk/aws-events-targets": "1.86.0",
@@ -53,6 +53,7 @@
     "@aws-cdk/aws-lambda-event-sources": "1.86.0",
     "@aws-cdk/aws-rds": "1.86.0",
     "@aws-cdk/aws-s3": "1.86.0",
-    "@aws-cdk/core": "1.86.0"
+    "@aws-cdk/core": "1.86.0",
+    "read-pkg-up": "^7.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.32.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
   "repository": "github:guardian/cdk",
   "scripts": {
     "build": "tsc",

--- a/src/constants/library-info.ts
+++ b/src/constants/library-info.ts
@@ -1,4 +1,6 @@
-import { version } from "../../package.json";
+import readPkgUp from "read-pkg-up";
+
+const version = readPkgUp.sync({ cwd: __dirname })?.packageJson.version ?? "unknown";
 
 export const LibraryInfo = {
   VERSION: version,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "experimentalDecorators": true,
     "typeRoots": ["./node_modules/@types"],
     "outDir": "lib",
-    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "src/**/*.test.ts", "src/**/__snapshots__/**"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "outDir": "lib",
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "test", "src/**/*.test.ts", "src/**/__snapshots__/**"]
+  "exclude": ["node_modules", "test", "src/**/*.test.ts", "src/**/__snapshots__/**", "src/**/__mocks__/**"]
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Previously (in #223 and [v0.32.0 of this library](https://github.com/guardian/cdk/releases/tag/v0.32.0)) we read the version number from `package.json` by reading from a specific file path. To do this we had to set `resolveJsonModule` to `true`.

This resulted in `lib` ([the output directory for TypeScript](https://github.com/guardian/cdk/blob/6c19e431055d3348b107e69a28a5476e4a319d3e/tsconfig.json#L17) and [entry point of the library](https://github.com/guardian/cdk/blob/6c19e431055d3348b107e69a28a5476e4a319d3e/package.json#L4)) going from:

```console
lib
 |_index.js
 |_package.json
```

to:

```console
lib
 |_src
 | |_index.js
 | |_package.json
 |_package.json
```

Note the extra `src` subdirectory. This impacts import statements. From:

```typescript
import { GuAutoScalingGroup } from "@guardian/cdk/lib/constructs/autoscaling";
```

to:

```typescript
import { GuAutoScalingGroup } from "@guardian/cdk/lib/src/constructs/autoscaling";
```

😷 

Using [read-pkg-up](https://www.npmjs.com/package/read-pkg-up) means we do not need to set `resolveJsonModule` and can keep the old `lib` structure and sane import paths.

The [tests on read-pkg-up](https://github.com/sindresorhus/read-pkg-up/blob/021b1ec5c8db94670f18603b67ddcae5e560ba3a/test.js#L16-L22) look sane, and setting `cwd` to `__dirname` should be safe. As in it should always resolve to this library's `package.json` when installed in other projects.

During this investigation, I noticed the contents of the tarball we publish is essentially the entire contents of the repository minus `node_modules`. That is it includes config files for TS, Jest, ESLint etc.

Set `paths` in `package.json` to only include `lib` in the tarball. Furthermore, remove `__mock__` directories, as we do `__snapshots__`.

This results in the tarball including only 90 files vs the current 307. This can be demonstrated by running [`npm pack`](https://docs.npmjs.com/cli/v6/commands/npm-pack).

<details>
<summary>npm pack before (on main)</summary>

```console
➜ npm pack

> @guardian/cdk@0.32.0 prepare /Users/akash_askoolum/code/cdk
> tsc

npm notice
npm notice 📦  @guardian/cdk@0.32.0
npm notice === Tarball Contents ===
npm notice 166B   .editorconfig
npm notice 51B    .eslintignore
npm notice 7B     .nvmrc
npm notice 24B    .prettierrc
npm notice 353B   script/build
npm notice 825B   script/check-aws-cdk
npm notice 418B   script/check-yarn-lock
npm notice 33B    CODEOWNERS
npm notice 48B    script/docs
npm notice 271B   script/lint
npm notice 255B   script/release
npm notice 279B   script/release-docs
npm notice 41B    script/setup
npm notice 46B    script/start
npm notice 480B   script/test
npm notice 133B   script/update-aws-cdk
npm notice 602B   cdk.iml
npm notice 528B   .eslintrc.js
npm notice 2.6kB  lib/constructs/cloudwatch/alarm.js
npm notice 2.6kB  lib/src/constructs/cloudwatch/alarm.js
npm notice 7.6kB  lib/constructs/autoscaling/asg.js
npm notice 7.6kB  lib/src/constructs/autoscaling/asg.js
npm notice 2.3kB  lib/constructs/iam/policies/assume-role.js
npm notice 2.4kB  lib/src/constructs/iam/policies/assume-role.js
npm notice 4.6kB  lib/constructs/iam/policies/base-policy.js
npm notice 4.6kB  lib/src/constructs/iam/policies/base-policy.js
npm notice 9.1kB  lib/constructs/loadbalancing/clb.js
npm notice 9.1kB  lib/src/constructs/loadbalancing/clb.js
npm notice 3.3kB  lib/constructs/iam/policies/describe-ec2.js
npm notice 3.3kB  lib/src/constructs/iam/policies/describe-ec2.js
npm notice 4.1kB  lib/constructs/iam/policies/dynamodb.js
npm notice 4.1kB  lib/src/constructs/iam/policies/dynamodb.js
npm notice 10.5kB lib/constructs/loadbalancing/elb.js
npm notice 10.5kB lib/src/constructs/loadbalancing/elb.js
npm notice 443B   lib/constructs/core/identity.js
npm notice 447B   lib/src/constructs/core/identity.js
npm notice 103B   eslint/index.js
npm notice 1.0kB  lib/constants/index.js
npm notice 952B   lib/constructs/autoscaling/index.js
npm notice 1.2kB  lib/constructs/cloudwatch/index.js
npm notice 1.1kB  lib/constructs/core/index.js
npm notice 1.1kB  lib/constructs/ec2/index.js
npm notice 1.0kB  lib/constructs/iam/index.js
npm notice 1.9kB  lib/constructs/iam/policies/index.js
npm notice 1.1kB  lib/constructs/iam/roles/index.js
npm notice 951B   lib/constructs/lambda/index.js
npm notice 1.0kB  lib/constructs/loadbalancing/index.js
npm notice 953B   lib/constructs/rds/index.js
npm notice 925B   lib/index.js
npm notice 1.1kB  lib/patterns/index.js
npm notice 1.1kB  lib/src/constants/index.js
npm notice 956B   lib/src/constructs/autoscaling/index.js
npm notice 1.2kB  lib/src/constructs/cloudwatch/index.js
npm notice 1.1kB  lib/src/constructs/core/index.js
npm notice 1.1kB  lib/src/constructs/ec2/index.js
npm notice 1.1kB  lib/src/constructs/iam/index.js
npm notice 1.9kB  lib/src/constructs/iam/policies/index.js
npm notice 1.1kB  lib/src/constructs/iam/roles/index.js
npm notice 955B   lib/src/constructs/lambda/index.js
npm notice 1.0kB  lib/src/constructs/loadbalancing/index.js
npm notice 957B   lib/src/constructs/rds/index.js
npm notice 929B   lib/src/index.js
npm notice 1.1kB  lib/src/patterns/index.js
npm notice 1.5kB  lib/src/utils/index.js
npm notice 1.5kB  lib/utils/index.js
npm notice 4.0kB  lib/constructs/iam/roles/instance-role.js
npm notice 4.0kB  lib/src/constructs/iam/roles/instance-role.js
npm notice 5.1kB  lib/constructs/rds/instance.js
npm notice 5.1kB  lib/src/constructs/rds/instance.js
npm notice 146B   jest.config.js
npm notice 43B    jest.setup.js
npm notice 5.2kB  lib/constructs/cloudwatch/lambda-alarms.js
npm notice 5.2kB  lib/src/constructs/cloudwatch/lambda-alarms.js
npm notice 8.1kB  lib/constructs/lambda/lambda.js
npm notice 8.1kB  lib/src/constructs/lambda/lambda.js
npm notice 1.6kB  lib/constants/library-info.js
npm notice 939B   lib/src/constants/__mocks__/library-info.js
npm notice 1.1kB  lib/src/constants/library-info.js
npm notice 3.5kB  lib/constructs/iam/policies/log-shipping.js
npm notice 3.5kB  lib/src/constructs/iam/policies/log-shipping.js
npm notice 431B   lib/constructs/cloudwatch/no-monitoring.js
npm notice 435B   lib/src/constructs/cloudwatch/no-monitoring.js
npm notice 3.4kB  lib/constructs/iam/policies/parameter-store-read.js
npm notice 3.4kB  lib/src/constructs/iam/policies/parameter-store-read.js
npm notice 11.8kB lib/constructs/core/parameters.js
npm notice 11.8kB lib/src/constructs/core/parameters.js
npm notice 1.6kB  lib/constants/regex-pattern.js
npm notice 1.6kB  lib/src/constants/regex-pattern.js
npm notice 2.0kB  lib/constructs/iam/roles/roles.js
npm notice 2.0kB  lib/src/constructs/iam/roles/roles.js
npm notice 3.7kB  lib/constructs/iam/policies/s3-get-object.js
npm notice 3.7kB  lib/src/constructs/iam/policies/s3-get-object.js
npm notice 2.8kB  lib/patterns/scheduled-lambda.js
npm notice 2.8kB  lib/src/patterns/scheduled-lambda.js
npm notice 7.4kB  lib/constructs/ec2/security-groups.js
npm notice 7.4kB  lib/src/constructs/ec2/security-groups.js
npm notice 3.0kB  lib/constructs/iam/policies/ses.js
npm notice 3.0kB  lib/src/constructs/iam/policies/ses.js
npm notice 9.1kB  lib/patterns/sns-lambda.js
npm notice 9.1kB  lib/src/patterns/sns-lambda.js
npm notice 1.7kB  lib/constructs/sns/sns-topic.js
npm notice 1.7kB  lib/src/constructs/sns/sns-topic.js
npm notice 4.4kB  lib/constructs/iam/policies/ssm.js
npm notice 4.4kB  lib/src/constructs/iam/policies/ssm.js
npm notice 8.0kB  lib/constructs/core/stack.js
npm notice 8.0kB  lib/src/constructs/core/stack.js
npm notice 1.2kB  lib/constants/stage.js
npm notice 1.2kB  lib/src/constants/stage.js
npm notice 547B   typedoc.js
npm notice 4.7kB  eslint/rules/valid-constructors.js
npm notice 7.9kB  lib/constructs/ec2/vpc.js
npm notice 7.9kB  lib/src/constructs/ec2/vpc.js
npm notice 87B    eslint/package.json
npm notice 2.3kB  lib/package.json
npm notice 2.1kB  package.json
npm notice 159B   .vscode/settings.json
npm notice 126B   tsconfig.eslint.json
npm notice 618B   tsconfig.json
npm notice 479B   docs/architecture-decision-records/000-template.md
npm notice 3.0kB  docs/architecture-decision-records/001-constructs-and-patterns.md
npm notice 2.4kB  docs/001-general-usage.md
npm notice 3.8kB  docs/architecture-decision-records/002-component-constuctors.md
npm notice 1.4kB  docs/002-starting-a-new-project.md
npm notice 4.9kB  docs/003-migrating-existing-stacks.md
npm notice 2.7kB  docs/architecture-decision-records/003-package-manager.md
npm notice 3.1kB  docs/architecture-decision-records/004-testing.md
npm notice 1.1kB  docs/004-tips-tricks-and-gotchas.md
npm notice 1.2kB  docs/005-default-parameter-store-locations.md
npm notice 2.9kB  docs/architecture-decision-records/005-package-structure.md
npm notice 1.3kB  .github/PULL_REQUEST_TEMPLATE.md
npm notice 339B   eslint/README.md
npm notice 4.9kB  README.md
npm notice 20.1kB src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
npm notice 7.3kB  src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
npm notice 26.6kB src/constructs/lambda/__snapshots__/lambda.test.ts.snap
npm notice 5.6kB  src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
npm notice 3.1kB  src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
npm notice 6.3kB  src/patterns/__snapshots__/sns-lambda.test.ts.snap
npm notice 51.3kB guardian-cdk-0.32.0.tgz
npm notice 340B   lib/constructs/cloudwatch/alarm.d.ts
npm notice 340B   lib/src/constructs/cloudwatch/alarm.d.ts
npm notice 2.1kB  src/constructs/cloudwatch/alarm.test.ts
npm notice 767B   src/constructs/cloudwatch/alarm.ts
npm notice 992B   lib/constructs/autoscaling/asg.d.ts
npm notice 992B   lib/src/constructs/autoscaling/asg.d.ts
npm notice 6.0kB  src/constructs/autoscaling/asg.test.ts
npm notice 2.7kB  src/constructs/autoscaling/asg.ts
npm notice 391B   lib/constructs/iam/policies/assume-role.d.ts
npm notice 391B   lib/src/constructs/iam/policies/assume-role.d.ts
npm notice 1.3kB  src/constructs/iam/policies/assume-role.test.ts
npm notice 673B   src/constructs/iam/policies/assume-role.ts
npm notice 450B   test/utils/attach-policy-to-test-role.ts
npm notice 874B   lib/constructs/iam/policies/base-policy.d.ts
npm notice 874B   lib/src/constructs/iam/policies/base-policy.d.ts
npm notice 1.4kB  src/constructs/iam/policies/base-policy.ts
npm notice 1.4kB  lib/constructs/loadbalancing/clb.d.ts
npm notice 1.4kB  lib/src/constructs/loadbalancing/clb.d.ts
npm notice 6.8kB  src/constructs/loadbalancing/clb.test.ts
npm notice 2.7kB  src/constructs/loadbalancing/clb.ts
npm notice 304B   lib/constructs/iam/policies/describe-ec2.d.ts
npm notice 304B   lib/src/constructs/iam/policies/describe-ec2.d.ts
npm notice 974B   src/constructs/iam/policies/describe-ec2.test.ts
npm notice 935B   src/constructs/iam/policies/describe-ec2.ts
npm notice 806B   lib/constructs/iam/policies/dynamodb.d.ts
npm notice 806B   lib/src/constructs/iam/policies/dynamodb.d.ts
npm notice 2.4kB  src/constructs/iam/policies/dynamodb.test.ts
npm notice 1.2kB  src/constructs/iam/policies/dynamodb.ts
npm notice 1.8kB  lib/constructs/loadbalancing/elb.d.ts
npm notice 1.8kB  lib/src/constructs/loadbalancing/elb.d.ts
npm notice 13.4kB src/constructs/loadbalancing/elb.test.ts
npm notice 3.3kB  src/constructs/loadbalancing/elb.ts
npm notice 85B    lib/constructs/core/identity.d.ts
npm notice 85B    lib/src/constructs/core/identity.d.ts
npm notice 79B    src/constructs/core/identity.ts
npm notice 58B    lib/constants/index.d.ts
npm notice 23B    lib/constructs/autoscaling/index.d.ts
npm notice 91B    lib/constructs/cloudwatch/index.d.ts
npm notice 55B    lib/constructs/core/index.d.ts
npm notice 58B    lib/constructs/ec2/index.d.ts
npm notice 53B    lib/constructs/iam/index.d.ts
npm notice 273B   lib/constructs/iam/policies/index.d.ts
npm notice 58B    lib/constructs/iam/roles/index.d.ts
npm notice 26B    lib/constructs/lambda/index.d.ts
npm notice 46B    lib/constructs/loadbalancing/index.d.ts
npm notice 28B    lib/constructs/rds/index.d.ts
npm notice 28B    lib/index.d.ts
npm notice 66B    lib/patterns/index.d.ts
npm notice 58B    lib/src/constants/index.d.ts
npm notice 23B    lib/src/constructs/autoscaling/index.d.ts
npm notice 91B    lib/src/constructs/cloudwatch/index.d.ts
npm notice 55B    lib/src/constructs/core/index.d.ts
npm notice 58B    lib/src/constructs/ec2/index.d.ts
npm notice 53B    lib/src/constructs/iam/index.d.ts
npm notice 273B   lib/src/constructs/iam/policies/index.d.ts
npm notice 58B    lib/src/constructs/iam/roles/index.d.ts
npm notice 26B    lib/src/constructs/lambda/index.d.ts
npm notice 46B    lib/src/constructs/loadbalancing/index.d.ts
npm notice 28B    lib/src/constructs/rds/index.d.ts
npm notice 28B    lib/src/index.d.ts
npm notice 66B    lib/src/patterns/index.d.ts
npm notice 154B   lib/src/utils/index.d.ts
npm notice 154B   lib/utils/index.d.ts
npm notice 776B   src/utils/index.test.ts
npm notice 58B    src/constants/index.ts
npm notice 23B    src/constructs/autoscaling/index.ts
npm notice 91B    src/constructs/cloudwatch/index.ts
npm notice 55B    src/constructs/core/index.ts
npm notice 58B    src/constructs/ec2/index.ts
npm notice 53B    src/constructs/iam/index.ts
npm notice 273B   src/constructs/iam/policies/index.ts
npm notice 58B    src/constructs/iam/roles/index.ts
npm notice 26B    src/constructs/lambda/index.ts
npm notice 46B    src/constructs/loadbalancing/index.ts
npm notice 28B    src/constructs/rds/index.ts
npm notice 28B    src/index.ts
npm notice 66B    src/patterns/index.ts
npm notice 318B   src/utils/index.ts
npm notice 114B   test/utils/index.ts
npm notice 390B   lib/constructs/iam/roles/instance-role.d.ts
npm notice 390B   lib/src/constructs/iam/roles/instance-role.d.ts
npm notice 1.5kB  src/constructs/iam/roles/instance-role.test.ts
npm notice 1.2kB  src/constructs/iam/roles/instance-role.ts
npm notice 492B   lib/constructs/rds/instance.d.ts
npm notice 492B   lib/src/constructs/rds/instance.d.ts
npm notice 5.8kB  src/constructs/rds/instance.test.ts
npm notice 1.6kB  src/constructs/rds/instance.ts
npm notice 804B   lib/constructs/cloudwatch/lambda-alarms.d.ts
npm notice 804B   lib/src/constructs/cloudwatch/lambda-alarms.d.ts
npm notice 3.1kB  src/constructs/cloudwatch/lambda-alarms.test.ts
npm notice 1.8kB  src/constructs/cloudwatch/lambda-alarms.ts
npm notice 897B   lib/constructs/lambda/lambda.d.ts
npm notice 897B   lib/src/constructs/lambda/lambda.d.ts
npm notice 6.2kB  src/constructs/lambda/lambda.test.ts
npm notice 2.5kB  src/constructs/lambda/lambda.ts
npm notice 135B   lib/constants/library-info.d.ts
npm notice 135B   lib/src/constants/__mocks__/library-info.d.ts
npm notice 135B   lib/src/constants/library-info.d.ts
npm notice 141B   src/constants/__mocks__/library-info.ts
npm notice 189B   src/constants/library-info.ts
npm notice 268B   lib/constructs/iam/policies/log-shipping.d.ts
npm notice 268B   lib/src/constructs/iam/policies/log-shipping.d.ts
npm notice 2.3kB  src/constructs/iam/policies/log-shipping.test.ts
npm notice 967B   src/constructs/iam/policies/log-shipping.ts
npm notice 58B    lib/constructs/cloudwatch/no-monitoring.d.ts
npm notice 58B    lib/src/constructs/cloudwatch/no-monitoring.d.ts
npm notice 56B    src/constructs/cloudwatch/no-monitoring.ts
npm notice 311B   lib/constructs/iam/policies/parameter-store-read.d.ts
npm notice 311B   lib/src/constructs/iam/policies/parameter-store-read.d.ts
npm notice 1.5kB  src/constructs/iam/policies/parameter-store-read.test.ts
npm notice 934B   src/constructs/iam/policies/parameter-store-read.ts
npm notice 1.8kB  lib/constructs/core/parameters.d.ts
npm notice 1.8kB  lib/src/constructs/core/parameters.d.ts
npm notice 7.0kB  src/constructs/core/parameters.test.ts
npm notice 3.3kB  src/constructs/core/parameters.ts
npm notice 104B   lib/constants/regex-pattern.d.ts
npm notice 104B   lib/src/constants/regex-pattern.d.ts
npm notice 1.2kB  src/constants/regex-pattern.test.ts
npm notice 389B   src/constants/regex-pattern.ts
npm notice 364B   lib/constructs/iam/roles/roles.d.ts
npm notice 364B   lib/src/constructs/iam/roles/roles.d.ts
npm notice 1.3kB  src/constructs/iam/roles/roles.test.ts
npm notice 563B   src/constructs/iam/roles/roles.ts
npm notice 562B   lib/constructs/iam/policies/s3-get-object.d.ts
npm notice 562B   lib/src/constructs/iam/policies/s3-get-object.d.ts
npm notice 2.8kB  src/constructs/iam/policies/s3-get-object.test.ts
npm notice 1.1kB  src/constructs/iam/policies/s3-get-object.ts
npm notice 778B   lib/patterns/scheduled-lambda.d.ts
npm notice 778B   lib/src/patterns/scheduled-lambda.d.ts
npm notice 1.7kB  src/patterns/scheduled-lambda.test.ts
npm notice 1.0kB  src/patterns/scheduled-lambda.ts
npm notice 5.5kB  src/constructs/ec2/security-group.test.ts
npm notice 990B   lib/constructs/ec2/security-groups.d.ts
npm notice 990B   lib/src/constructs/ec2/security-groups.d.ts
npm notice 2.2kB  src/constructs/ec2/security-groups.ts
npm notice 266B   lib/constructs/iam/policies/ses.d.ts
npm notice 266B   lib/src/constructs/iam/policies/ses.d.ts
npm notice 1.4kB  src/constructs/iam/policies/ses.test.ts
npm notice 863B   src/constructs/iam/policies/ses.ts
npm notice 336B   test/utils/simple-gu-stack.ts
npm notice 3.4kB  lib/patterns/sns-lambda.d.ts
npm notice 3.4kB  lib/src/patterns/sns-lambda.d.ts
npm notice 3.0kB  src/patterns/sns-lambda.test.ts
npm notice 4.4kB  src/patterns/sns-lambda.ts
npm notice 340B   lib/constructs/sns/sns-topic.d.ts
npm notice 340B   lib/src/constructs/sns/sns-topic.d.ts
npm notice 922B   src/constructs/sns/sns-topic.test.ts
npm notice 485B   src/constructs/sns/sns-topic.ts
npm notice 431B   lib/constructs/iam/policies/ssm.d.ts
npm notice 431B   lib/src/constructs/iam/policies/ssm.d.ts
npm notice 2.6kB  src/constructs/iam/policies/ssm.test.ts
npm notice 1.3kB  src/constructs/iam/policies/ssm.ts
npm notice 1.8kB  lib/constructs/core/stack.d.ts
npm notice 1.8kB  lib/src/constructs/core/stack.d.ts
npm notice 1.8kB  src/constructs/core/stack.test.ts
npm notice 2.8kB  src/constructs/core/stack.ts
npm notice 118B   lib/constants/stage.d.ts
npm notice 118B   lib/src/constants/stage.d.ts
npm notice 198B   src/constants/stage.ts
npm notice 175B   test/utils/synthed-stack.ts
npm notice 794B   lib/constructs/ec2/vpc.d.ts
npm notice 794B   lib/src/constructs/ec2/vpc.d.ts
npm notice 2.5kB  src/constructs/ec2/vpc.test.ts
npm notice 2.5kB  src/constructs/ec2/vpc.ts
npm notice 696B   .github/workflows/cd-docs.yaml
npm notice 1.1kB  .github/workflows/cd.yaml
npm notice 1.6kB  .github/workflows/ci.yaml
npm notice 463B   .github/dependabot.yml
npm notice === Tarball Details ===
npm notice name:          @guardian/cdk
npm notice version:       0.32.0
npm notice filename:      guardian-cdk-0.32.0.tgz
npm notice package size:  153.1 kB
npm notice unpacked size: 664.7 kB
npm notice shasum:        87e0bfe75e4672b4d4a27edd13a002469b1a1596
npm notice integrity:     sha512-VyWg+e1z34eVt[...]97920AMfb1BYg==
npm notice total files:   307
npm notice
guardian-cdk-0.32.0.tgz
```
</details>

<details>
<summary>npm pack after (on this branch)</summary>

```console
➜ npm pack

> @guardian/cdk@0.32.0 prepare /Users/akash_askoolum/code/cdk
> tsc

npm notice
npm notice 📦  @guardian/cdk@0.32.0
npm notice === Tarball Contents ===
npm notice 2.6kB  lib/constructs/cloudwatch/alarm.js
npm notice 7.6kB  lib/constructs/autoscaling/asg.js
npm notice 2.3kB  lib/constructs/iam/policies/assume-role.js
npm notice 4.6kB  lib/constructs/iam/policies/base-policy.js
npm notice 9.1kB  lib/constructs/loadbalancing/clb.js
npm notice 3.3kB  lib/constructs/iam/policies/describe-ec2.js
npm notice 4.1kB  lib/constructs/iam/policies/dynamodb.js
npm notice 10.5kB lib/constructs/loadbalancing/elb.js
npm notice 443B   lib/constructs/core/identity.js
npm notice 1.0kB  lib/constants/index.js
npm notice 952B   lib/constructs/autoscaling/index.js
npm notice 1.2kB  lib/constructs/cloudwatch/index.js
npm notice 1.1kB  lib/constructs/core/index.js
npm notice 1.1kB  lib/constructs/ec2/index.js
npm notice 1.0kB  lib/constructs/iam/index.js
npm notice 1.9kB  lib/constructs/iam/policies/index.js
npm notice 1.1kB  lib/constructs/iam/roles/index.js
npm notice 951B   lib/constructs/lambda/index.js
npm notice 1.0kB  lib/constructs/loadbalancing/index.js
npm notice 953B   lib/constructs/rds/index.js
npm notice 925B   lib/index.js
npm notice 1.1kB  lib/patterns/index.js
npm notice 1.5kB  lib/utils/index.js
npm notice 4.0kB  lib/constructs/iam/roles/instance-role.js
npm notice 5.1kB  lib/constructs/rds/instance.js
npm notice 5.2kB  lib/constructs/cloudwatch/lambda-alarms.js
npm notice 8.1kB  lib/constructs/lambda/lambda.js
npm notice 1.6kB  lib/constants/library-info.js
npm notice 3.5kB  lib/constructs/iam/policies/log-shipping.js
npm notice 431B   lib/constructs/cloudwatch/no-monitoring.js
npm notice 3.4kB  lib/constructs/iam/policies/parameter-store-read.js
npm notice 11.8kB lib/constructs/core/parameters.js
npm notice 1.6kB  lib/constants/regex-pattern.js
npm notice 2.0kB  lib/constructs/iam/roles/roles.js
npm notice 3.7kB  lib/constructs/iam/policies/s3-get-object.js
npm notice 2.8kB  lib/patterns/scheduled-lambda.js
npm notice 7.4kB  lib/constructs/ec2/security-groups.js
npm notice 3.0kB  lib/constructs/iam/policies/ses.js
npm notice 9.1kB  lib/patterns/sns-lambda.js
npm notice 1.7kB  lib/constructs/sns/sns-topic.js
npm notice 4.4kB  lib/constructs/iam/policies/ssm.js
npm notice 8.0kB  lib/constructs/core/stack.js
npm notice 1.2kB  lib/constants/stage.js
npm notice 7.9kB  lib/constructs/ec2/vpc.js
npm notice 2.1kB  package.json
npm notice 4.9kB  README.md
npm notice 340B   lib/constructs/cloudwatch/alarm.d.ts
npm notice 992B   lib/constructs/autoscaling/asg.d.ts
npm notice 391B   lib/constructs/iam/policies/assume-role.d.ts
npm notice 874B   lib/constructs/iam/policies/base-policy.d.ts
npm notice 1.4kB  lib/constructs/loadbalancing/clb.d.ts
npm notice 304B   lib/constructs/iam/policies/describe-ec2.d.ts
npm notice 806B   lib/constructs/iam/policies/dynamodb.d.ts
npm notice 1.8kB  lib/constructs/loadbalancing/elb.d.ts
npm notice 85B    lib/constructs/core/identity.d.ts
npm notice 58B    lib/constants/index.d.ts
npm notice 23B    lib/constructs/autoscaling/index.d.ts
npm notice 91B    lib/constructs/cloudwatch/index.d.ts
npm notice 55B    lib/constructs/core/index.d.ts
npm notice 58B    lib/constructs/ec2/index.d.ts
npm notice 53B    lib/constructs/iam/index.d.ts
npm notice 273B   lib/constructs/iam/policies/index.d.ts
npm notice 58B    lib/constructs/iam/roles/index.d.ts
npm notice 26B    lib/constructs/lambda/index.d.ts
npm notice 46B    lib/constructs/loadbalancing/index.d.ts
npm notice 28B    lib/constructs/rds/index.d.ts
npm notice 28B    lib/index.d.ts
npm notice 66B    lib/patterns/index.d.ts
npm notice 154B   lib/utils/index.d.ts
npm notice 390B   lib/constructs/iam/roles/instance-role.d.ts
npm notice 492B   lib/constructs/rds/instance.d.ts
npm notice 804B   lib/constructs/cloudwatch/lambda-alarms.d.ts
npm notice 897B   lib/constructs/lambda/lambda.d.ts
npm notice 135B   lib/constants/library-info.d.ts
npm notice 268B   lib/constructs/iam/policies/log-shipping.d.ts
npm notice 58B    lib/constructs/cloudwatch/no-monitoring.d.ts
npm notice 311B   lib/constructs/iam/policies/parameter-store-read.d.ts
npm notice 1.8kB  lib/constructs/core/parameters.d.ts
npm notice 104B   lib/constants/regex-pattern.d.ts
npm notice 364B   lib/constructs/iam/roles/roles.d.ts
npm notice 562B   lib/constructs/iam/policies/s3-get-object.d.ts
npm notice 778B   lib/patterns/scheduled-lambda.d.ts
npm notice 990B   lib/constructs/ec2/security-groups.d.ts
npm notice 266B   lib/constructs/iam/policies/ses.d.ts
npm notice 3.4kB  lib/patterns/sns-lambda.d.ts
npm notice 340B   lib/constructs/sns/sns-topic.d.ts
npm notice 431B   lib/constructs/iam/policies/ssm.d.ts
npm notice 1.8kB  lib/constructs/core/stack.d.ts
npm notice 118B   lib/constants/stage.d.ts
npm notice 794B   lib/constructs/ec2/vpc.d.ts
npm notice === Tarball Details ===
npm notice name:          @guardian/cdk
npm notice version:       0.32.0
npm notice filename:      guardian-cdk-0.32.0.tgz
npm notice package size:  51.3 kB
npm notice unpacked size: 186.3 kB
npm notice shasum:        be2fe5e5d5afef9f089bf6011e2a89edbf1bf58c
npm notice integrity:     sha512-PXbmc3lCnApUN[...]87XxPfYJsJYfw==
npm notice total files:   90
npm notice
guardian-cdk-0.32.0.tgz
```
</details>

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No. Nothing is using v0.32.0. I tried to update deploy-tools-platform and then noticed the import paths changing, hence this PR.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run `npm pack`?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We publish only the necessary files and get back to a sane path in import statements.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a