### PR TITLE
feat!: Implement stage dependent ASG capacity via Mappings

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -3,8 +3,9 @@ import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import { InstanceType, Vpc } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stack } from "@aws-cdk/core";
-import { simpleGuStackForTesting } from "../../../test/utils/simple-gu-stack";
-import type { SynthedStack } from "../../../test/utils/synthed-stack";
+import { simpleGuStackForTesting } from "../../../test/utils";
+import type { SynthedStack } from "../../../test/utils";
+import { Stage } from "../../constants";
 import { GuAmiParameter } from "../core";
 import { GuSecurityGroup } from "../ec2";
 import { GuApplicationTargetGroup } from "../loadbalancing";
@@ -20,9 +21,13 @@ describe("The GuAutoScalingGroup", () => {
   const defaultProps: GuAutoScalingGroupProps = {
     vpc,
     userData: "user data",
-    capacity: {
-      minimumCodeInstances: 1,
-      minimumProdInstances: 3,
+    stageDependentProps: {
+      [Stage.CODE]: {
+        minimumInstances: 1,
+      },
+      [Stage.PROD]: {
+        minimumInstances: 3,
+      },
     },
   };
 
@@ -213,11 +218,15 @@ describe("The GuAutoScalingGroup", () => {
     const stack = simpleGuStackForTesting();
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       ...defaultProps,
-      capacity: {
-        minimumCodeInstances: 1,
-        minimumProdInstances: 3,
-        maximumCodeInstances: 5,
-        maximumProdInstances: 7,
+      stageDependentProps: {
+        [Stage.CODE]: {
+          minimumInstances: 1,
+          maximumInstances: 5,
+        },
+        [Stage.PROD]: {
+          minimumInstances: 3,
+          maximumInstances: 7,
+        },
       },
     });
 

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -3,7 +3,7 @@ import { AutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import type { ISecurityGroup, MachineImage, MachineImageConfig } from "@aws-cdk/aws-ec2";
 import { InstanceType, OperatingSystemType, UserData } from "@aws-cdk/aws-ec2";
 import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
-import type { GuStack, GuStageDependentValue } from "../core";
+import type { GuStack, GuStageDependentNumber } from "../core";
 import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 
 // Since we want to override the types of what gets passed in for the below props,
@@ -58,12 +58,12 @@ interface AwsAsgCapacityProps {
 function wireCapacityProps(stack: GuStack, capacity: GuAsgCapacityProps): AwsAsgCapacityProps {
   const minInstancesKey = "minInstances";
   const maxInstancesKey = "maxInstances";
-  const minInstances: GuStageDependentValue = {
+  const minInstances: GuStageDependentNumber = {
     variableName: minInstancesKey,
     codeValue: capacity.minimumCodeInstances,
     prodValue: capacity.minimumProdInstances,
   };
-  const maxInstances: GuStageDependentValue = {
+  const maxInstances: GuStageDependentNumber = {
     variableName: maxInstancesKey,
     codeValue: capacity.maximumCodeInstances ?? capacity.minimumCodeInstances * 2,
     prodValue: capacity.maximumProdInstances ?? capacity.minimumProdInstances * 2,

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -3,7 +3,7 @@ import { AutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import type { ISecurityGroup, MachineImage, MachineImageConfig } from "@aws-cdk/aws-ec2";
 import { InstanceType, OperatingSystemType, UserData } from "@aws-cdk/aws-ec2";
 import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
-import type { GuStack, GuStageVariable } from "../core";
+import type { GuStack, GuStageDependentValue } from "../core";
 import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 
 // Since we want to override the types of what gets passed in for the below props,
@@ -55,24 +55,24 @@ interface AwsAsgCapacityProps {
   maxCapacity: number;
 }
 
-function wireCapacityProps(scope: GuStack, capacity: GuAsgCapacityProps): AwsAsgCapacityProps {
+function wireCapacityProps(stack: GuStack, capacity: GuAsgCapacityProps): AwsAsgCapacityProps {
   const minInstancesKey = "minInstances";
   const maxInstancesKey = "maxInstances";
-  const minInstances: GuStageVariable = {
+  const minInstances: GuStageDependentValue = {
     variableName: minInstancesKey,
     codeValue: capacity.minimumCodeInstances,
     prodValue: capacity.minimumProdInstances,
   };
-  const maxInstances: GuStageVariable = {
+  const maxInstances: GuStageDependentValue = {
     variableName: maxInstancesKey,
     codeValue: capacity.maximumCodeInstances ?? capacity.minimumCodeInstances * 2,
     prodValue: capacity.maximumProdInstances ?? capacity.minimumProdInstances * 2,
   };
-  scope.mappings.addStageVariable(minInstances);
-  scope.mappings.addStageVariable(maxInstances);
+  stack.setStageDependentValue(minInstances);
+  stack.setStageDependentValue(maxInstances);
   return {
-    minCapacity: (scope.mappings.findInMap(scope.stage, minInstancesKey) as unknown) as number,
-    maxCapacity: (scope.mappings.findInMap(scope.stage, maxInstancesKey) as unknown) as number,
+    minCapacity: stack.getStageDependentValue(minInstancesKey),
+    maxCapacity: stack.getStageDependentValue(maxInstancesKey),
   };
 }
 

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -36,14 +36,13 @@ export interface GuAutoScalingGroupProps
 type GuStageDependentAsgProps = Record<Stage, GuAsgCapacityProps>;
 
 /**
- * `minimumCodeInstances` and `minimumProdInstances` determine the number of ec2 instances running
- * in each stage under normal circumstances (i.e. when there are no deployment or scaling events in progress).
+ * `minimumInstances` determines the number of ec2 instances running under normal circumstances
+ * (i.e. when there are no deployment or scaling events in progress).
  *
- * `maximumCodeInstances` and `maximumProdInstances` are both optional. If omitted, these
- * will be set to `minimumCodeInstances * 2` and `minimumProdInstances * 2`, respectively.
+ * `maximumInstances` is optional. If omitted, this will be set to `minimumInstances * 2`.
  * This allows us to support Riff-Raff's autoscaling deployment type by default.
  *
- * The maximum capacity values can be set manually if you need to scale beyond the default limit (e.g. due to heavy traffic)
+ * The maximum capacity value should only be set if you need to scale beyond the default limit (e.g. due to heavy traffic)
  * or restrict scaling for a specific reason.
  */
 export interface GuAsgCapacityProps {

--- a/src/constructs/core/index.ts
+++ b/src/constructs/core/index.ts
@@ -1,2 +1,3 @@
+export * from "./mappings";
 export * from "./parameters";
 export * from "./stack";

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -3,8 +3,23 @@ import type { GuStack } from "./stack";
 
 export interface GuStageDependentValue {
   variableName: string;
-  codeValue: unknown;
+  codeValue: number | string | boolean;
   prodValue: unknown;
+}
+
+export interface GuStageDependentNumber extends GuStageDependentValue {
+  codeValue: number;
+  prodValue: number;
+}
+
+export interface GuStageDependentString extends GuStageDependentValue {
+  codeValue: string;
+  prodValue: string;
+}
+
+export interface GuStageDependentBoolean extends GuStageDependentValue {
+  codeValue: boolean;
+  prodValue: boolean;
 }
 
 export class GuStageMapping extends CfnMapping {

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -1,17 +1,13 @@
 import { CfnMapping } from "@aws-cdk/core";
 import type { GuStack } from "./stack";
 
-export interface GuStageVariable {
+export interface GuStageDependentValue {
   variableName: string;
   codeValue: unknown;
   prodValue: unknown;
 }
 
 export class GuStageMapping extends CfnMapping {
-  addStageVariable(stageVariable: GuStageVariable): void {
-    this.setValue("CODE", stageVariable.variableName, stageVariable.codeValue);
-    this.setValue("PROD", stageVariable.variableName, stageVariable.prodValue);
-  }
   constructor(scope: GuStack, id: string = "stage-mapping") {
     super(scope, id);
   }

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -1,25 +1,10 @@
 import { CfnMapping } from "@aws-cdk/core";
+import type { Stage } from "../../constants";
 import type { GuStack } from "./stack";
 
-export interface GuStageDependentValue {
+export interface GuStageDependentValue<T extends string | number | boolean> {
   variableName: string;
-  codeValue: number | string | boolean;
-  prodValue: unknown;
-}
-
-export interface GuStageDependentNumber extends GuStageDependentValue {
-  codeValue: number;
-  prodValue: number;
-}
-
-export interface GuStageDependentString extends GuStageDependentValue {
-  codeValue: string;
-  prodValue: string;
-}
-
-export interface GuStageDependentBoolean extends GuStageDependentValue {
-  codeValue: boolean;
-  prodValue: boolean;
+  stageValues: Record<Stage, T>;
 }
 
 export class GuStageMapping extends CfnMapping {

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -1,0 +1,18 @@
+import { CfnMapping } from "@aws-cdk/core";
+import type { GuStack } from "./stack";
+
+export interface GuStageVariable {
+  variableName: string;
+  codeValue: unknown;
+  prodValue: unknown;
+}
+
+export class GuStageMapping extends CfnMapping {
+  addStageVariable(stageVariable: GuStageVariable): void {
+    this.setValue("CODE", stageVariable.variableName, stageVariable.codeValue);
+    this.setValue("PROD", stageVariable.variableName, stageVariable.prodValue);
+  }
+  constructor(scope: GuStack, id: string = "stage-mapping") {
+    super(scope, id);
+  }
+}

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,6 +1,7 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { TrackingTag } from "../../constants/library-info";
+import type { GuStageDependentValue } from "./mappings";
 import { GuStageMapping } from "./mappings";
 import { GuStackParameter, GuStageParameter } from "./parameters";
 
@@ -61,6 +62,15 @@ export class GuStack extends Stack {
   // Use lazy initialisation for GuStageMapping so that Mappings block is only created when necessary
   get mappings(): GuStageMapping {
     return this._mappings ?? (this._mappings = new GuStageMapping(this));
+  }
+
+  setStageDependentValue(stageVariable: GuStageDependentValue): void {
+    this.mappings.setValue("CODE", stageVariable.variableName, stageVariable.codeValue);
+    this.mappings.setValue("PROD", stageVariable.variableName, stageVariable.prodValue);
+  }
+
+  getStageDependentValue<T>(key: string): T {
+    return (this.mappings.findInMap(this.stage, key) as unknown) as T;
   }
 
   /**

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,6 +1,7 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { TrackingTag } from "../../constants/library-info";
+import { GuStageMapping } from "./mappings";
 import { GuStackParameter, GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
@@ -40,6 +41,7 @@ export interface GuStackProps extends StackProps {
 export class GuStack extends Stack {
   private readonly _stage: GuStageParameter;
   private readonly _stack: GuStackParameter;
+  private _mappings: undefined | GuStageMapping;
   private readonly _app: string;
 
   public readonly migratedFromCloudFormation: boolean;
@@ -54,6 +56,11 @@ export class GuStack extends Stack {
 
   get app(): string {
     return this._app;
+  }
+
+  // Use lazy initialisation for GuStageMapping so that Mappings block is only created when necessary
+  get mappings(): GuStageMapping {
+    return this._mappings ?? (this._mappings = new GuStageMapping(this));
   }
 
   /**

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,5 +1,6 @@
 import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
+import { Stage } from "../../constants";
 import { TrackingTag } from "../../constants/library-info";
 import type { GuStageDependentValue } from "./mappings";
 import { GuStageMapping } from "./mappings";
@@ -67,9 +68,9 @@ export class GuStack extends Stack {
     return this._mappings ?? (this._mappings = new GuStageMapping(this));
   }
 
-  setStageDependentValue(stageDependentValue: GuStageDependentValue): void {
-    this.mappings.setValue("CODE", stageDependentValue.variableName, stageDependentValue.codeValue);
-    this.mappings.setValue("PROD", stageDependentValue.variableName, stageDependentValue.prodValue);
+  setStageDependentValue<T extends string | number | boolean>(stageDependentValue: GuStageDependentValue<T>): void {
+    this.mappings.setValue(Stage.CODE, stageDependentValue.variableName, stageDependentValue.stageValues.CODE);
+    this.mappings.setValue(Stage.PROD, stageDependentValue.variableName, stageDependentValue.stageValues.PROD);
   }
 
   getStageDependentValue<T>(key: string): T {

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -64,9 +64,9 @@ export class GuStack extends Stack {
     return this._mappings ?? (this._mappings = new GuStageMapping(this));
   }
 
-  setStageDependentValue(stageVariable: GuStageDependentValue): void {
-    this.mappings.setValue("CODE", stageVariable.variableName, stageVariable.codeValue);
-    this.mappings.setValue("PROD", stageVariable.variableName, stageVariable.prodValue);
+  setStageDependentValue(stageDependentValue: GuStageDependentValue): void {
+    this.mappings.setValue("CODE", stageDependentValue.variableName, stageDependentValue.codeValue);
+    this.mappings.setValue("PROD", stageDependentValue.variableName, stageDependentValue.prodValue);
   }
 
   getStageDependentValue<T>(key: string): T {

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -46,7 +46,7 @@ export class GuStack extends Stack {
   private readonly _stack: string;
   private readonly _app: string;
 
-  private _mappings: undefined | GuStageMapping;
+  private _mappings?: GuStageMapping;
   private params: Map<string, GuParameter>;
 
   public readonly migratedFromCloudFormation: boolean;

--- a/test/utils/synthed-stack.ts
+++ b/test/utils/synthed-stack.ts
@@ -1,4 +1,5 @@
 export interface SynthedStack {
   Parameters: Record<string, { Properties: Record<string, unknown> }>;
+  Mappings: Record<string, unknown>;
   Resources: Record<string, { Properties: Record<string, unknown> }>;
 }


### PR DESCRIPTION
## What does this change?

Since Guardian stacks typically use the same CFN template for different stages (e.g. `CODE` or `PROD`), we often need a way to provide different values to a template depending on which stage is being CloudFormed. For example, many applications use fewer ec2 instances in `CODE` (needs to handle minimal test traffic) than they do in `PROD` (needs to cope with real production workloads). Unfortunately, stage is passed into templates via a parameter which means that it's not available at build-time. Consequently, we cannot simply use TypeScript logic to conditionally change values. 

This PR adds functionality for defining (non-secret) values which differ depending on stage, without forcing library users to think about CFN concepts like `Parameters` or `Mappings` and without requiring them to pass in values via the CFN UI. Under the hood, this is achieved via CFN `Mappings`.

In order to illustrate usage of this technique, this PR also:

* Removes the `minCapacity` and `maxCapacity` props from `GuAutoScalingGroup`, in favour of using new stage-based `Mappings`.
* Removes the `desiredCapacity` prop, due to the advice [here](https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation):

```NOTE: It is strongly recommended you do NOT set a desired-capacity on auto-scaling groups, managed with CloudFormation templates deployed in this way [via Riff-Raff], as otherwise any deployment will reset the capacity to this number, even if scaling actions have triggered, changing the capacity, in the mean-time.```

## Does this change require changes to existing projects or CDK CLI?

Yes, once this version is released any stack which defines an AutoScaling Group will need to make use of the new `capacity` prop in order to upgrade.

## How to test

I've tested this by creating change sets for the ec2-based apps in `deploy-tools-platform`. I've also CloudFormed `AMIable-CODE` to confirm that removing [`desiredCapacity` from an existing stack](https://github.com/guardian/deploy-tools-platform/blob/c5a075d872198fda05cb08d84ca105728a0682fa/cdk/lib/amiable/amiable.ts#L76) is a safe operation.

## How can we measure success?

* Users of the library can define values which differ between stages without understanding CFN concepts
* It should also be harder to accidentally set up ASGs which are incompatible with Riff-Raff deployments

## Have we considered potential risks?

* This is a breaking change so it will impact the upgrade path for a number of projects. 