### PR TITLE
fix: add module index for sns

### DIFF
--- a/src/constructs/sns/index.ts
+++ b/src/constructs/sns/index.ts
@@ -1,0 +1,1 @@
+export * from "./sns-topic";

--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -1,12 +1,11 @@
 import { SnsEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import { Topic } from "@aws-cdk/aws-sns";
 import { CfnOutput } from "@aws-cdk/core";
-import type { GuLambdaErrorPercentageMonitoringProps } from "../constructs/cloudwatch/lambda-alarms";
-import type { NoMonitoring } from "../constructs/cloudwatch/no-monitoring";
+import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
 import type { GuFunctionProps } from "../constructs/lambda";
 import { GuLambdaFunction } from "../constructs/lambda";
-import { GuSnsTopic } from "../constructs/sns/sns-topic";
+import { GuSnsTopic } from "../constructs/sns";
 
 /**
  * Used to provide information about an existing SNS topic to the [[`GuSnsLambda`]] pattern.


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This simplifies import statements and also makes the sns namespace(?) consistent to others.

Going from:

```typescript
import { GuSnsTopic } from "@guardian/cdk/lib/constructs/sns/sns-topic"
```

To:

```typescript
import { GuSnsTopic } from "@guardian/cdk/lib/constructs/sns"
```

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Consistency.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a