### PR TITLE
refactor!: Share private config interface so it can be used by EC2 Pattern

### DIFF
--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -73,7 +73,7 @@ describe("GuUserData", () => {
         executionStatement: `dpkg -i /${stack.app}/my-app.deb`,
       },
       configuration: {
-        bucketName: new GuPrivateConfigBucketParameter(stack),
+        bucket: new GuPrivateConfigBucketParameter(stack),
         files: ["secrets.json", "application.conf"],
       },
     };

--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -3,7 +3,7 @@ import { Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../test/utils";
 import { Stage } from "../../constants";
-import { GuDistributionBucketParameter } from "../core";
+import { GuDistributionBucketParameter, GuPrivateConfigBucketParameter } from "../core";
 import { GuAutoScalingGroup } from "./asg";
 import type { GuUserDataProps } from "./user-data";
 import { GuUserData } from "./user-data";
@@ -73,7 +73,7 @@ describe("GuUserData", () => {
         executionStatement: `dpkg -i /${stack.app}/my-app.deb`,
       },
       configuration: {
-        bucketName: "test-app-config",
+        bucketName: new GuPrivateConfigBucketParameter(stack),
         files: ["secrets.json", "application.conf"],
       },
     };
@@ -99,7 +99,15 @@ describe("GuUserData", () => {
           "Fn::Join": [
             "",
             [
-              "#!/bin/bash\nmkdir -p $(dirname '/etc/testing/secrets.json')\naws s3 cp 's3://test-app-config/secrets.json' '/etc/testing/secrets.json'\nmkdir -p $(dirname '/etc/testing/application.conf')\naws s3 cp 's3://test-app-config/application.conf' '/etc/testing/application.conf'\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
+              "#!/bin/bash\nmkdir -p $(dirname '/etc/testing/secrets.json')\naws s3 cp 's3://",
+              {
+                Ref: "PrivateConfigBucketName",
+              },
+              "/secrets.json' '/etc/testing/secrets.json'\nmkdir -p $(dirname '/etc/testing/application.conf')\naws s3 cp 's3://",
+              {
+                Ref: "PrivateConfigBucketName",
+              },
+              "/application.conf' '/etc/testing/application.conf'\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
               {
                 Ref: "DistributionBucketName",
               },

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -51,14 +51,12 @@ export class GuUserData {
 
   private downloadConfiguration(scope: GuStack, props: GuPrivateS3ConfigurationProps) {
     const localDirectory = `/etc/${scope.app}`;
-    const bucketName = props.bucketName.valueAsString;
-    const files = props.files;
 
     const bucket = Bucket.fromBucketAttributes(scope, `${scope.app}ConfigurationBucket`, {
-      bucketName,
+      bucketName: props.bucket.valueAsString,
     });
 
-    files.forEach((bucketKey) => {
+    props.files.forEach((bucketKey) => {
       const fileName = bucketKey.split("/").slice(-1)[0];
 
       this.addS3DownloadCommand({

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -1,6 +1,7 @@
 import type { S3DownloadOptions } from "@aws-cdk/aws-ec2";
 import { UserData } from "@aws-cdk/aws-ec2";
 import { Bucket } from "@aws-cdk/aws-s3";
+import type { GuPrivateS3ConfigurationProps } from "../../utils/ec2";
 import type { GuDistributionBucketParameter, GuStack } from "../core";
 
 /**
@@ -14,19 +15,9 @@ export interface GuUserDataS3DistributableProps {
   executionStatement: string; // TODO can we detect this and auto generate it? Maybe from the file extension?
 }
 
-/**
- * Where to download configuration from.
- * `files` are paths from the root of the bucket.
- *   TODO change this once we have defined best practice for configuration.
- */
-export interface GuUserDataS3ConfigurationProps {
-  bucketName: string;
-  files: string[];
-}
-
 export interface GuUserDataProps {
   distributable: GuUserDataS3DistributableProps;
-  configuration?: GuUserDataS3ConfigurationProps;
+  configuration?: GuPrivateS3ConfigurationProps;
 }
 
 /**
@@ -58,9 +49,10 @@ export class GuUserData {
     });
   }
 
-  private downloadConfiguration(scope: GuStack, props: GuUserDataS3ConfigurationProps) {
+  private downloadConfiguration(scope: GuStack, props: GuPrivateS3ConfigurationProps) {
     const localDirectory = `/etc/${scope.app}`;
-    const { bucketName, files } = props;
+    const bucketName = props.bucketName.valueAsString;
+    const files = props.files;
 
     const bucket = Bucket.fromBucketAttributes(scope, `${scope.app}ConfigurationBucket`, {
       bucketName,

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -12,3 +12,15 @@ export class GuDistributionBucketParameter extends GuStringParameter {
     });
   }
 }
+
+export class GuPrivateConfigBucketParameter extends GuStringParameter {
+  public static parameterName = "PrivateConfigBucketName";
+
+  constructor(scope: GuStack, id: string = GuPrivateConfigBucketParameter.parameterName) {
+    super(scope, id, {
+      description: "SSM parameter containing the S3 bucket name holding the app's private configuration",
+      default: "/account/services/private.config.bucket",
+      fromSSM: true,
+    });
+  }
+}

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -3,13 +3,13 @@ import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import type { SynthedStack } from "../../../../test/utils";
 import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
 import { GuDistributionBucketParameter } from "../../core";
-import { GuGetDistributablePolicy, GuGetS3ObjectPolicy } from "./s3-get-object";
+import { GuGetDistributablePolicy, GuGetS3ObjectsPolicy } from "./s3-get-object";
 
 describe("The GuGetS3ObjectPolicy class", () => {
   it("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const s3Policy = new GuGetS3ObjectPolicy(stack, "S3Policy", { bucketName: "test" });
+    const s3Policy = new GuGetS3ObjectsPolicy(stack, "S3Policy", { bucketName: "test" });
 
     attachPolicyToTestRole(stack, s3Policy);
 
@@ -30,7 +30,7 @@ describe("The GuGetS3ObjectPolicy class", () => {
   it("merges defaults and passed in props", () => {
     const stack = simpleGuStackForTesting();
 
-    const s3Policy = new GuGetS3ObjectPolicy(stack, "S3Policy", { bucketName: "test", policyName: "test" });
+    const s3Policy = new GuGetS3ObjectsPolicy(stack, "S3Policy", { bucketName: "test", policyName: "test" });
 
     attachPolicyToTestRole(stack, s3Policy);
 
@@ -42,6 +42,30 @@ describe("The GuGetS3ObjectPolicy class", () => {
           {
             Effect: "Allow",
             Resource: "arn:aws:s3:::test/*",
+            Action: "s3:GetObject",
+          },
+        ],
+      },
+    });
+  });
+
+  it("handles multiple paths correctly", () => {
+    const stack = simpleGuStackForTesting();
+
+    const s3Policy = new GuGetS3ObjectsPolicy(stack, "S3Policy", {
+      bucketName: "test",
+      paths: ["file1.txt", "file2.txt"],
+    });
+
+    attachPolicyToTestRole(stack, s3Policy);
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Resource: ["arn:aws:s3:::test/file1.txt", "arn:aws:s3:::test/file2.txt"],
             Action: "s3:GetObject",
           },
         ],

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -24,8 +24,8 @@ export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
   }
 }
 
-export class GuGetPrivateConfigFilePolicy extends GuGetS3ObjectsPolicy {
+export class GuGetPrivateConfigPolicy extends GuGetS3ObjectsPolicy {
   constructor(scope: GuStack, id: string, props: GuPrivateS3ConfigurationProps) {
-    super(scope, id, { bucketName: new GuDistributionBucketParameter(scope).valueAsString, paths: props.files });
+    super(scope, id, { bucketName: props.bucket.valueAsString, paths: props.files });
   }
 }

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,3 +1,4 @@
+import type { GuPrivateS3ConfigurationProps } from "../../../utils/ec2";
 import type { GuStack } from "../../core";
 import { GuDistributionBucketParameter } from "../../core";
 import type { GuNoStatementsPolicyProps } from "./base-policy";
@@ -5,19 +6,26 @@ import { GuAllowPolicy } from "./base-policy";
 
 export interface GuGetS3ObjectPolicyProps extends GuNoStatementsPolicyProps {
   bucketName: string;
-  path?: string;
+  paths?: string[];
 }
 
-export class GuGetS3ObjectPolicy extends GuAllowPolicy {
+export class GuGetS3ObjectsPolicy extends GuAllowPolicy {
   constructor(scope: GuStack, id: string, props: GuGetS3ObjectPolicyProps) {
-    const path: string = props.path ?? "*";
-    super(scope, id, { ...props, actions: ["s3:GetObject"], resources: [`arn:aws:s3:::${props.bucketName}/${path}`] });
+    const paths: string[] = props.paths ?? ["*"];
+    const s3Resources: string[] = paths.map((path) => `arn:aws:s3:::${props.bucketName}/${path}`);
+    super(scope, id, { ...props, actions: ["s3:GetObject"], resources: s3Resources });
   }
 }
 
-export class GuGetDistributablePolicy extends GuGetS3ObjectPolicy {
+export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
   constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuNoStatementsPolicyProps) {
     const path = [scope.stack, scope.stage, scope.app, "*"].join("/");
-    super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString, path });
+    super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString, paths: [path] });
+  }
+}
+
+export class GuGetPrivateConfigFilePolicy extends GuGetS3ObjectsPolicy {
+  constructor(scope: GuStack, id: string, props: GuPrivateS3ConfigurationProps) {
+    super(scope, id, { bucketName: new GuDistributionBucketParameter(scope).valueAsString, paths: props.files });
   }
 }

--- a/src/constructs/iam/roles/instance-role.test.ts
+++ b/src/constructs/iam/roles/instance-role.test.ts
@@ -1,7 +1,7 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { simpleGuStackForTesting } from "../../../../test/utils";
-import { GuGetS3ObjectPolicy } from "../policies";
+import { GuGetS3ObjectsPolicy } from "../policies";
 import { GuInstanceRole } from "./instance-role";
 
 describe("The GuInstanceRole construct", () => {
@@ -28,7 +28,7 @@ describe("The GuInstanceRole construct", () => {
 
     new GuInstanceRole(stack, "GuInstanceRole", {
       withoutLogShipping: true,
-      additionalPolicies: [new GuGetS3ObjectPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
+      additionalPolicies: [new GuGetS3ObjectsPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
     });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();

--- a/src/utils/ec2/index.ts
+++ b/src/utils/ec2/index.ts
@@ -1,0 +1,1 @@
+export * from "./private-config";

--- a/src/utils/ec2/private-config.ts
+++ b/src/utils/ec2/private-config.ts
@@ -6,6 +6,6 @@ import type { GuPrivateConfigBucketParameter } from "../../constructs/core";
  *   TODO change this once we have defined best practice for configuration.
  */
 export interface GuPrivateS3ConfigurationProps {
-  bucketName: GuPrivateConfigBucketParameter;
+  bucket: GuPrivateConfigBucketParameter;
   files: string[];
 }

--- a/src/utils/ec2/private-config.ts
+++ b/src/utils/ec2/private-config.ts
@@ -1,0 +1,11 @@
+import type { GuPrivateConfigBucketParameter } from "../../constructs/core";
+
+/**
+ * Information about an ec2 app's private configuration.
+ * `files` are paths from the root of the bucket.
+ *   TODO change this once we have defined best practice for configuration.
+ */
+export interface GuPrivateS3ConfigurationProps {
+  bucketName: GuPrivateConfigBucketParameter;
+  files: string[];
+}


### PR DESCRIPTION
## What does this change?

This refactor allows us to specify information about private configuration at the pattern-level. It seems necessary to do this because two separate constructs (`GuUserData` and `GuInstanceRole`) both need this same information. Similarly, we want users to pass the private config bucket name in via a parameter (we don't want bucket names in public GitHub repos) and we must only define this parameter once.

### How will this work in the context of the pattern?

The EC2 app pattern props will take `privateS3Configuration` as an optional prop:

```typescript
export interface GuEc2AppProps {
    privateS3Configuration?: GuPrivateS3ConfigurationProps
    // other props
}
```

If this prop is defined, we'll be able to wire it through into `GuUserData`. We'll also be able to create the appropriate IAM policies via `GuInstanceRole`'s `additionalPolicies` prop e.g.

```typescript
const additionalPolicies = privateS3Configuration ? [new GuGetPrivateConfigPolicy(this, "GetPrivateConfigFromS3Policy", privateS3Configuration)] : undefined 
new GuInstanceRole(stack, "GuInstanceRole", { additionalPolicies: additionalPolicies });
```

A single CFN parameter will be created and accessed via both constructs.

## Does this change require changes to existing projects or CDK CLI?

No, I don't think so.

## How to test

I've tested this by updating a stack to use my local version of this change - it seems to build a sensible looking template! We will need to test this more thoroughly as part of the EC2 Pattern work.

## How can we measure success?

Users (will) only need to specify information about private config in one place. After this refactor, we should be able to easily wire up permissions and user-data, if necessary (see examples above).

## Have we considered potential risks?

I can't think of any in this context.