### PR TITLE
feat: auto generating UserData

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -19,7 +19,9 @@ describe("The GuAutoScalingGroup", () => {
     publicSubnetIds: [""],
   });
 
-  const { userData } = new GuUserData().addCommands(...["service some-dependency start", "service my-app start"]);
+  const { userData } = new GuUserData(simpleGuStackForTesting()).addCommands(
+    ...["service some-dependency start", "service my-app start"]
+  );
 
   const defaultProps: GuAutoScalingGroupProps = {
     vpc,

--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -22,6 +22,7 @@ describe("GuUserData", () => {
       distributable: {
         bucketName: new GuDistributionBucketParameter(stack).valueAsString,
         fileName: "my-app.deb",
+        executionStatement: `dpkg -i /${stack.app}/my-app.deb`,
       },
     };
 
@@ -54,7 +55,7 @@ describe("GuUserData", () => {
               {
                 Ref: "Stage",
               },
-              "/testing/my-app.deb' '/testing/my-app.deb'",
+              "/testing/my-app.deb' '/testing/my-app.deb'\ndpkg -i /testing/my-app.deb",
             ],
           ],
         },
@@ -69,6 +70,7 @@ describe("GuUserData", () => {
       distributable: {
         bucketName: new GuDistributionBucketParameter(stack).valueAsString,
         fileName: "my-app.deb",
+        executionStatement: `dpkg -i /${stack.app}/my-app.deb`,
       },
       configuration: {
         bucketName: "test-app-config",
@@ -105,7 +107,7 @@ describe("GuUserData", () => {
               {
                 Ref: "Stage",
               },
-              "/testing/my-app.deb' '/testing/my-app.deb'",
+              "/testing/my-app.deb' '/testing/my-app.deb'\ndpkg -i /testing/my-app.deb",
             ],
           ],
         },

--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -1,0 +1,115 @@
+import "@aws-cdk/assert/jest";
+import { Vpc } from "@aws-cdk/aws-ec2";
+import { Stack } from "@aws-cdk/core";
+import { simpleGuStackForTesting } from "../../../test/utils";
+import { Stage } from "../../constants";
+import { GuDistributionBucketParameter } from "../core";
+import { GuAutoScalingGroup } from "./asg";
+import type { GuUserDataProps } from "./user-data";
+import { GuUserData } from "./user-data";
+
+describe("GuUserData", () => {
+  const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
+    vpcId: "test",
+    availabilityZones: [""],
+    publicSubnetIds: [""],
+  });
+
+  test("Distributable should be downloaded from a standard path in S3 (bucket/stack/stage/app/filename)", () => {
+    const stack = simpleGuStackForTesting();
+
+    const props: GuUserDataProps = {
+      distributable: {
+        bucketName: new GuDistributionBucketParameter(stack).valueAsString,
+        fileName: "my-app.deb",
+      },
+    };
+
+    const { userData } = new GuUserData(stack, props);
+
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", {
+      vpc,
+      userData,
+      stageDependentProps: {
+        [Stage.CODE]: {
+          minimumInstances: 1,
+        },
+        [Stage.PROD]: {
+          minimumInstances: 3,
+        },
+      },
+    });
+
+    expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
+      UserData: {
+        "Fn::Base64": {
+          "Fn::Join": [
+            "",
+            [
+              "#!/bin/bash\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
+              {
+                Ref: "DistributionBucketName",
+              },
+              "/test-stack/",
+              {
+                Ref: "Stage",
+              },
+              "/testing/my-app.deb' '/testing/my-app.deb'",
+            ],
+          ],
+        },
+      },
+    });
+  });
+
+  test("Distributable should download configuration first", () => {
+    const stack = simpleGuStackForTesting();
+
+    const props: GuUserDataProps = {
+      distributable: {
+        bucketName: new GuDistributionBucketParameter(stack).valueAsString,
+        fileName: "my-app.deb",
+      },
+      configuration: {
+        bucketName: "test-app-config",
+        files: ["secrets.json", "application.conf"],
+      },
+    };
+
+    const { userData } = new GuUserData(stack, props);
+
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", {
+      vpc,
+      userData,
+      stageDependentProps: {
+        [Stage.CODE]: {
+          minimumInstances: 1,
+        },
+        [Stage.PROD]: {
+          minimumInstances: 3,
+        },
+      },
+    });
+
+    expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
+      UserData: {
+        "Fn::Base64": {
+          "Fn::Join": [
+            "",
+            [
+              "#!/bin/bash\nmkdir -p $(dirname '/etc/testing/secrets.json')\naws s3 cp 's3://test-app-config/secrets.json' '/etc/testing/secrets.json'\nmkdir -p $(dirname '/etc/testing/application.conf')\naws s3 cp 's3://test-app-config/application.conf' '/etc/testing/application.conf'\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
+              {
+                Ref: "DistributionBucketName",
+              },
+              "/test-stack/",
+              {
+                Ref: "Stage",
+              },
+              "/testing/my-app.deb' '/testing/my-app.deb'",
+            ],
+          ],
+        },
+      },
+    });
+  });
+});

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -11,6 +11,7 @@ import type { GuStack } from "../core";
 export interface GuUserDataS3DistributableProps {
   bucketName: string;
   fileName: string;
+  executionStatement: string; // TODO can we detect this and auto generate it? Maybe from the file extension?
 }
 
 /**
@@ -84,6 +85,7 @@ export class GuUserData {
     if (props) {
       props.configuration && this.downloadConfiguration(scope, props.configuration);
       this.downloadDistributable(scope, props.distributable);
+      this.addCommands(props.distributable.executionStatement);
     }
   }
 

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -1,11 +1,90 @@
 import type { S3DownloadOptions } from "@aws-cdk/aws-ec2";
 import { UserData } from "@aws-cdk/aws-ec2";
+import { Bucket } from "@aws-cdk/aws-s3";
+import type { GuStack } from "../core";
 
+/**
+ * Where to download a distributable from.
+ * We'll look for `fileName` on the path "bucket/stack/stage/app/<fileName>".
+ * `executionStatement` will be something like "dpkg -i application.deb` or `service foo start`.
+ */
+export interface GuUserDataS3DistributableProps {
+  bucketName: string;
+  fileName: string;
+}
+
+/**
+ * Where to download configuration from.
+ * `files` are paths from the root of the bucket.
+ *   TODO change this once we have defined best practice for configuration.
+ */
+export interface GuUserDataS3ConfigurationProps {
+  bucketName: string;
+  files: string[];
+}
+
+export interface GuUserDataProps {
+  distributable: GuUserDataS3DistributableProps;
+  configuration?: GuUserDataS3ConfigurationProps;
+}
+
+/**
+ * An abstraction over UserData to simplify its creation.
+ * Especially useful for simple user data where we:
+ *   - (optional) download config
+ *   - download distributable
+ *   - execute distributable
+ */
 export class GuUserData {
-  private _userData = UserData.forLinux();
+  private readonly _userData: UserData;
 
   get userData(): UserData {
     return this._userData;
+  }
+
+  private downloadDistributable(scope: GuStack, props: GuUserDataS3DistributableProps) {
+    const localDirectory = `/${scope.app}`;
+    const { bucketName, fileName } = props;
+    const bucketKey = [scope.stack, scope.stage, scope.app, fileName].join("/");
+
+    const bucket = Bucket.fromBucketAttributes(scope, "DistributionBucket", {
+      bucketName,
+    });
+
+    this.addS3DownloadCommand({
+      bucket: bucket,
+      bucketKey,
+      localFile: `${localDirectory}/${fileName}`,
+    });
+  }
+
+  private downloadConfiguration(scope: GuStack, props: GuUserDataS3ConfigurationProps) {
+    const localDirectory = `/etc/${scope.app}`;
+    const { bucketName, files } = props;
+
+    const bucket = Bucket.fromBucketAttributes(scope, `${scope.app}ConfigurationBucket`, {
+      bucketName,
+    });
+
+    files.forEach((bucketKey) => {
+      const fileName = bucketKey.split("/").slice(-1)[0];
+
+      this.addS3DownloadCommand({
+        bucket,
+        bucketKey,
+        localFile: `${localDirectory}/${fileName}`,
+      });
+    });
+  }
+
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO only lint for things that extend IConstruct
+  constructor(scope: GuStack, props?: GuUserDataProps) {
+    this._userData = UserData.forLinux();
+
+    if (props) {
+      props.configuration && this.downloadConfiguration(scope, props.configuration);
+      this.downloadDistributable(scope, props.distributable);
+    }
   }
 
   addCommands(...commands: string[]): GuUserData {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following the change in #267 , introduce a way to autogenerate user data for the ideal scenario of:
- download config
- download distributable
- run distributable

This is part of a wider task of creating an EC2 based pattern.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

For the simplest use case, the library has an easier API.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a