### PR TITLE
refactor: Move security groups util code

### DIFF
--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -1,6 +1,6 @@
 import type { CfnSecurityGroup, IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { Peer, Port, SecurityGroup } from "@aws-cdk/aws-ec2";
-import { transformToCidrIngress } from "../../utils";
+import { transformToCidrIngress } from "../../utils/security-groups";
 import type { GuStack } from "../core";
 
 export interface CidrIngress {

--- a/src/utils/security-groups/helpers.test.ts
+++ b/src/utils/security-groups/helpers.test.ts
@@ -1,5 +1,5 @@
 import { Peer } from "@aws-cdk/aws-ec2";
-import { transformToCidrIngress } from "./index";
+import { transformToCidrIngress } from "./helpers";
 
 describe("The transformToCidrIngress", () => {
   const expected = [

--- a/src/utils/security-groups/helpers.ts
+++ b/src/utils/security-groups/helpers.ts
@@ -1,5 +1,5 @@
 import { Peer } from "@aws-cdk/aws-ec2";
-import type { CidrIngress } from "../constructs/ec2";
+import type { CidrIngress } from "../../constructs/ec2";
 
 export const transformToCidrIngress = (ingresses: Array<[string, string]>): CidrIngress[] => {
   return ingresses.map(([key, value]) => {

--- a/src/utils/security-groups/index.ts
+++ b/src/utils/security-groups/index.ts
@@ -1,0 +1,1 @@
+export * from "./helpers";


### PR DESCRIPTION
## What does this change?

We [now have code related to different constructs/patterns](https://github.com/guardian/cdk/pull/296#discussion_r590455719) in `utils`, so the code related to security groups is better placed in its own subdirectory.