### PR TITLE
refactor: make SSM policy extend GuAllowPolicy for DRYness

### DIFF
--- a/src/constructs/iam/policies/ssm.test.ts
+++ b/src/constructs/iam/policies/ssm.test.ts
@@ -6,7 +6,7 @@ describe("The GuSSMRunCommandPolicy class", () => {
   it("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const ssmPolicy = new GuSSMRunCommandPolicy(stack, "SSMRunCommandPolicy", {});
+    const ssmPolicy = new GuSSMRunCommandPolicy(stack);
 
     attachPolicyToTestRole(stack, ssmPolicy);
 

--- a/src/constructs/iam/policies/ssm.ts
+++ b/src/constructs/iam/policies/ssm.ts
@@ -1,41 +1,28 @@
-import type { PolicyProps } from "@aws-cdk/aws-iam";
-import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
-import { GuPolicy } from "./base-policy";
+import type { GuNoStatementsPolicyProps } from "./base-policy";
+import { GuAllowPolicy } from "./base-policy";
 
-export const allowSSMRunCommandPolicyStatement = new PolicyStatement({
-  effect: Effect.ALLOW,
-  actions: [
-    "ec2messages:AcknowledgeMessage",
-    "ec2messages:DeleteMessage",
-    "ec2messages:FailMessage",
-    "ec2messages:GetEndpoint",
-    "ec2messages:GetMessages",
-    "ec2messages:SendReply",
-    "ssm:UpdateInstanceInformation",
-    "ssm:ListInstanceAssociations",
-    "ssm:DescribeInstanceProperties",
-    "ssm:DescribeDocumentParameters",
-    "ssmmessages:CreateControlChannel",
-    "ssmmessages:CreateDataChannel",
-    "ssmmessages:OpenControlChannel",
-    "ssmmessages:OpenDataChannel",
-  ],
-  resources: ["*"],
-});
-
-export class GuSSMRunCommandPolicy extends GuPolicy {
-  private static getDefaultProps(): Partial<PolicyProps> {
-    return {
-      policyName: "ssm-run-command-policy",
-      statements: [allowSSMRunCommandPolicyStatement],
-    };
-  }
-
-  constructor(scope: GuStack, id: string = "SSMRunCommandPolicy", props?: GuPolicyProps) {
+export class GuSSMRunCommandPolicy extends GuAllowPolicy {
+  constructor(scope: GuStack, id: string = "SSMRunCommandPolicy", props?: GuNoStatementsPolicyProps) {
     super(scope, id, {
-      ...GuSSMRunCommandPolicy.getDefaultProps(),
+      policyName: "ssm-run-command-policy",
+      resources: ["*"],
+      actions: [
+        "ec2messages:AcknowledgeMessage",
+        "ec2messages:DeleteMessage",
+        "ec2messages:FailMessage",
+        "ec2messages:GetEndpoint",
+        "ec2messages:GetMessages",
+        "ec2messages:SendReply",
+        "ssm:UpdateInstanceInformation",
+        "ssm:ListInstanceAssociations",
+        "ssm:DescribeInstanceProperties",
+        "ssm:DescribeDocumentParameters",
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+      ],
       ...props,
     });
   }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

`GuAllowPolicy`'s signature makes it really simple to create policies, let's use it to DRY out `GuSSMRunCommandPolicy`.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Existing tests should continue to pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

DRY.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a