### PR TITLE
refactor: create a simpler interface for defining security group rules

### DIFF
--- a/src/constructs/ec2/security-group.test.ts
+++ b/src/constructs/ec2/security-group.test.ts
@@ -188,11 +188,11 @@ describe("The GuPublicInternetAccessSecurityGroup class", () => {
     });
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "Allows internet access on 443",
+      GroupDescription: "Allow all inbound traffic via HTTPS",
       SecurityGroupIngress: [
         {
           CidrIp: "0.0.0.0/0",
-          Description: "Allows internet access on 443",
+          Description: "Allow all inbound traffic via HTTPS",
           FromPort: 443,
           IpProtocol: "tcp",
           ToPort: 443,
@@ -215,11 +215,11 @@ describe("The GuHttpsEgressSecurityGroup class", () => {
     GuHttpsEgressSecurityGroup.forVpc(stack, { vpc });
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "Allow all outbound traffic on port 443",
+      GroupDescription: "Allow all outbound HTTPS traffic",
       SecurityGroupEgress: [
         {
           CidrIp: "0.0.0.0/0",
-          Description: "Allow all outbound traffic on port 443",
+          Description: "Allow all outbound HTTPS traffic",
           FromPort: 443,
           IpProtocol: "tcp",
           ToPort: 443,

--- a/src/constructs/ec2/security-group.test.ts
+++ b/src/constructs/ec2/security-group.test.ts
@@ -42,8 +42,8 @@ describe("The GuSecurityGroup class", () => {
     new GuSecurityGroup(stack, "TestSecurityGroup", {
       vpc,
       ingresses: [
-        { range: Peer.ipv4("127.0.0.1/24"), description: "ingress1" },
-        { range: Peer.ipv4("127.0.0.2/8"), description: "ingress2" },
+        { range: Peer.ipv4("127.0.0.1/24"), description: "ingress1", port: 443 },
+        { range: Peer.ipv4("127.0.0.2/8"), description: "ingress2", port: 443 },
       ],
     });
 
@@ -181,7 +181,7 @@ describe("The GuPublicInternetAccessSecurityGroup class", () => {
       SecurityGroupIngress: [
         {
           CidrIp: "0.0.0.0/0",
-          Description: "GLOBAL_ACCESS",
+          Description: "Allows internet access on 443",
           FromPort: 443,
           IpProtocol: "tcp",
           ToPort: 443,
@@ -208,7 +208,7 @@ describe("The GuHttpsEgressSecurityGroup class", () => {
       SecurityGroupEgress: [
         {
           CidrIp: "0.0.0.0/0",
-          Description: "from 0.0.0.0/0:443",
+          Description: "Allow all outbound traffic on port 443",
           FromPort: 443,
           IpProtocol: "tcp",
           ToPort: 443,

--- a/src/constructs/ec2/security-group.test.ts
+++ b/src/constructs/ec2/security-group.test.ts
@@ -98,6 +98,17 @@ describe("The GuSecurityGroup class", () => {
       ],
     });
   });
+
+  it("should not allow an ingress rule for port 22", () => {
+    const stack = simpleGuStackForTesting();
+
+    expect(() => {
+      new GuSecurityGroup(stack, "TestSecurityGroup", {
+        vpc,
+        ingresses: [{ range: Peer.anyIpv4(), description: "SSH access", port: 22 }],
+      });
+    }).toThrow(new Error("An ingress rule on port 22 is not allowed. Prefer to setup SSH via SSM."));
+  });
 });
 
 describe("The GuWazuhAccess class", () => {

--- a/src/constructs/ec2/security-group.test.ts
+++ b/src/constructs/ec2/security-group.test.ts
@@ -128,14 +128,14 @@ describe("The GuWazuhAccess class", () => {
       SecurityGroupEgress: [
         {
           CidrIp: "0.0.0.0/0",
-          Description: "wazuh event logging",
+          Description: "Wazuh event logging",
           FromPort: 1514,
           IpProtocol: "tcp",
           ToPort: 1514,
         },
         {
           CidrIp: "0.0.0.0/0",
-          Description: "wazuh agent registration",
+          Description: "Wazuh agent registration",
           FromPort: 1515,
           IpProtocol: "tcp",
           ToPort: 1515,

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -33,6 +33,16 @@ export interface GuSecurityGroupProps extends SecurityGroupProps {
   egresses?: SecurityGroupAccessRule[];
 }
 
+/**
+ * Defining an AWS Security Group with ingress and egress rules.
+ *
+ * An ingress rule on port 22 is strictly forbidden as SSH via SSM is preferred.
+ *
+ * Prefer to use a concrete implementation where possible. See:
+ * - [[GuWazuhAccess]]
+ * - [[GuPublicInternetAccessSecurityGroup]]
+ * - [[GuHttpsEgressSecurityGroup]]
+ */
 export class GuSecurityGroup extends SecurityGroup {
   constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
     super(scope, id, props);

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -65,8 +65,8 @@ export class GuWazuhAccess extends GuSecurityGroup {
       overrideId: true,
       allowAllOutbound: false,
       egresses: [
-        { range: Peer.anyIpv4(), port: 1514, description: "wazuh event logging" },
-        { range: Peer.anyIpv4(), port: 1515, description: "wazuh agent registration" },
+        { range: Peer.anyIpv4(), port: 1514, description: "Wazuh event logging" },
+        { range: Peer.anyIpv4(), port: 1515, description: "Wazuh agent registration" },
       ],
     };
   }

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -93,8 +93,8 @@ export class GuPublicInternetAccessSecurityGroup extends GuSecurityGroup {
   constructor(scope: GuStack, id: string, props: SecurityGroupProps) {
     super(scope, id, {
       ...props,
-      ingresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allows internet access on 443" }],
-      description: "Allows internet access on 443",
+      ingresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allow all inbound traffic via HTTPS" }],
+      description: "Allow all inbound traffic via HTTPS",
     });
   }
 }
@@ -104,8 +104,8 @@ export class GuHttpsEgressSecurityGroup extends GuSecurityGroup {
     super(scope, id, {
       vpc: props.vpc,
       allowAllOutbound: false,
-      description: "Allow all outbound traffic on port 443",
-      egresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allow all outbound traffic on port 443" }],
+      description: "Allow all outbound HTTPS traffic",
+      egresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allow all outbound HTTPS traffic" }],
     });
   }
 

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -44,6 +44,10 @@ export class GuSecurityGroup extends SecurityGroup {
     props.ingresses?.forEach(({ range, port, description }) => {
       const connection: Port = typeof port === "number" ? Port.tcp(port) : port;
 
+      if (connection.toString() === "22") {
+        throw new Error("An ingress rule on port 22 is not allowed. Prefer to setup SSH via SSM.");
+      }
+
       this.addIngressRule(range, connection, description);
     });
 

--- a/src/constructs/ec2/security-groups.ts
+++ b/src/constructs/ec2/security-groups.ts
@@ -1,28 +1,39 @@
 import type { CfnSecurityGroup, IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { Peer, Port, SecurityGroup } from "@aws-cdk/aws-ec2";
-import { transformToCidrIngress } from "../../utils/security-groups";
 import type { GuStack } from "../core";
 
-export interface CidrIngress {
+/**
+ * A way to describe an ingress or egress rule for a security group.
+ *
+ * See [[transformToSecurityGroupAccessRule]] for a handy helper function.
+ */
+export interface SecurityGroupAccessRule {
+  /**
+   * The CIDR address for this rule.
+   * Use `Peer.anyIpv4()` for global access.
+   */
   range: IPeer;
-  description: string;
-}
 
-export interface CidrEgress {
-  range: IPeer;
-  port: Port;
-  description?: string;
+  /**
+   * The port to open in a security group.
+   * The default protocol is TCP.
+   * Use `Port.udp(port)` for the UDP protocol.
+   */
+  port: number | Port;
+
+  /**
+   * A short explanation for this rule.
+   */
+  description: string;
 }
 
 export interface GuSecurityGroupProps extends SecurityGroupProps {
   overrideId?: boolean;
-  ingresses?: CidrIngress[];
-  egresses?: CidrEgress[];
+  ingresses?: SecurityGroupAccessRule[];
+  egresses?: SecurityGroupAccessRule[];
 }
 
 export class GuSecurityGroup extends SecurityGroup {
-  static defaultIngressPort = Port.tcp(443);
-
   constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
     super(scope, id, props);
 
@@ -30,13 +41,16 @@ export class GuSecurityGroup extends SecurityGroup {
       (this.node.defaultChild as CfnSecurityGroup).overrideLogicalId(id);
     }
 
-    props.ingresses?.forEach(({ range, description }) =>
-      this.addIngressRule(range, GuSecurityGroup.defaultIngressPort, description)
-    );
+    props.ingresses?.forEach(({ range, port, description }) => {
+      const connection: Port = typeof port === "number" ? Port.tcp(port) : port;
 
-    props.egresses?.forEach(({ range, description, port }) =>
-      this.addEgressRule(range, port, description ?? undefined)
-    );
+      this.addIngressRule(range, connection, description);
+    });
+
+    props.egresses?.forEach(({ range, port, description }) => {
+      const connection: Port = typeof port === "number" ? Port.tcp(port) : port;
+      this.addEgressRule(range, connection, description);
+    });
   }
 }
 
@@ -47,8 +61,8 @@ export class GuWazuhAccess extends GuSecurityGroup {
       overrideId: true,
       allowAllOutbound: false,
       egresses: [
-        { range: Peer.anyIpv4(), port: Port.tcp(1514), description: "wazuh event logging" },
-        { range: Peer.anyIpv4(), port: Port.tcp(1515), description: "wazuh agent registration" },
+        { range: Peer.anyIpv4(), port: 1514, description: "wazuh event logging" },
+        { range: Peer.anyIpv4(), port: 1515, description: "wazuh agent registration" },
       ],
     };
   }
@@ -65,8 +79,8 @@ export class GuPublicInternetAccessSecurityGroup extends GuSecurityGroup {
   constructor(scope: GuStack, id: string, props: SecurityGroupProps) {
     super(scope, id, {
       ...props,
-      ingresses: transformToCidrIngress(Object.entries({ GLOBAL_ACCESS: "0.0.0.0/0" })),
-      description: `Allows internet access on ${GuPublicInternetAccessSecurityGroup.defaultIngressPort.toString()}`,
+      ingresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allows internet access on 443" }],
+      description: "Allows internet access on 443",
     });
   }
 }
@@ -77,7 +91,7 @@ export class GuHttpsEgressSecurityGroup extends GuSecurityGroup {
       vpc: props.vpc,
       allowAllOutbound: false,
       description: "Allow all outbound traffic on port 443",
-      egresses: [{ range: Peer.anyIpv4(), port: Port.tcp(443) }],
+      egresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allow all outbound traffic on port 443" }],
     });
   }
 

--- a/src/utils/security-groups/helpers.test.ts
+++ b/src/utils/security-groups/helpers.test.ts
@@ -1,15 +1,17 @@
 import { Peer } from "@aws-cdk/aws-ec2";
-import { transformToCidrIngress } from "./helpers";
+import { transformToSecurityGroupAccessRule } from "./helpers";
 
-describe("The transformToCidrIngress", () => {
+describe("The transformToSecurityGroupAccessRule", () => {
   const expected = [
     {
       range: Peer.ipv4("127.0.0.1/32"),
       description: "One",
+      port: 443,
     },
     {
       range: Peer.ipv4("127.0.0.2/32"),
       description: "Two",
+      port: 443,
     },
   ];
   test("correctly transforms objects", () => {
@@ -18,7 +20,7 @@ describe("The transformToCidrIngress", () => {
       Two: "127.0.0.2/32",
     };
 
-    expect(transformToCidrIngress(Object.entries(ingresses))).toStrictEqual(expected);
+    expect(transformToSecurityGroupAccessRule(Object.entries(ingresses), 443)).toStrictEqual(expected);
   });
 
   test("correctly transforms enums", () => {
@@ -27,6 +29,6 @@ describe("The transformToCidrIngress", () => {
       Two = "127.0.0.2/32",
     }
 
-    expect(transformToCidrIngress(Object.entries(Ingresses))).toStrictEqual(expected);
+    expect(transformToSecurityGroupAccessRule(Object.entries(Ingresses), 443)).toStrictEqual(expected);
   });
 });

--- a/src/utils/security-groups/helpers.ts
+++ b/src/utils/security-groups/helpers.ts
@@ -1,11 +1,16 @@
+import type { Port } from "@aws-cdk/aws-ec2";
 import { Peer } from "@aws-cdk/aws-ec2";
-import type { CidrIngress } from "../../constructs/ec2";
+import type { SecurityGroupAccessRule } from "../../constructs/ec2";
 
-export const transformToCidrIngress = (ingresses: Array<[string, string]>): CidrIngress[] => {
-  return ingresses.map(([key, value]) => {
+export const transformToSecurityGroupAccessRule = (
+  cidrBlocks: Array<[string, string]>,
+  port: Port | number
+): SecurityGroupAccessRule[] => {
+  return cidrBlocks.map(([key, value]) => {
     return {
       range: Peer.ipv4(value),
       description: key,
+      port,
     };
   });
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This hopefully creates a simpler interface to defining security group ingress and egress rules. Now, to define an ingress or egress rule we provide a `SecurityGroupAccessRule`.

`SecurityGroupAccessRule` has three mandatory fields:
1. `range` which is the CIDR range
2. `port` which is the port number and protocol (tcp by default)
3. `description` to provide some useful information to the reader viewing the security group in the AWS console

Example usage:

```typescript
new GuSecurityGroup(stack, "FtpAccessSecurityGroup", {
  vpc,
  ingresses: [
    { range: Peer.anyIpv4(), port: 21, description: "Allow FTP access from the world" },
  ],
});
```

BREAKING CHANGES:
`CidrIngress` and `CidrEgress` have been removed in favour of a single `SecurityGroupAccessRule`. This change forces a description to be provided for every rule as it makes it easier to reason about in the AWS console. 

It also changes the type of `port` to `number | Port` - if you provide a `number` the protocol will default to `TCP` as this is the most common use-case. This should provide a simpler API.

`transformToCidrIngress` is renamed to `transformToSecurityGroupAccessRule` as it's not longer tied to ingress rules.

Port 22 is completely forbidden as SSH over SSM is preferred.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - some types and function names have changed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See existing tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler API.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a