### PR TITLE
feat(stack): GuStack accepts Stack value as prop

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -3,11 +3,6 @@
 exports[`The GuLambdaErrorPercentageAlarm pattern should create the correct alarm resource with minimal config 1`] = `
 Object {
   "Parameters": Object {
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -49,9 +44,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -103,9 +96,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -17,30 +17,21 @@ describe("The GuStack construct", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Parameters).toEqual({
-      Stack: {
+      Stage: {
         Type: "String",
-        Description: "Name of this stack",
-        Default: "deploy",
+        Description: "Stage name",
+        AllowedValues: Stages,
+        Default: Stage.CODE,
       },
     });
   });
 
-  it("can accept only one of stack or stage", function () {
-    const stack = simpleGuStackForTesting({ stage: "some-stage" });
-    expect(stack.stage).toEqual("some-stage");
-  });
-
-  it("should have stack and stage parameters", () => {
-    const stack = simpleGuStackForTesting();
+  it("should have a stage parameter", () => {
+    const stack = simpleGuStackForTesting({ stack: "test" });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Parameters).toEqual({
-      Stack: {
-        Type: "String",
-        Description: "Name of this stack",
-        Default: "deploy",
-      },
       Stage: {
         Type: "String",
         Description: "Stage name",
@@ -51,7 +42,7 @@ describe("The GuStack construct", () => {
   });
 
   it("should apply the stack, stage and app tags to resources added to it", () => {
-    const stack = new GuStack(new App(), "Test", { app: "MyApp" });
+    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
 
     new Role(stack, "MyRole", {
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
@@ -65,9 +56,7 @@ describe("The GuStack construct", () => {
         },
         {
           Key: "Stack",
-          Value: {
-            Ref: "Stack",
-          },
+          Value: "test",
         },
         {
           Key: "Stage",
@@ -81,7 +70,7 @@ describe("The GuStack construct", () => {
   });
 
   it("should return the correct app value when app is set", () => {
-    const stack = new GuStack(new App(), "Test", { app: "MyApp" });
+    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
 
     expect(stack.app).toBe("MyApp");
   });

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -10,14 +10,19 @@ import { TrackingTag } from "../../constants/library-info";
 import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
-  it("should be able to take stack and stage values as props", function () {
-    const stack = simpleGuStackForTesting({ stack: "some-stack", stage: "some-stage" });
+  it("requires passing the stack value as props", function () {
+    const stack = simpleGuStackForTesting({ stack: "some-stack" });
     expect(stack.stack).toEqual("some-stack");
-    expect(stack.stage).toEqual("some-stage");
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
-    expect(json.Parameters).toBeUndefined();
+    expect(json.Parameters).toEqual({
+      Stack: {
+        Type: "String",
+        Description: "Name of this stack",
+        Default: "deploy",
+      },
+    });
   });
 
   it("can accept only one of stack or stage", function () {

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -10,6 +10,15 @@ import { TrackingTag } from "../../constants/library-info";
 import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
+  it("should be able to take stack and stage values as props", function () {
+    const stack = simpleGuStackForTesting({ stack: "some-stack", stage: "some-stage" });
+    expect(stack.stack).toEqual("some-stack");
+    expect(stack.stage).toEqual("some-stage");
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters).toBeUndefined();
+  });
   it("should have stack and stage parameters", () => {
     const stack = simpleGuStackForTesting();
 

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -19,6 +19,12 @@ describe("The GuStack construct", () => {
 
     expect(json.Parameters).toBeUndefined();
   });
+
+  it("can accept only one of stack or stage", function () {
+    const stack = simpleGuStackForTesting({ stage: "some-stage" });
+    expect(stack.stage).toEqual("some-stage");
+  });
+
   it("should have stack and stage parameters", () => {
     const stack = simpleGuStackForTesting();
 

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -13,17 +13,6 @@ describe("The GuStack construct", () => {
   it("requires passing the stack value as props", function () {
     const stack = simpleGuStackForTesting({ stack: "some-stack" });
     expect(stack.stack).toEqual("some-stack");
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters).toEqual({
-      Stage: {
-        Type: "String",
-        Description: "Stage name",
-        AllowedValues: Stages,
-        Default: Stage.CODE,
-      },
-    });
   });
 
   it("should have a stage parameter", () => {

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -7,6 +7,8 @@ export interface GuStackProps extends StackProps {
   // This limits GuStack to supporting a single app.
   // In the future, support for stacks with multiple apps may be required
   app: string;
+  stack?: string;
+  stage?: string;
   migratedFromCloudFormation?: boolean;
 }
 
@@ -38,17 +40,23 @@ export interface GuStackProps extends StackProps {
  * ```
  */
 export class GuStack extends Stack {
-  private readonly _stage: GuStageParameter;
-  private readonly _stack: GuStackParameter;
+  private readonly _stage: string | GuStageParameter;
+  private readonly _stack: string | GuStackParameter;
   private readonly _app: string;
 
   public readonly migratedFromCloudFormation: boolean;
 
   get stage(): string {
+    if (typeof this._stage === "string") {
+      return this._stage;
+    }
     return this._stage.valueAsString;
   }
 
   get stack(): string {
+    if (typeof this._stack === "string") {
+      return this._stack;
+    }
     return this._stack.valueAsString;
   }
 
@@ -78,8 +86,8 @@ export class GuStack extends Stack {
 
     this.migratedFromCloudFormation = !!props.migratedFromCloudFormation;
 
-    this._stage = new GuStageParameter(this);
-    this._stack = new GuStackParameter(this);
+    this._stage = props.stage ?? new GuStageParameter(this);
+    this._stack = props.stack ?? new GuStackParameter(this);
     this._app = props.app;
 
     this.addTag(TrackingTag.Key, TrackingTag.Value);

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,14 +1,13 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { TrackingTag } from "../../constants/library-info";
-import { GuStackParameter, GuStageParameter } from "./parameters";
+import { GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
   // This limits GuStack to supporting a single app.
   // In the future, support for stacks with multiple apps may be required
   app: string;
-  stack?: string;
-  stage?: string;
+  stack: string;
   migratedFromCloudFormation?: boolean;
 }
 
@@ -40,24 +39,18 @@ export interface GuStackProps extends StackProps {
  * ```
  */
 export class GuStack extends Stack {
-  private readonly _stage: string | GuStageParameter;
-  private readonly _stack: string | GuStackParameter;
+  private readonly _stage: GuStageParameter;
+  private readonly _stack: string;
   private readonly _app: string;
 
   public readonly migratedFromCloudFormation: boolean;
 
   get stage(): string {
-    if (typeof this._stage === "string") {
-      return this._stage;
-    }
     return this._stage.valueAsString;
   }
 
   get stack(): string {
-    if (typeof this._stack === "string") {
-      return this._stack;
-    }
-    return this._stack.valueAsString;
+    return this._stack;
   }
 
   get app(): string {
@@ -86,8 +79,8 @@ export class GuStack extends Stack {
 
     this.migratedFromCloudFormation = !!props.migratedFromCloudFormation;
 
-    this._stage = props.stage ?? new GuStageParameter(this);
-    this._stack = props.stack ?? new GuStackParameter(this);
+    this._stage = new GuStageParameter(this);
+    this._stack = props.stack;
     this._app = props.app;
 
     this.addTag(TrackingTag.Key, TrackingTag.Value);

--- a/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
@@ -8,11 +8,6 @@ Object {
       "ConstraintDescription": "Must be an @theguardian.com email address",
       "Type": "String",
     },
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -98,9 +93,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",

--- a/src/constructs/iam/policies/parameter-store-read.test.ts
+++ b/src/constructs/iam/policies/parameter-store-read.test.ts
@@ -6,7 +6,7 @@ import { GuParameterStoreReadPolicy } from "./parameter-store-read";
 
 describe("ParameterStoreReadPolicy", () => {
   it("should constrain the policy to the patch of a stack's identity", () => {
-    const stack = new GuStack(new App(), "my-app", { app: "MyApp" });
+    const stack = new GuStack(new App(), "my-app", { app: "MyApp", stack: "test-stack" });
 
     const policy = new GuParameterStoreReadPolicy(stack);
 
@@ -36,11 +36,7 @@ describe("ParameterStoreReadPolicy", () => {
                   {
                     Ref: "Stage",
                   },
-                  "/",
-                  {
-                    Ref: "Stack",
-                  },
-                  "/MyApp",
+                  "/test-stack/MyApp",
                 ],
               ],
             },

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -57,7 +57,7 @@ describe("The GuGetDistributablePolicy construct", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     const parameterKeys = Object.keys(json.Parameters);
-    const expectedKeys = ["Stage", "Stack", "DistributionBucketName"];
+    const expectedKeys = ["Stage", "DistributionBucketName"];
     expect(parameterKeys).toEqual(expectedKeys);
 
     expect(json.Parameters.DistributionBucketName).toEqual({

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -8,11 +8,6 @@ Object {
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -139,9 +134,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -176,11 +169,7 @@ Object {
                     Object {
                       "Ref": "Stage",
                     },
-                    "/",
-                    Object {
-                      "Ref": "Stack",
-                    },
-                    "/testing",
+                    "/test-stack/testing",
                   ],
                 ],
               },
@@ -249,11 +238,6 @@ Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
     },
     "Stage": Object {
       "AllowedValues": Array [
@@ -402,9 +386,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -439,11 +421,7 @@ Object {
                     Object {
                       "Ref": "Stage",
                     },
-                    "/",
-                    Object {
-                      "Ref": "Stack",
-                    },
-                    "/testing",
+                    "/test-stack/testing",
                   ],
                 ],
               },
@@ -507,11 +485,6 @@ Object {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
     },
     "Stage": Object {
       "AllowedValues": Array [
@@ -618,9 +591,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -655,11 +626,7 @@ Object {
                     Object {
                       "Ref": "Stage",
                     },
-                    "/",
-                    Object {
-                      "Ref": "Stack",
-                    },
-                    "/testing",
+                    "/test-stack/testing",
                   ],
                 ],
               },

--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -57,11 +57,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -103,9 +98,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -157,9 +150,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -236,9 +227,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -424,9 +413,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -438,7 +425,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB93739afe50d503afeac32f7e1b1edd2caf70": Object {
+    "lambdaapi2Deployment4ECB9373eeef9ed08d134e870f1057489fa78a0f": Object {
       "DependsOn": Array [
         "lambdaapi2proxyANY3F8E1D36",
         "lambdaapi2proxyE68FDFBC",
@@ -455,7 +442,7 @@ Object {
     "lambdaapi2DeploymentStageprodCC9E3016": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB93739afe50d503afeac32f7e1b1edd2caf70",
+          "Ref": "lambdaapi2Deployment4ECB9373eeef9ed08d134e870f1057489fa78a0f",
         },
         "RestApiId": Object {
           "Ref": "lambdaapi239350ECC",
@@ -472,9 +459,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -769,9 +754,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -822,9 +805,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -836,7 +817,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B5854a7d40530a7080bd25491376ccd199af": Object {
+    "lambdaapiDeployment8E95B58563248bfce6018e332697b729bf0efbba": Object {
       "DependsOn": Array [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -853,7 +834,7 @@ Object {
     "lambdaapiDeploymentStageprod9598BC2F": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B5854a7d40530a7080bd25491376ccd199af",
+          "Ref": "lambdaapiDeployment8E95B58563248bfce6018e332697b729bf0efbba",
         },
         "RestApiId": Object {
           "Ref": "lambdaapiC1812993",
@@ -870,9 +851,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -91,9 +91,7 @@ describe("The GuDatabaseInstance class", () => {
         },
         {
           Key: "Stack",
-          Value: {
-            Ref: "Stack",
-          },
+          Value: "test-stack",
         },
         {
           Key: "Stage",

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -3,11 +3,6 @@
 exports[`The GuScheduledLambda pattern should create the correct resources with minimal config 1`] = `
 Object {
   "Parameters": Object {
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -50,9 +45,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -154,9 +147,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -13,11 +13,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "Stack": Object {
-      "Default": "deploy",
-      "Description": "Name of this stack",
-      "Type": "String",
-    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -42,9 +37,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -87,9 +80,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",
@@ -207,9 +198,7 @@ Object {
           },
           Object {
             "Key": "Stack",
-            "Value": Object {
-              "Ref": "Stack",
-            },
+            "Value": "test-stack",
           },
           Object {
             "Key": "Stage",

--- a/test/utils/simple-gu-stack.ts
+++ b/test/utils/simple-gu-stack.ts
@@ -3,4 +3,4 @@ import type { GuStackProps } from "../../src/constructs/core";
 import { GuStack } from "../../src/constructs/core";
 
 export const simpleGuStackForTesting: (props?: Partial<GuStackProps>) => GuStack = (props?: Partial<GuStackProps>) =>
-  new GuStack(new App(), "Test", { app: "testing", ...props });
+  new GuStack(new App(), "Test", { app: "testing", stack: props?.stack ?? "test-stack", ...props });


### PR DESCRIPTION
## What does this change?

As we look to reduce the number of parameters requiring manual updating and maintaining in CFN, this allows library users to hard-code stack and stage variables so we can reason with their values in other parts of the codebase.

If a user would like to avoid having the stack and stage as tokens (which later gets resolved at deployment by writing the values in the CFN UI), you could now simply state these values in the stack declaration:


```typescript
const stack =  new GuStack(new App(), "Test", { app: "testing", stack: "deploy", stage: "CODE" });
```

Since we don't often (or ever) write stage-specific CDK declarations, I expect the `stage` prop will not be used often. However, being able to provide the `stack` as a hardcoded string I think provides value in a) having more configuration explicit in the repository, b) remove a parameter from CFN UI and c) remove a tiny bit of cognitive load in the process

## Does this change require changes to existing projects or CDK CLI?

No, this shouldn't affect existing projects.

## How to test

`./script/test` from the root of the repository.

## How can we measure success?

More projects can be explicit about what stack (and perhaps rarely stage) the CDK stacks belong to.