### PR TITLE
feat!: tighten GuGetDistributablePolicy's access

### DIFF
--- a/src/constructs/core/parameters.ts
+++ b/src/constructs/core/parameters.ts
@@ -127,3 +127,15 @@ export class GuCertificateArnParameter extends GuStringParameter {
     });
   }
 }
+
+export class GuDistributionBucketParameter extends GuStringParameter {
+  public static parameterName = "DistributionBucketName";
+
+  constructor(scope: GuStack, id: string = GuDistributionBucketParameter.parameterName) {
+    super(scope, id, {
+      description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      default: "/account/services/artifact.bucket",
+      fromSSM: true,
+    });
+  }
+}

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -2,6 +2,7 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import type { SynthedStack } from "../../../../test/utils";
 import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
+import { GuDistributionBucketParameter } from "../../core";
 import { GuGetDistributablePolicy, GuGetS3ObjectPolicy } from "./s3-get-object";
 
 describe("The GuGetS3ObjectPolicy class", () => {
@@ -57,7 +58,7 @@ describe("The GuGetDistributablePolicy construct", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     const parameterKeys = Object.keys(json.Parameters);
-    const expectedKeys = ["Stage", "DistributionBucketName"];
+    const expectedKeys = ["Stage", GuDistributionBucketParameter.parameterName];
     expect(parameterKeys).toEqual(expectedKeys);
 
     expect(json.Parameters.DistributionBucketName).toEqual({
@@ -67,7 +68,6 @@ describe("The GuGetDistributablePolicy construct", () => {
     });
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
-      PolicyName: "GetDistributablePolicyC6B4A871",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -82,7 +82,11 @@ describe("The GuGetDistributablePolicy construct", () => {
                   {
                     Ref: "DistributionBucketName",
                   },
-                  "/*",
+                  `/test-stack/`,
+                  {
+                    Ref: "Stage",
+                  },
+                  "/testing/*",
                 ],
               ],
             },

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,5 +1,5 @@
 import type { GuStack } from "../../core";
-import { GuStringParameter } from "../../core";
+import { GuDistributionBucketParameter } from "../../core";
 import type { GuNoStatementsPolicyProps } from "./base-policy";
 import { GuAllowPolicy } from "./base-policy";
 
@@ -15,12 +15,6 @@ export class GuGetS3ObjectPolicy extends GuAllowPolicy {
 
 export class GuGetDistributablePolicy extends GuGetS3ObjectPolicy {
   constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuNoStatementsPolicyProps) {
-    const distributionBucketNameParam = new GuStringParameter(scope, "DistributionBucketName", {
-      description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
-      default: "/account/services/artifact.bucket",
-      fromSSM: true,
-    });
-
-    super(scope, id, { ...props, bucketName: distributionBucketNameParam.valueAsString });
+    super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString });
   }
 }

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -5,16 +5,19 @@ import { GuAllowPolicy } from "./base-policy";
 
 export interface GuGetS3ObjectPolicyProps extends GuNoStatementsPolicyProps {
   bucketName: string;
+  path?: string;
 }
 
 export class GuGetS3ObjectPolicy extends GuAllowPolicy {
   constructor(scope: GuStack, id: string, props: GuGetS3ObjectPolicyProps) {
-    super(scope, id, { ...props, actions: ["s3:GetObject"], resources: [`arn:aws:s3:::${props.bucketName}/*`] });
+    const path: string = props.path ?? "*";
+    super(scope, id, { ...props, actions: ["s3:GetObject"], resources: [`arn:aws:s3:::${props.bucketName}/${path}`] });
   }
 }
 
 export class GuGetDistributablePolicy extends GuGetS3ObjectPolicy {
   constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuNoStatementsPolicyProps) {
-    super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString });
+    const path = [scope.stack, scope.stage, scope.app, "*"].join("/");
+    super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString, path });
   }
 }

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -81,7 +81,11 @@ Object {
                     Object {
                       "Ref": "DistributionBucketName",
                     },
-                    "/*",
+                    "/test-stack/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/testing/*",
                   ],
                 ],
               },
@@ -291,7 +295,11 @@ Object {
                     Object {
                       "Ref": "DistributionBucketName",
                     },
-                    "/*",
+                    "/test-stack/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/testing/*",
                   ],
                 ],
               },
@@ -538,7 +546,11 @@ Object {
                     Object {
                       "Ref": "DistributionBucketName",
                     },
-                    "/*",
+                    "/test-stack/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/testing/*",
                   ],
                 ],
               },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

`GuGetDistributablePolicy` is a policy that allows the Instance Profile to download artefacts from S3.

### Before
Currently, it has `s3:GetObject` permissions to `bucket/*`. This is pretty wide!

### After
This PR follows the principal of least privilege and grants `s3:GetObject` permissions to `bucket/stack/stage/app/*` only.

We're also creating a standalone `GuDistributionBucketParameter` with a static field to remove magic strings and make it easier to reference ([see Prism's stack](https://github.com/guardian/prism/blob/0602058ccd349ca6c137777e6cb9e1e908cc6325/cdk/lib/prism.ts#L49)).

This is a breaking change, as denoted by the `!` in the PR title: see risk section below for detail.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. With the The IAM policy changes, we need to ensure the artefact is in the correct location.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Following the principal of least privilege.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

If an application's artefact is not in this standard place, the instance will not launch as the InstanceProfile will no longer have permissions to the entire bucket 😱 .