### PR TITLE
feat: tweak type of GuASG's userData

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -10,7 +10,7 @@ import { GuAmiParameter } from "../core";
 import { GuSecurityGroup } from "../ec2";
 import { GuApplicationTargetGroup } from "../loadbalancing";
 import type { GuAutoScalingGroupProps } from "./asg";
-import { GuAutoScalingGroup, GuUserData } from "./asg";
+import { GuAutoScalingGroup, GuUserData } from "./";
 
 describe("The GuAutoScalingGroup", () => {
   const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -1,6 +1,6 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import { InstanceType, Vpc } from "@aws-cdk/aws-ec2";
+import { InstanceType, UserData, Vpc } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../test/utils";
@@ -18,9 +18,13 @@ describe("The GuAutoScalingGroup", () => {
     availabilityZones: [""],
     publicSubnetIds: [""],
   });
+
+  const userData = UserData.forLinux();
+  userData.addCommands("service my-app start");
+
   const defaultProps: GuAutoScalingGroupProps = {
     vpc,
-    userData: "user data",
+    userData,
     stageDependentProps: {
       [Stage.CODE]: {
         minimumInstances: 1,

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -1,6 +1,6 @@
 import type { AutoScalingGroupProps, CfnAutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import { AutoScalingGroup } from "@aws-cdk/aws-autoscaling";
-import type { ISecurityGroup, MachineImage, MachineImageConfig, S3DownloadOptions } from "@aws-cdk/aws-ec2";
+import type { ISecurityGroup, MachineImage, MachineImageConfig } from "@aws-cdk/aws-ec2";
 import { InstanceType, OperatingSystemType, UserData } from "@aws-cdk/aws-ec2";
 import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stage } from "../../constants";
@@ -32,24 +32,6 @@ export interface GuAutoScalingGroupProps
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
   overrideId?: boolean;
-}
-
-export class GuUserData {
-  private _userData = UserData.forLinux();
-
-  get userData(): UserData {
-    return this._userData;
-  }
-
-  addCommands(...commands: string[]): GuUserData {
-    this._userData.addCommands(...commands);
-    return this;
-  }
-
-  addS3DownloadCommand(params: S3DownloadOptions): GuUserData {
-    this._userData.addS3DownloadCommand(params);
-    return this;
-  }
 }
 
 type GuStageDependentAsgProps = Record<Stage, GuAsgCapacityProps>;

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -29,7 +29,7 @@ export interface GuAutoScalingGroupProps
   imageId?: GuAmiParameter;
   osType?: OperatingSystemType;
   machineImage?: MachineImage;
-  userData: string;
+  userData: UserData | string;
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
   overrideId?: boolean;
@@ -84,13 +84,15 @@ function wireStageDependentProps(stack: GuStack, stageDependentProps: GuStageDep
 
 export class GuAutoScalingGroup extends AutoScalingGroup {
   constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {
+    const userData = props.userData instanceof UserData ? props.userData : UserData.custom(props.userData);
+
     // We need to override getImage() so that we can pass in the AMI as a parameter
     // Otherwise, MachineImage.lookup({ name: 'some str' }) would work as long
     // as the name is hard-coded
     function getImage(): MachineImageConfig {
       return {
         osType: props.osType ?? OperatingSystemType.LINUX,
-        userData: UserData.custom(props.userData),
+        userData,
         imageId:
           props.imageId?.valueAsString ??
           new GuAmiParameter(scope, "AMI", {
@@ -104,7 +106,7 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
       ...wireStageDependentProps(scope, props.stageDependentProps),
       machineImage: { getImage: getImage },
       instanceType: props.instanceType ?? new InstanceType(new GuInstanceTypeParameter(scope).valueAsString),
-      userData: UserData.custom(props.userData),
+      userData,
 
       // Do not use the default AWS security group which allows egress on any port.
       // Favour HTTPS only egress rules by default.

--- a/src/constructs/autoscaling/index.ts
+++ b/src/constructs/autoscaling/index.ts
@@ -1,1 +1,2 @@
 export * from "./asg";
+export * from "./user-data";

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -1,0 +1,20 @@
+import type { S3DownloadOptions } from "@aws-cdk/aws-ec2";
+import { UserData } from "@aws-cdk/aws-ec2";
+
+export class GuUserData {
+  private _userData = UserData.forLinux();
+
+  get userData(): UserData {
+    return this._userData;
+  }
+
+  addCommands(...commands: string[]): GuUserData {
+    this._userData.addCommands(...commands);
+    return this;
+  }
+
+  addS3DownloadCommand(params: S3DownloadOptions): GuUserData {
+    this._userData.addS3DownloadCommand(params);
+    return this;
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Update the type of `userData` in `GuAutoScalingGroup` to be `UserData | string`. This allows it to be more strongly typed.

A side-effect of this change is hard coding the `osType` to linux. Currently all our stacks run a flavour of linux, so this shouldn't be too controversial. There are ambitions from InfoSec and Enterprise to run Windows machines in AWS, however I think we can cross that bridge when we come to it as it'll likely mean other tools, such as AMIgo, need updating too.

This change also paves the way auto generating the user data for the most basic launch configurations of:
- Download config
- Download artefact
- Run artefact

This will be added in a subsequent PR - https://github.com/guardian/cdk/pull/269.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No mandatory, but we can change the type of `userData`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Existing tests have been updated, so observe CI?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Stricter types.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a