### PR TITLE
feat!: Tag support for a stack with multiple apps

### DIFF
--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -17,12 +17,14 @@ describe("GuUserData", () => {
 
   test("Distributable should be downloaded from a standard path in S3 (bucket/stack/stage/app/filename)", () => {
     const stack = simpleGuStackForTesting();
+    const app = "testing";
 
     const props: GuUserDataProps = {
+      app,
       distributable: {
         bucket: new GuDistributionBucketParameter(stack),
         fileName: "my-app.deb",
-        executionStatement: `dpkg -i /${stack.app}/my-app.deb`,
+        executionStatement: `dpkg -i /${app}/my-app.deb`,
       },
     };
 
@@ -39,6 +41,7 @@ describe("GuUserData", () => {
           minimumInstances: 3,
         },
       },
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
@@ -65,12 +68,14 @@ describe("GuUserData", () => {
 
   test("Distributable should download configuration first", () => {
     const stack = simpleGuStackForTesting();
+    const app = "testing";
 
     const props: GuUserDataProps = {
+      app,
       distributable: {
         bucket: new GuDistributionBucketParameter(stack),
         fileName: "my-app.deb",
-        executionStatement: `dpkg -i /${stack.app}/my-app.deb`,
+        executionStatement: `dpkg -i /${app}/my-app.deb`,
       },
       configuration: {
         bucket: new GuPrivateConfigBucketParameter(stack),
@@ -91,6 +96,7 @@ describe("GuUserData", () => {
           minimumInstances: 3,
         },
       },
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -12,6 +12,7 @@ describe("The GuAlarm class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
     new GuAlarm(stack, "alarm", {
       alarmName: `Alarm in ${stack.stage}`,
@@ -31,6 +32,7 @@ describe("The GuAlarm class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
     new GuAlarm(stack, "alarm", {
       alarmName: `Alarm in ${stack.stage}`,

--- a/src/constructs/cloudwatch/lambda-alarms.test.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.test.ts
@@ -12,6 +12,7 @@ describe("The GuLambdaErrorPercentageAlarm pattern", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
     const props = {
       toleratedErrorPercentage: 80,
@@ -28,6 +29,7 @@ describe("The GuLambdaErrorPercentageAlarm pattern", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
     const props = {
       toleratedErrorPercentage: 65,
@@ -47,6 +49,7 @@ describe("The GuLambdaErrorPercentageAlarm pattern", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
     const props = {
       toleratedErrorPercentage: 65,
@@ -67,6 +70,7 @@ describe("The GuLambdaErrorPercentageAlarm pattern", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
     const props = {
       toleratedErrorPercentage: 65,

--- a/src/constructs/core/identity.test.ts
+++ b/src/constructs/core/identity.test.ts
@@ -30,15 +30,15 @@ describe("AppIdentity.suffixText", () => {
   });
 });
 
-describe("AppIdentity.addTag", () => {
+describe("AppIdentity.taggedConstruct", () => {
   it("should apply a tag to a resource", () => {
-    // not using any Gu constructs to purely test the impact of AppIdentity.addTag
+    // not using any Gu constructs to purely test the impact of AppIdentity.taggedConstruct
     const stack = new Stack();
 
     const snsTopic = new Topic(stack, "myTopic");
     const appIdentity: AppIdentity = { app: "testing" };
 
-    AppIdentity.addTag(appIdentity, snsTopic);
+    AppIdentity.taggedConstruct(appIdentity, snsTopic);
 
     expect(stack).toHaveResource("AWS::SNS::Topic", {
       Tags: alphabeticalTags([

--- a/src/constructs/core/identity.test.ts
+++ b/src/constructs/core/identity.test.ts
@@ -1,3 +1,7 @@
+import "@aws-cdk/assert/jest";
+import { Topic } from "@aws-cdk/aws-sns";
+import { Stack } from "@aws-cdk/core";
+import { alphabeticalTags } from "../../../test/utils";
 import { AppIdentity } from "./identity";
 
 describe("AppIdentity.suffixText", () => {
@@ -23,5 +27,26 @@ describe("AppIdentity.suffixText", () => {
     const actual = AppIdentity.suffixText({ app: "my-app" }, "InstanceType");
     const expected = "InstanceTypeMy-app";
     expect(actual).toEqual(expected);
+  });
+});
+
+describe("AppIdentity.addTag", () => {
+  it("should apply a tag to a resource", () => {
+    // not using any Gu constructs to purely test the impact of AppIdentity.addTag
+    const stack = new Stack();
+
+    const snsTopic = new Topic(stack, "myTopic");
+    const appIdentity: AppIdentity = { app: "testing" };
+
+    AppIdentity.addTag(appIdentity, snsTopic);
+
+    expect(stack).toHaveResource("AWS::SNS::Topic", {
+      Tags: alphabeticalTags([
+        {
+          Key: "App",
+          Value: "testing",
+        },
+      ]),
+    });
   });
 });

--- a/src/constructs/core/identity.test.ts
+++ b/src/constructs/core/identity.test.ts
@@ -1,0 +1,27 @@
+import { AppIdentity } from "./identity";
+
+describe("AppIdentity.suffixText", () => {
+  it("should title case the app before suffixing it", () => {
+    const actual = AppIdentity.suffixText({ app: "myapp" }, "InstanceType");
+    const expected = "InstanceTypeMyapp";
+    expect(actual).toEqual(expected);
+  });
+
+  it("should work with title case input", () => {
+    const actual = AppIdentity.suffixText({ app: "MyApp" }, "InstanceType");
+    const expected = "InstanceTypeMyApp";
+    expect(actual).toEqual(expected);
+  });
+
+  it("should work with uppercase input", () => {
+    const actual = AppIdentity.suffixText({ app: "MYAPP" }, "InstanceType");
+    const expected = "InstanceTypeMYAPP";
+    expect(actual).toEqual(expected);
+  });
+
+  it("should handle hyphens", () => {
+    const actual = AppIdentity.suffixText({ app: "my-app" }, "InstanceType");
+    const expected = "InstanceTypeMy-app";
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -1,5 +1,10 @@
-export interface Identity {
+export interface StackStageIdentity {
   stack: string;
   stage: string;
+}
+
+export interface AppIdentity {
   app: string;
 }
+
+export interface Identity extends StackStageIdentity, AppIdentity {}

--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -17,7 +17,7 @@ export const AppIdentity = {
     const titleCaseApp = appIdentity.app.charAt(0).toUpperCase() + appIdentity.app.slice(1);
     return `${text}${titleCaseApp}`;
   },
-  addTag<T extends IConstruct>(appIdentity: AppIdentity, construct: T): T {
+  taggedConstruct<T extends IConstruct>(appIdentity: AppIdentity, construct: T): T {
     Tags.of(construct).add("App", appIdentity.app);
     return construct;
   },

--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -1,3 +1,6 @@
+import type { IConstruct } from "@aws-cdk/core";
+import { Tags } from "@aws-cdk/core";
+
 export interface StackStageIdentity {
   stack: string;
   stage: string;
@@ -13,5 +16,9 @@ export const AppIdentity = {
   suffixText(appIdentity: AppIdentity, text: string): string {
     const titleCaseApp = appIdentity.app.charAt(0).toUpperCase() + appIdentity.app.slice(1);
     return `${text}${titleCaseApp}`;
+  },
+  addTag<T extends IConstruct>(appIdentity: AppIdentity, construct: T): T {
+    Tags.of(construct).add("App", appIdentity.app);
+    return construct;
   },
 };

--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -8,3 +8,10 @@ export interface AppIdentity {
 }
 
 export interface Identity extends StackStageIdentity, AppIdentity {}
+
+export const AppIdentity = {
+  suffixText(appIdentity: AppIdentity, text: string): string {
+    const titleCaseApp = appIdentity.app.charAt(0).toUpperCase() + appIdentity.app.slice(1);
+    return `${text}${titleCaseApp}`;
+  },
+};

--- a/src/constructs/core/parameters/base.ts
+++ b/src/constructs/core/parameters/base.ts
@@ -1,6 +1,7 @@
 import type { CfnParameterProps } from "@aws-cdk/core";
 import { CfnParameter } from "@aws-cdk/core";
 import { RegexPattern } from "../../../constants";
+import type { AppIdentity } from "../identity";
 import type { GuStack } from "../stack";
 
 export interface GuParameterProps extends CfnParameterProps {
@@ -8,6 +9,7 @@ export interface GuParameterProps extends CfnParameterProps {
 }
 
 export type GuNoTypeParameterProps = Omit<GuParameterProps, "type">;
+export type GuNoTypeParameterPropsWithAppIdentity = Omit<GuParameterProps, "type"> & AppIdentity;
 
 export class GuParameter extends CfnParameter {
   public readonly id: string;

--- a/src/constructs/core/parameters/ec2.test.ts
+++ b/src/constructs/core/parameters/ec2.test.ts
@@ -2,19 +2,19 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import type { SynthedStack } from "../../../../test/utils";
 import { simpleGuStackForTesting } from "../../../../test/utils";
-import { GuAmiParameter, GuInstanceTypeParameter } from "./ec2";
+import { GuInstanceTypeParameter } from "./ec2";
 
 describe("The GuInstanceTypeParameter class", () => {
   it("should combine default, override and prop values", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuInstanceTypeParameter(stack, "Parameter", { allowedValues: ["t3.small"] });
+    new GuInstanceTypeParameter(stack, { allowedValues: ["t3.small"], app: "testing" });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
-    expect(json.Parameters.Parameter).toEqual({
+    expect(json.Parameters[`InstanceTypeTesting`]).toEqual({
       Type: "String",
-      Description: "EC2 Instance Type",
+      Description: "EC2 Instance Type for the app testing",
       Default: "t3.small",
       AllowedValues: ["t3.small"],
     });
@@ -23,32 +23,18 @@ describe("The GuInstanceTypeParameter class", () => {
   it("let's you override the default values", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuInstanceTypeParameter(stack, "Parameter", {
+    new GuInstanceTypeParameter(stack, {
       description: "This is a test",
       default: 1,
+      app: "testing",
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
-    expect(json.Parameters.Parameter).toEqual({
+    expect(json.Parameters["InstanceTypeTesting"]).toEqual({
       Type: "String",
       Description: "This is a test",
       Default: 1,
-    });
-  });
-});
-
-describe("The GuAmiParameter class", () => {
-  it("should combine override and prop values", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuAmiParameter(stack, "Parameter", { description: "This is a test" });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters.Parameter).toEqual({
-      Type: "AWS::EC2::Image::Id",
-      Description: "This is a test",
     });
   });
 });

--- a/src/constructs/core/parameters/ec2.ts
+++ b/src/constructs/core/parameters/ec2.ts
@@ -1,12 +1,14 @@
+import { AppIdentity } from "../identity";
 import type { GuStack } from "../stack";
-import type { GuNoTypeParameterProps } from "./base";
+import type { GuNoTypeParameterPropsWithAppIdentity } from "./base";
 import { GuParameter } from "./base";
 
 export class GuInstanceTypeParameter extends GuParameter {
-  constructor(scope: GuStack, id: string = "InstanceType", props?: GuNoTypeParameterProps) {
-    super(scope, id, {
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  constructor(scope: GuStack, props: GuNoTypeParameterPropsWithAppIdentity) {
+    super(scope, AppIdentity.suffixText(props, "InstanceType"), {
       type: "String",
-      description: "EC2 Instance Type",
+      description: `EC2 Instance Type for the app ${props.app}`,
       default: "t3.small",
       ...props,
     });
@@ -14,10 +16,11 @@ export class GuInstanceTypeParameter extends GuParameter {
 }
 
 export class GuAmiParameter extends GuParameter {
-  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
-    super(scope, id, {
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  constructor(scope: GuStack, props: GuNoTypeParameterPropsWithAppIdentity) {
+    super(scope, AppIdentity.suffixText(props, "AMI"), {
       type: "AWS::EC2::Image::Id",
-      description: "Amazon Machine Image ID. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      description: `Amazon Machine Image ID for the app ${props.app}. Use this in conjunction with AMIgo to keep AMIs up to date.`,
       ...props,
     });
   }

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -31,8 +31,8 @@ describe("The GuStack construct", () => {
     });
   });
 
-  it("should apply the stack, stage and app tags to resources added to it", () => {
-    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
+  it("should apply the stack and stage tags to resources added to it", () => {
+    const stack = new GuStack(new App(), "Test", { stack: "test" });
 
     new Role(stack, "MyRole", {
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
@@ -40,10 +40,6 @@ describe("The GuStack construct", () => {
 
     expect(stack).toHaveResource("AWS::IAM::Role", {
       Tags: alphabeticalTags([
-        {
-          Key: "App",
-          Value: "MyApp",
-        },
         {
           Key: "Stack",
           Value: "test",
@@ -59,14 +55,8 @@ describe("The GuStack construct", () => {
     });
   });
 
-  it("should return the correct app value when app is set", () => {
-    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
-
-    expect(stack.app).toBe("MyApp");
-  });
-
   it("should return a parameter that exists", () => {
-    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
+    const stack = new GuStack(new App(), "Test", { stack: "test" });
     const testParam = new GuParameter(stack, "MyTestParam", {});
     stack.setParam(testParam);
 
@@ -75,7 +65,7 @@ describe("The GuStack construct", () => {
   });
 
   it("should throw on attempt to get a parameter that doesn't exist", () => {
-    const stack = new GuStack(new App(), "Test", { app: "MyApp", stack: "test" });
+    const stack = new GuStack(new App(), "Test", { stack: "test" });
 
     expect(() => stack.getParam<GuParameter>("i-do-not-exist")).toThrowError(
       "Attempting to read parameter i-do-not-exist which does not exist"

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -2,15 +2,13 @@ import type { App, StackProps } from "@aws-cdk/core";
 import { Stack, Tags } from "@aws-cdk/core";
 import { Stage } from "../../constants";
 import { TrackingTag } from "../../constants/library-info";
+import type { StackStageIdentity } from "./identity";
 import type { GuStageDependentValue } from "./mappings";
 import { GuStageMapping } from "./mappings";
 import type { GuParameter } from "./parameters";
 import { GuStageParameter } from "./parameters";
 
 export interface GuStackProps extends StackProps {
-  // This limits GuStack to supporting a single app.
-  // In the future, support for stacks with multiple apps may be required
-  app: string;
   stack: string;
   migratedFromCloudFormation?: boolean;
 }
@@ -42,10 +40,9 @@ export interface GuStackProps extends StackProps {
  * }
  * ```
  */
-export class GuStack extends Stack {
+export class GuStack extends Stack implements StackStageIdentity {
   private readonly _stack: string;
   private readonly _stage: string;
-  private readonly _app: string;
 
   private _mappings?: GuStageMapping;
   private params: Map<string, GuParameter>;
@@ -58,10 +55,6 @@ export class GuStack extends Stack {
 
   get stack(): string {
     return this._stack;
-  }
-
-  get app(): string {
-    return this._app;
   }
 
   // Use lazy initialisation for GuStageMapping so that Mappings block is only created when necessary
@@ -116,12 +109,10 @@ export class GuStack extends Stack {
 
     this._stack = props.stack;
     this._stage = new GuStageParameter(this).valueAsString;
-    this._app = props.app;
 
     this.addTag(TrackingTag.Key, TrackingTag.Value);
 
     this.addTag("Stack", this.stack);
     this.addTag("Stage", this.stage);
-    this.addTag("App", props.app);
   }
 }

--- a/src/constructs/iam/policies/parameter-store-read.test.ts
+++ b/src/constructs/iam/policies/parameter-store-read.test.ts
@@ -6,9 +6,9 @@ import { GuParameterStoreReadPolicy } from "./parameter-store-read";
 
 describe("ParameterStoreReadPolicy", () => {
   it("should constrain the policy to the patch of a stack's identity", () => {
-    const stack = new GuStack(new App(), "my-app", { app: "MyApp", stack: "test-stack" });
+    const stack = new GuStack(new App(), "my-app", { stack: "test-stack" });
 
-    const policy = new GuParameterStoreReadPolicy(stack);
+    const policy = new GuParameterStoreReadPolicy(stack, { app: "MyApp" });
 
     attachPolicyToTestRole(stack, policy);
 

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -19,6 +19,6 @@ export class GuParameterStoreReadPolicy extends GuPolicy {
       ],
     });
 
-    AppIdentity.addTag(props, this);
+    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -1,26 +1,24 @@
-import type { PolicyProps } from "@aws-cdk/aws-iam";
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
+import { AppIdentity } from "../../core/identity";
 import { GuPolicy } from "./base-policy";
 
 export class GuParameterStoreReadPolicy extends GuPolicy {
-  private static getDefaultProps(scope: GuStack): PolicyProps {
-    return {
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  constructor(scope: GuStack, props: AppIdentity) {
+    super(scope, AppIdentity.suffixText(props, "ParameterStoreRead"), {
       policyName: "parameter-store-read-policy",
       statements: [
         new PolicyStatement({
           effect: Effect.ALLOW,
           actions: ["ssm:GetParametersByPath"],
           resources: [
-            `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/${scope.app}`,
+            `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/${props.app}`,
           ],
         }),
       ],
-    };
-  }
+    });
 
-  constructor(scope: GuStack, id: string = "ParameterStoreRead", props?: GuPolicyProps) {
-    super(scope, id, { ...GuParameterStoreReadPolicy.getDefaultProps(scope), ...props });
+    AppIdentity.addTag(props, this);
   }
 }

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -77,7 +77,7 @@ describe("The GuGetS3ObjectPolicy class", () => {
 describe("The GuGetDistributablePolicy construct", () => {
   it("creates the correct policy", () => {
     const stack = simpleGuStackForTesting();
-    attachPolicyToTestRole(stack, new GuGetDistributablePolicy(stack));
+    attachPolicyToTestRole(stack, new GuGetDistributablePolicy(stack, { app: "testing" }));
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,6 +1,7 @@
 import type { GuPrivateS3ConfigurationProps } from "../../../utils/ec2";
 import type { GuStack } from "../../core";
 import { GuDistributionBucketParameter } from "../../core";
+import { AppIdentity } from "../../core/identity";
 import type { GuNoStatementsPolicyProps } from "./base-policy";
 import { GuAllowPolicy } from "./base-policy";
 
@@ -18,9 +19,15 @@ export class GuGetS3ObjectsPolicy extends GuAllowPolicy {
 }
 
 export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
-  constructor(scope: GuStack, id: string = "GetDistributablePolicy", props?: GuNoStatementsPolicyProps) {
-    const path = [scope.stack, scope.stage, scope.app, "*"].join("/");
-    super(scope, id, { ...props, bucketName: new GuDistributionBucketParameter(scope).valueAsString, paths: [path] });
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  constructor(scope: GuStack, props: AppIdentity) {
+    const path = [scope.stack, scope.stage, props.app, "*"].join("/");
+    super(scope, AppIdentity.suffixText(props, "GetDistributablePolicy"), {
+      ...props,
+      bucketName: new GuDistributionBucketParameter(scope).valueAsString,
+      paths: [path],
+    });
+    AppIdentity.addTag(props, this);
   }
 }
 

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -27,7 +27,7 @@ export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
       bucketName: new GuDistributionBucketParameter(scope).valueAsString,
       paths: [path],
     });
-    AppIdentity.addTag(props, this);
+    AppIdentity.taggedConstruct(props, this);
   }
 }
 

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -39,7 +39,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -60,13 +60,13 @@ Object {
         "PolicyName": "GetConfigPolicy6F934A1C",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablePolicyC6B4A871": Object {
+    "GetDistributablePolicyTestingF9D43A3E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -93,16 +93,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "GetDistributablePolicyC6B4A871",
+        "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GuInstanceRole": Object {
+    "InstanceRoleTesting": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -150,7 +150,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ParameterStoreRead9D2F4FAB": Object {
+    "ParameterStoreReadTesting0F3B634A": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -184,7 +184,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -220,7 +220,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -274,13 +274,13 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablePolicyC6B4A871": Object {
+    "GetDistributablePolicyTestingF9D43A3E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -307,10 +307,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "GetDistributablePolicyC6B4A871",
+        "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -352,13 +352,13 @@ Object {
         "PolicyName": "GuLogShippingPolicy981BFE5A",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRole": Object {
+    "InstanceRoleTesting": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -406,7 +406,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ParameterStoreRead9D2F4FAB": Object {
+    "ParameterStoreReadTesting0F3B634A": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -440,7 +440,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -476,7 +476,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -525,13 +525,13 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablePolicyC6B4A871": Object {
+    "GetDistributablePolicyTestingF9D43A3E": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -558,16 +558,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "GetDistributablePolicyC6B4A871",
+        "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GuInstanceRole": Object {
+    "InstanceRoleTesting": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -615,7 +615,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ParameterStoreRead9D2F4FAB": Object {
+    "ParameterStoreReadTesting0F3B634A": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -649,7 +649,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },
@@ -685,7 +685,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "GuInstanceRole",
+            "Ref": "InstanceRoleTesting",
           },
         ],
       },

--- a/src/constructs/iam/roles/instance-role.test.ts
+++ b/src/constructs/iam/roles/instance-role.test.ts
@@ -7,7 +7,7 @@ import { GuInstanceRole } from "./instance-role";
 describe("The GuInstanceRole construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
-    new GuInstanceRole(stack, "GuInstanceRole", { withoutLogShipping: true });
+    new GuInstanceRole(stack, { withoutLogShipping: true, app: "testing" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -16,7 +16,7 @@ describe("The GuInstanceRole construct", () => {
 
   it("should create an additional logging policy if logging stream is specified", () => {
     const stack = simpleGuStackForTesting();
-    new GuInstanceRole(stack);
+    new GuInstanceRole(stack, { app: "testing" });
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
     expect(stack).toCountResources("AWS::IAM::Role", 1);
@@ -26,7 +26,8 @@ describe("The GuInstanceRole construct", () => {
   it("should allow additional policies to be specified", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuInstanceRole(stack, "GuInstanceRole", {
+    new GuInstanceRole(stack, {
+      app: "testing",
       withoutLogShipping: true,
       additionalPolicies: [new GuGetS3ObjectsPolicy(stack, "GetConfigPolicy", { bucketName: "config" })],
     });

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -38,6 +38,6 @@ export class GuInstanceRole extends GuRole {
 
     this.policies.forEach((p) => p.attachToRole(this));
 
-    AppIdentity.addTag(props, this);
+    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -14,6 +14,7 @@ describe("The GuLambdaFunction class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -31,6 +32,7 @@ describe("The GuLambdaFunction class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
 
     expect(stack).not.toHaveResource("AWS::Events::Rule");
@@ -53,6 +55,7 @@ describe("The GuLambdaFunction class", () => {
           description: "run every hour (cron)",
         },
       ],
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::Events::Rule", {
@@ -82,6 +85,7 @@ describe("The GuLambdaFunction class", () => {
           description: "this is a test2",
         },
       ],
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::ApiGateway::RestApi", {
@@ -107,6 +111,7 @@ describe("The GuLambdaFunction class", () => {
         toleratedErrorPercentage: 5,
         snsTopicName: "test-topic",
       },
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::CloudWatch::Alarm"); // The shape of this alarm is tested via lambda-alarms.test.ts
@@ -119,6 +124,7 @@ describe("The GuLambdaFunction class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
@@ -168,6 +174,7 @@ describe("The GuLambdaFunction class", () => {
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
       memorySize: 2048,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -182,6 +189,7 @@ describe("The GuLambdaFunction class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -197,6 +205,7 @@ describe("The GuLambdaFunction class", () => {
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
       timeout: Duration.seconds(60),
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -211,6 +220,7 @@ describe("The GuLambdaFunction class", () => {
       code: { bucket: "bucket1", key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::Lambda::Function", {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -76,6 +76,6 @@ export class GuLambdaFunction extends Function {
 
     bucket.grantRead(this);
 
-    AppIdentity.addTag(props, this);
+    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -7,15 +7,16 @@ import { Code, Function, RuntimeFamily } from "@aws-cdk/aws-lambda";
 import type { FunctionProps, Runtime } from "@aws-cdk/aws-lambda";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration } from "@aws-cdk/core";
-import type { GuLambdaErrorPercentageMonitoringProps } from "../cloudwatch/lambda-alarms";
-import { GuLambdaErrorPercentageAlarm } from "../cloudwatch/lambda-alarms";
+import type { GuLambdaErrorPercentageMonitoringProps } from "../cloudwatch";
+import { GuLambdaErrorPercentageAlarm } from "../cloudwatch";
 import type { GuStack } from "../core";
+import { AppIdentity } from "../core/identity";
 
 interface ApiProps extends Omit<LambdaRestApiProps, "handler"> {
   id: string;
 }
 
-export interface GuFunctionProps extends Omit<FunctionProps, "code"> {
+export interface GuFunctionProps extends Omit<FunctionProps, "code">, AppIdentity {
   code: { bucket: string; key: string };
   rules?: Array<{
     schedule: Schedule;
@@ -74,5 +75,7 @@ export class GuLambdaFunction extends Function {
     }
 
     bucket.grantRead(this);
+
+    AppIdentity.addTag(props, this);
   }
 }

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -28,6 +28,7 @@ describe("The GuDatabaseInstance class", () => {
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,
       }),
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::RDS::DBInstance", {
@@ -52,6 +53,7 @@ describe("The GuDatabaseInstance class", () => {
         version: PostgresEngineVersion.VER_11_8,
       }),
       parameterGroup,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::RDS::DBInstance", {
@@ -70,6 +72,7 @@ describe("The GuDatabaseInstance class", () => {
         version: PostgresEngineVersion.VER_11_8,
       }),
       parameters: { max_connections: "100" },
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::RDS::DBInstance", {
@@ -113,6 +116,7 @@ describe("The GuDatabaseInstance class", () => {
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,
       }),
+      app: "testing",
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -128,6 +132,7 @@ describe("The GuDatabaseInstance class", () => {
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,
       }),
+      app: "testing",
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -143,6 +148,7 @@ describe("The GuDatabaseInstance class", () => {
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,
       }),
+      app: "testing",
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -159,6 +165,7 @@ describe("The GuDatabaseInstance class", () => {
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,
       }),
+      app: "testing",
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -174,6 +181,7 @@ describe("The GuDatabaseInstance class", () => {
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,
       }),
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::RDS::DBInstance", {

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -3,8 +3,9 @@ import type { CfnDBInstance, DatabaseInstanceProps, IParameterGroup } from "@aws
 import { DatabaseInstance, ParameterGroup } from "@aws-cdk/aws-rds";
 import { Fn } from "@aws-cdk/core";
 import type { GuStack } from "../core";
+import { AppIdentity } from "../core/identity";
 
-export interface GuDatabaseInstanceProps extends Omit<DatabaseInstanceProps, "instanceType"> {
+export interface GuDatabaseInstanceProps extends Omit<DatabaseInstanceProps, "instanceType">, AppIdentity {
   overrideId?: boolean;
   instanceType: string;
   parameters?: Record<string, string>;
@@ -37,5 +38,8 @@ export class GuDatabaseInstance extends DatabaseInstance {
     if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false)) {
       (this.node.defaultChild as CfnDBInstance).overrideLogicalId(id);
     }
+
+    parameterGroup && AppIdentity.addTag(props, parameterGroup);
+    AppIdentity.addTag(props, this);
   }
 }

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -39,7 +39,7 @@ export class GuDatabaseInstance extends DatabaseInstance {
       (this.node.defaultChild as CfnDBInstance).overrideLogicalId(id);
     }
 
-    parameterGroup && AppIdentity.addTag(props, parameterGroup);
-    AppIdentity.addTag(props, this);
+    parameterGroup && AppIdentity.taggedConstruct(props, parameterGroup);
+    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/patterns/kinesis-lambda.test.ts
+++ b/src/patterns/kinesis-lambda.test.ts
@@ -26,6 +26,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -46,6 +47,7 @@ describe("The GuKinesisLambda pattern", () => {
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
       existingKinesisStream: { logicalIdFromCloudFormation: "pre-existing-kinesis-stream" },
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -67,6 +69,7 @@ describe("The GuKinesisLambda pattern", () => {
       monitoringConfiguration: noMonitoring,
       errorHandlingConfiguration: basicErrorHandling,
       existingKinesisStream: { externalKinesisStreamName: "kinesis-stream-from-another-stack" },
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::Lambda::EventSourceMapping", {
@@ -106,6 +109,7 @@ describe("The GuKinesisLambda pattern", () => {
         toleratedErrorPercentage: 1,
         snsTopicName: "alerts-topic",
       },
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::CloudWatch::Alarm");
@@ -125,6 +129,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::Kinesis::Stream", {
@@ -152,6 +157,7 @@ describe("The GuKinesisLambda pattern", () => {
       kinesisStreamProps: {
         encryption: StreamEncryption.UNENCRYPTED,
       },
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).not.toHaveResource("AWS::Kinesis::Stream", {
@@ -182,6 +188,7 @@ describe("The GuKinesisLambda pattern", () => {
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
       kinesisStreamProps: kinesisStreamProps,
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::Kinesis::Stream", {
@@ -213,6 +220,7 @@ describe("The GuKinesisLambda pattern", () => {
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
       processingProps: processingProps,
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::Lambda::EventSourceMapping", {
@@ -238,6 +246,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: errorHandlingProps,
       monitoringConfiguration: noMonitoring,
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::Lambda::EventSourceMapping", {
@@ -260,6 +269,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: errorHandlingProps,
       monitoringConfiguration: noMonitoring,
+      app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::Lambda::EventSourceMapping", {

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -5,6 +5,7 @@ import type { KinesisEventSourceProps } from "@aws-cdk/aws-lambda-event-sources"
 import { KinesisEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
+import { AppIdentity } from "../constructs/core/identity";
 import type { GuKinesisStreamProps } from "../constructs/kinesis";
 import { GuKinesisStream } from "../constructs/kinesis";
 import type { GuFunctionProps } from "../constructs/lambda";
@@ -108,13 +109,14 @@ export class GuKinesisLambda extends GuLambdaFunction {
       ...props.kinesisStreamProps,
     };
     const streamId = props.existingKinesisStream?.logicalIdFromCloudFormation ?? "KinesisStream";
+
     const kinesisStream = props.existingKinesisStream?.externalKinesisStreamName
       ? Stream.fromStreamArn(
           scope,
           streamId,
           `arn:aws:kinesis:${scope.region}:${scope.account}:stream/${props.existingKinesisStream.externalKinesisStreamName}`
         )
-      : new GuKinesisStream(scope, streamId, kinesisProps);
+      : AppIdentity.addTag(props, new GuKinesisStream(scope, streamId, kinesisProps));
 
     const errorHandlingPropsToAwsProps = toAwsErrorHandlingProps(props.errorHandlingConfiguration);
 

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -116,7 +116,7 @@ export class GuKinesisLambda extends GuLambdaFunction {
           streamId,
           `arn:aws:kinesis:${scope.region}:${scope.account}:stream/${props.existingKinesisStream.externalKinesisStreamName}`
         )
-      : AppIdentity.addTag(props, new GuKinesisStream(scope, streamId, kinesisProps));
+      : AppIdentity.taggedConstruct(props, new GuKinesisStream(scope, streamId, kinesisProps));
 
     const errorHandlingPropsToAwsProps = toAwsErrorHandlingProps(props.errorHandlingConfiguration);
 

--- a/src/patterns/scheduled-lambda.test.ts
+++ b/src/patterns/scheduled-lambda.test.ts
@@ -18,6 +18,7 @@ describe("The GuScheduledLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       schedule: Schedule.rate(Duration.minutes(1)),
       monitoringConfiguration: noMonitoring,
+      app: "testing",
     };
     new GuScheduledLambda(stack, "my-lambda-function", props);
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -35,6 +36,7 @@ describe("The GuScheduledLambda pattern", () => {
         toleratedErrorPercentage: 99,
         snsTopicName: "alerts-topic",
       },
+      app: "testing",
     };
     new GuScheduledLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::CloudWatch::Alarm");

--- a/src/patterns/sns-lambda.test.ts
+++ b/src/patterns/sns-lambda.test.ts
@@ -16,6 +16,7 @@ describe("The GuSnsLambda pattern", () => {
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
       monitoringConfiguration: noMonitoring,
+      app: "testing",
     };
     new GuSnsLambda(stack, "my-lambda-function", props);
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -31,6 +32,7 @@ describe("The GuSnsLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       monitoringConfiguration: noMonitoring,
       existingSnsTopic: { logicalIdFromCloudFormation: "in-use-sns-topic" },
+      app: "testing",
     };
     new GuSnsLambda(stack, "my-lambda-function", props);
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
@@ -47,6 +49,7 @@ describe("The GuSnsLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       monitoringConfiguration: noMonitoring,
       existingSnsTopic: { externalTopicName: "sns-topic-from-another-stack" },
+      app: "testing",
     };
     new GuSnsLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::SNS::Subscription");
@@ -64,6 +67,7 @@ describe("The GuSnsLambda pattern", () => {
         toleratedErrorPercentage: 99,
         snsTopicName: "alerts-topic",
       },
+      app: "testing",
     };
     new GuSnsLambda(stack, "my-lambda-function", props);
     expect(stack).toHaveResource("AWS::CloudWatch::Alarm");

--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -93,7 +93,7 @@ export class GuSnsLambda extends GuLambdaFunction {
           topicId,
           `arn:aws:sns:${scope.region}:${scope.account}:${props.existingSnsTopic.externalTopicName}`
         )
-      : AppIdentity.addTag(
+      : AppIdentity.taggedConstruct(
           props,
           new GuSnsTopic(scope, topicId, {
             overrideId: !!props.existingSnsTopic?.logicalIdFromCloudFormation,

--- a/test/utils/attach-policy-to-test-role.ts
+++ b/test/utils/attach-policy-to-test-role.ts
@@ -1,12 +1,13 @@
 import type { Policy } from "@aws-cdk/aws-iam";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
 import type { Stack } from "@aws-cdk/core";
+import { Tags } from "@aws-cdk/core";
 
 // IAM Policies need to be attached to a role, group or user to be created in a stack
-export const attachPolicyToTestRole = (stack: Stack, policy: Policy): void => {
-  policy.attachToRole(
-    new Role(stack, "TestRole", {
-      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-    })
-  );
+export const attachPolicyToTestRole = (stack: Stack, policy: Policy, app: string = "testing"): void => {
+  const role = new Role(stack, "TestRole", {
+    assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  });
+  Tags.of(role).add("App", app);
+  policy.attachToRole(role);
 };

--- a/test/utils/simple-gu-stack.ts
+++ b/test/utils/simple-gu-stack.ts
@@ -3,4 +3,4 @@ import type { GuStackProps } from "../../src/constructs/core";
 import { GuStack } from "../../src/constructs/core";
 
 export const simpleGuStackForTesting: (props?: Partial<GuStackProps>) => GuStack = (props?: Partial<GuStackProps>) =>
-  new GuStack(new App(), "Test", { app: "testing", stack: props?.stack ?? "test-stack", ...props });
+  new GuStack(new App(), "Test", { stack: props?.stack ?? "test-stack", ...props });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently, as noted by [this comment](https://github.com/guardian/cdk/blob/27543797cc5c2f0dbfcf5c262c5456c13e730a10/src/constructs/core/stack.ts#L11-L12), our constructs are tailored for single app stacks. We don't support a stack that has, for example, a frontend web app and an API app. If we were to create two ASGs in the same stack, they'd both get incorrectly tagged as the same "app". That is, we don't support micro-services very well.

This change moves the app string into an interface, this interface is then extended by any construct's props if they need to be app-aware.

As "app" is not in `GuStack` and we want to continue adding the "app" tag to resources, we're having to call `Tags.of(this).add("App", props.app);` a few more times, maybe there's a better solution here that keeps things DRY?

Lastly, this is quite a big diff - a lot of the changes are within test files. I've tried to make each commit standalone, so it might be easier to review commit by commit?

BREAKING CHANGE:
- `GuStack` no longer takes knows about an "app"
- Constructors for `GuAutoScalingGroup`, `GuUserData`, `GuParameterStoreReadPolicy`,  `GuGetDistributablePolicy` and `GuInstanceRole` now require `props`
- Props for `GuLambdaFunction`, `GuDatabaseInstance`, `GuInstanceTypeParameter` and `GuAmiParameter` now take an "app" prop

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes! There are numerous breaking changes in this PR!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See updated tests, aka observe CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is possible to have a stack with multiple apps that are tagged correctly.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
