### PR TITLE
fix: tweak the name of the AMI parameter

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -12,7 +12,6 @@ import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 export interface GuAutoScalingGroupProps
   extends Omit<AutoScalingGroupProps, "imageId" | "osType" | "machineImage" | "instanceType" | "userData"> {
   instanceType?: InstanceType;
-  imageId?: GuAmiParameter;
   osType?: OperatingSystemType;
   machineImage?: MachineImage;
   userData: string;
@@ -30,11 +29,9 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
       return {
         osType: props.osType ?? OperatingSystemType.LINUX,
         userData: UserData.custom(props.userData),
-        imageId:
-          props.imageId?.valueAsString ??
-          new GuAmiParameter(scope, "AMI", {
-            description: "AMI ID",
-          }).valueAsString,
+        imageId: new GuAmiParameter(scope, `${scope.app}AMI`, {
+          description: "AMI ID",
+        }).valueAsString,
       };
     }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In order to support stacks with multiple apps, we need to specify an AMI per ASG as they are likely to be independent. This change prefixes the AMI with the app name and no-longer allows it to be passed in. For every ASG that's defined in the stack, there will be an AMI parameter.

Not sure if this is correct or not. I'm leaning on _not_ at the moment as we usually share AMIs across multiple ASGs. For example in Grid, there's a general purpose java based AMI and one other AMI that includes imaging libraries. These two AMIs are shared across 11 or so different ASGs.

Opinions wanted.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

TBD

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

TBD

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

TBD

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

TBD