### PR TITLE
feat!: refactor security groups in GuAutoScalingGroup

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -149,12 +149,14 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       ...defaultProps,
-      securityGroup,
-      securityGroups: [securityGroup1, securityGroup2],
+      securityGroups: [securityGroup, securityGroup1, securityGroup2],
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
       SecurityGroups: [
+        {
+          "Fn::GetAtt": ["GuHttpsEgressSecurityGroupF63CDA96", "GroupId"],
+        },
         {
           "Fn::GetAtt": ["SecurityGroup", "GroupId"],
         },

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -149,7 +149,7 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       ...defaultProps,
-      securityGroups: [securityGroup, securityGroup1, securityGroup2],
+      additionalSecurityGroups: [securityGroup, securityGroup1, securityGroup2],
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -30,7 +30,7 @@ export interface GuAutoScalingGroupProps
   osType?: OperatingSystemType;
   machineImage?: MachineImage;
   userData: string;
-  securityGroups?: ISecurityGroup[];
+  additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
   overrideId?: boolean;
 }
@@ -115,7 +115,7 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
 
     mergedProps.targetGroup && this.attachToApplicationTargetGroup(mergedProps.targetGroup);
 
-    mergedProps.securityGroups?.forEach((sg) => this.addSecurityGroup(sg));
+    mergedProps.additionalSecurityGroups?.forEach((sg) => this.addSecurityGroup(sg));
 
     const cfnAsg = this.node.defaultChild as CfnAutoScalingGroup;
     // A CDK AutoScalingGroup comes with this update policy, whereas the CFN autscaling group

--- a/src/constructs/ec2/security-group.test.ts
+++ b/src/constructs/ec2/security-group.test.ts
@@ -4,7 +4,12 @@ import { Peer, Port, Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../test/utils";
 import type { SynthedStack } from "../../../test/utils";
-import { GuPublicInternetAccessSecurityGroup, GuSecurityGroup, GuWazuhAccess } from "./security-groups";
+import {
+  GuHttpsEgressSecurityGroup,
+  GuPublicInternetAccessSecurityGroup,
+  GuSecurityGroup,
+  GuWazuhAccess,
+} from "./security-groups";
 
 describe("The GuSecurityGroup class", () => {
   const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
@@ -177,6 +182,33 @@ describe("The GuPublicInternetAccessSecurityGroup class", () => {
         {
           CidrIp: "0.0.0.0/0",
           Description: "GLOBAL_ACCESS",
+          FromPort: 443,
+          IpProtocol: "tcp",
+          ToPort: 443,
+        },
+      ],
+    });
+  });
+});
+
+describe("The GuHttpsEgressSecurityGroup class", () => {
+  const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
+    vpcId: "test",
+    availabilityZones: [""],
+    publicSubnetIds: [""],
+  });
+
+  it("adds global access on 443 by default", () => {
+    const stack = simpleGuStackForTesting();
+
+    GuHttpsEgressSecurityGroup.forVpc(stack, { vpc });
+
+    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
+      GroupDescription: "Allow all outbound traffic on port 443",
+      SecurityGroupEgress: [
+        {
+          CidrIp: "0.0.0.0/0",
+          Description: "from 0.0.0.0/0:443",
           FromPort: 443,
           IpProtocol: "tcp",
           ToPort: 443,

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -70,3 +70,18 @@ export class GuPublicInternetAccessSecurityGroup extends GuSecurityGroup {
     });
   }
 }
+
+export class GuHttpsEgressSecurityGroup extends GuSecurityGroup {
+  constructor(scope: GuStack, id: string, props: SecurityGroupProps) {
+    super(scope, id, {
+      vpc: props.vpc,
+      allowAllOutbound: false,
+      description: "Allow all outbound traffic on port 443",
+      egresses: [{ range: Peer.anyIpv4(), port: Port.tcp(443) }],
+    });
+  }
+
+  public static forVpc(scope: GuStack, props: SecurityGroupProps): GuHttpsEgressSecurityGroup {
+    return new GuHttpsEgressSecurityGroup(scope, "GuHttpsEgressSecurityGroup", props);
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Simplify how to define security groups in `GuAutoScalingGroup`. Currently, we can specify `securityGroup` (singular) _and_ `securityGroups` (multiple), where `securityGroup` overrides the [default one](https://github.com/aws/aws-cdk/blob/296a10d76a9f6fc2a374d1a6461c460bcc3eeb79/packages/%40aws-cdk/aws-autoscaling/lib/auto-scaling-group.ts#L913-L916) provided by AWS.

In this PR, we set the default security group to allow outgoing traffic on port 443 (https); this is tighter than AWS's default.

By setting the default security group, the props for `GuAutoScalingGroup` no longer needs the `securityGroup` field 🎉 .

Lastly, we're renaming `securityGroups` to `additionalSecurityGroups` to be more explicit; this is inspired by [`GuInstanceRole`](https://github.com/guardian/cdk/blob/974d1a864252e8d2344c512305266ea925276e0b/src/constructs/iam/roles/instance-role.ts).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes! The signature of `GuAutoScalingGroup` has changed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler API.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a