### PR TITLE
docs: Fix documentation for utils directory

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -1,16 +1,19 @@
 const { readdirSync } = require("fs");
 
 const constructsDir = "src/constructs";
+const utilsDir = "src/utils";
+
+function getEntryPointsFromSubdirectories(directory) {
+  return readdirSync(directory).map((dir) => `${directory}/${dir}/index.ts`);
+}
 
 module.exports = {
   entryPoints: [
     "src/index.ts",
     "src/constants/index.ts",
-    "src/utils/index.ts",
-
-    // we purposefully do not have an index.ts in `src/constructs` to encourage usage of patterns
-    // list sub directories for tsdoc to generate documentation for the constructs
-    ...readdirSync(constructsDir).map((dir) => `${constructsDir}/${dir}/index.ts`),
+    // we purposefully do not have an index.ts in `src/constructs` or `src/utils`
+    ...getEntryPointsFromSubdirectories(constructsDir),
+    ...getEntryPointsFromSubdirectories(utilsDir),
   ],
   out: "target",
   includeVersion: true,


### PR DESCRIPTION
## What does this change?

This fixes the documentation for all code in the `utils` directory, which was broken by https://github.com/guardian/cdk/pull/315 (and overlooked when implementing https://github.com/guardian/cdk/pull/296/commits/6672cce9b712fbfb5a035d6df033ddc499c0b04c).

## Does this change require changes to existing projects or CDK CLI?
No

## How to test
Run `./script/docs` and confirm that everything works as expected.

## How can we measure success?
There should be no missing docs/broken links after merging this change.

## Have we considered potential risks?
N/A
