### PR TITLE
feat: define the identity path once in GuStack

### DIFF
--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -2,4 +2,6 @@ export interface Identity {
   stack: string;
   stage: string;
   app: string;
+
+  identityPath: string;
 }

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -2,6 +2,7 @@ import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { Stage } from "../../constants";
 import { TrackingTag } from "../../constants/library-info";
+import type { Identity } from "./identity";
 import type { GuStageDependentValue } from "./mappings";
 import { GuStageMapping } from "./mappings";
 import type { GuParameter } from "./parameters";
@@ -42,7 +43,7 @@ export interface GuStackProps extends StackProps {
  * }
  * ```
  */
-export class GuStack extends Stack {
+export class GuStack extends Stack implements Identity {
   private readonly _stack: string;
   private readonly _app: string;
 
@@ -61,6 +62,10 @@ export class GuStack extends Stack {
 
   get app(): string {
     return this._app;
+  }
+
+  get identityPath(): string {
+    return [this.stack, this.stage, this.app].join("/");
   }
 
   // Use lazy initialisation for GuStageMapping so that Mappings block is only created when necessary

--- a/src/constructs/iam/policies/parameter-store-read.test.ts
+++ b/src/constructs/iam/policies/parameter-store-read.test.ts
@@ -32,11 +32,11 @@ describe("ParameterStoreReadPolicy", () => {
                   {
                     Ref: "AWS::AccountId",
                   },
-                  ":parameter/",
+                  ":parameter/test-stack/",
                   {
                     Ref: "Stage",
                   },
-                  "/test-stack/MyApp",
+                  "/MyApp",
                 ],
               ],
             },

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -12,9 +12,7 @@ export class GuParameterStoreReadPolicy extends GuPolicy {
         new PolicyStatement({
           effect: Effect.ALLOW,
           actions: ["ssm:GetParametersByPath"],
-          resources: [
-            `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/${scope.app}`,
-          ],
+          resources: [`arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.identityPath}`],
         }),
       ],
     };

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -17,7 +17,7 @@ export class GuGetS3ObjectPolicy extends GuAllowPolicy {
 
 export class GuGetDistributablePolicy extends GuGetS3ObjectPolicy {
   constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuNoStatementsPolicyProps) {
-    const path = [scope.stack, scope.stage, scope.app, "*"].join("/");
+    const path = [scope.identityPath, "*"].join("/");
     super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString, path });
   }
 }

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -169,11 +169,11 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
+                    ":parameter/test-stack/",
                     Object {
                       "Ref": "Stage",
                     },
-                    "/test-stack/testing",
+                    "/testing",
                   ],
                 ],
               },
@@ -425,11 +425,11 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
+                    ":parameter/test-stack/",
                     Object {
                       "Ref": "Stage",
                     },
-                    "/test-stack/testing",
+                    "/testing",
                   ],
                 ],
               },
@@ -634,11 +634,11 @@ Object {
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
+                    ":parameter/test-stack/",
                     Object {
                       "Ref": "Stage",
                     },
-                    "/test-stack/testing",
+                    "/testing",
                   ],
                 ],
               },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We're currently getting a distributable from S3 and config from Parameter Store from different paths:
- S3 is `stack/stage/app/*`
- Parameter store is `stage/stack/app`

This PR introduces `identityPath` to `GuStack` to keep things DRY and consistent.

The [simple-configuration library](https://github.com/guardian/simple-configuration#configurationloaderload) prefers `stage/stack/app` and [RIffRaff](https://github.com/guardian/riff-raff/blob/b33b49f0fea82423f0970f71d5034ba29c79e577/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala#L22) prefers `stack/stage/app`. So this I guess this PR is a conversation starter...

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - a version bump will be needed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Observe CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Consistency.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Whichever convention we choose to follow, either S3 bucket or Parameter Store layouts need to change.