### PR TITLE
feat: Constructs to create IAM policies for Cloudwatch GET and PUT

### DIFF
--- a/src/constructs/iam/policies/cloudwatch.test.ts
+++ b/src/constructs/iam/policies/cloudwatch.test.ts
@@ -1,0 +1,48 @@
+import "@aws-cdk/assert/jest";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
+import { GuGetCloudwatchMetricsPolicy, GuPutCloudwatchMetricsPolicy } from "./cloudwatch";
+
+describe("The GuGetCloudwatchMetricsPolicy construct", () => {
+  it("creates the correct policy", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuGetCloudwatchMetricsPolicy(stack));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: [
+              "cloudwatch:ListMetrics",
+              "cloudwatch:GetMetricData",
+              "cloudwatch:GetMetricStatistics",
+              "cloudwatch:DescribeAlarmsForMetric",
+            ],
+            Effect: "Allow",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("The GuPutCloudwatchMetricsPolicy construct", () => {
+  it("creates the correct policy", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, new GuPutCloudwatchMetricsPolicy(stack));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "cloudwatch:PutMetricData",
+            Effect: "Allow",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/cloudwatch.ts
+++ b/src/constructs/iam/policies/cloudwatch.ts
@@ -1,0 +1,25 @@
+import type { GuStack } from "../../core";
+import type { GuAllowPolicyProps } from "./base-policy";
+import { GuAllowPolicy } from "./base-policy";
+
+abstract class GuCloudwatchPolicy extends GuAllowPolicy {
+  protected constructor(scope: GuStack, id: string, props: Omit<GuAllowPolicyProps, "resources">) {
+    super(scope, id, {
+      ...props,
+      actions: props.actions.map((action) => `cloudwatch:${action}`),
+      resources: ["*"],
+    });
+  }
+}
+
+export class GuGetCloudwatchMetricsPolicy extends GuCloudwatchPolicy {
+  constructor(scope: GuStack, id: string = "GuGetCloudwatchMetricsPolicy") {
+    super(scope, id, { actions: ["ListMetrics", "GetMetricData", "GetMetricStatistics", "DescribeAlarmsForMetric"] });
+  }
+}
+
+export class GuPutCloudwatchMetricsPolicy extends GuCloudwatchPolicy {
+  constructor(scope: GuStack, id: string = "GuPutCloudwatchMetricsPolicy") {
+    super(scope, id, { actions: ["PutMetricData"] });
+  }
+}

--- a/src/constructs/iam/policies/index.ts
+++ b/src/constructs/iam/policies/index.ts
@@ -1,5 +1,6 @@
 export * from "./assume-role";
 export * from "./base-policy";
+export * from "./cloudwatch";
 export * from "./describe-ec2";
 export * from "./dynamodb";
 export * from "./log-shipping";


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Two simple constructs to allow the GETing and PUTing of Cloudwatch metrics. This will allow us to further DRY out templates such as Grafana which defines a custom policy.

I suspect the PUT policy will soon get added to the standard policies given to our [instance role](https://github.com/guardian/cdk/blob/98c95f94cebab71f1943a6c7a2e1900b6c11e9d4/src/constructs/iam/roles/instance-role.ts#L28-L35), possibly behind a flag similar to `GuLogShippingPolicy`. Will create this as it's own PR for clarity.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. They can be thinned out a little!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More constructs means shorter consumer templates!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a