### PR TITLE
chore: fix auto-generation of docs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,15 +17,22 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: CD
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # This step will create a tag when creating a new release.
+        # We have an action to update docs upon tag creation.
+        # The standard `secrets.GITHUB_TOKEN` doesn't trigger other actions.
+        # We cannot use the standard token as it won't trigger the docs action, so we need to provide a different token.
+        # This is a PAT for the guardian-ci user.
+        # See ./cd-docs.yaml
+        # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+        GITHUB_TOKEN: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: ./script/cd
     - name: post-release
       uses: guardian/post-release-action@main
       with:
         # This action will raise a PR to edit package.json.
-        # PRs raised by the default `secrets.GIT_TOKEN` will not trigger CI,
+        # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI,
         # so we need to provide a different token.
         # This is a PAT for the guardian-ci user.
         # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
-        github-token: ${{ secrets.POST_RELEASE_TOKEN }}
+        github-token: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

#275 was our first fully automated release 🎉 , well _almost_ fully automated as the [docs](https://guardian.github.io/cdk/) were not updated (it should be on [v0.38.1](https://github.com/guardian/cdk/tags)). We update docs via an Action triggered on new tag creation. However as the [default token given to Actions doesn't trigger other Actions](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token), the docs were not updated.

To fix this we can use a custom GH token, which should trigger the docs Action.

Also renames the custom token supplied to `post-release` for clarity as it's the same value.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Docs get updated upon new releases.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a