### PR TITLE
feat: support multiple GuInstanceRoles in a stack

### DIFF
--- a/src/constructs/iam/policies/describe-ec2.test.ts
+++ b/src/constructs/iam/policies/describe-ec2.test.ts
@@ -3,15 +3,15 @@ import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../tes
 import { GuDescribeEC2Policy } from "./describe-ec2";
 
 describe("DescribeEC2Policy", () => {
-  it("can accept a custom policy name", () => {
+  it("creates the correct policy", () => {
     const stack = simpleGuStackForTesting();
 
-    const policy = new GuDescribeEC2Policy(stack, "DescribeEC2Policy", { policyName: "my-awesome-policy" });
+    const policy = GuDescribeEC2Policy.getInstance(stack);
 
     attachPolicyToTestRole(stack, policy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
-      PolicyName: "my-awesome-policy",
+      PolicyName: "describe-ec2-policy",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/describe-ec2.ts
+++ b/src/constructs/iam/policies/describe-ec2.ts
@@ -1,12 +1,13 @@
-import type { PolicyProps } from "@aws-cdk/aws-iam";
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
 import { GuPolicy } from "./base-policy";
 
 export class GuDescribeEC2Policy extends GuPolicy {
-  private static getDefaultProps(): PolicyProps {
-    return {
+  private static instance: GuPolicy | undefined;
+
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  private constructor(scope: GuStack) {
+    super(scope, "DescribeEC2Policy", {
       policyName: "describe-ec2-policy",
       statements: [
         new PolicyStatement({
@@ -20,10 +21,18 @@ export class GuDescribeEC2Policy extends GuPolicy {
           resources: ["*"],
         }),
       ],
-    };
+    });
   }
 
-  constructor(scope: GuStack, id: string = "DescribeEC2Policy", props?: GuPolicyProps) {
-    super(scope, id, { ...GuDescribeEC2Policy.getDefaultProps(), ...props });
+  public static getInstance(stack: GuStack): GuDescribeEC2Policy {
+    // Resources can only live in the same App so return a new instance where necessary.
+    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
+    const isSameStack = this.instance?.node.root === stack.node.root;
+
+    if (!this.instance || !isSameStack) {
+      this.instance = new GuDescribeEC2Policy(stack);
+    }
+
+    return this.instance;
   }
 }

--- a/src/constructs/iam/policies/ssm.test.ts
+++ b/src/constructs/iam/policies/ssm.test.ts
@@ -6,51 +6,12 @@ describe("The GuSSMRunCommandPolicy class", () => {
   it("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const ssmPolicy = new GuSSMRunCommandPolicy(stack);
+    const ssmPolicy = GuSSMRunCommandPolicy.getInstance(stack);
 
     attachPolicyToTestRole(stack, ssmPolicy);
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "ssm-run-command-policy",
-      PolicyDocument: {
-        Version: "2012-10-17",
-        Statement: [
-          {
-            Effect: "Allow",
-            Resource: "*",
-            Action: [
-              "ec2messages:AcknowledgeMessage",
-              "ec2messages:DeleteMessage",
-              "ec2messages:FailMessage",
-              "ec2messages:GetEndpoint",
-              "ec2messages:GetMessages",
-              "ec2messages:SendReply",
-              "ssm:UpdateInstanceInformation",
-              "ssm:ListInstanceAssociations",
-              "ssm:DescribeInstanceProperties",
-              "ssm:DescribeDocumentParameters",
-              "ssmmessages:CreateControlChannel",
-              "ssmmessages:CreateDataChannel",
-              "ssmmessages:OpenControlChannel",
-              "ssmmessages:OpenDataChannel",
-            ],
-          },
-        ],
-      },
-    });
-  });
-
-  it("merges defaults and passed in props", () => {
-    const stack = simpleGuStackForTesting();
-
-    const ssmPolicy = new GuSSMRunCommandPolicy(stack, "SSMRunCommandPolicy", {
-      policyName: "test",
-    });
-
-    attachPolicyToTestRole(stack, ssmPolicy);
-
-    expect(stack).toHaveResource("AWS::IAM::Policy", {
-      PolicyName: "test",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/ssm.ts
+++ b/src/constructs/iam/policies/ssm.ts
@@ -1,10 +1,12 @@
 import type { GuStack } from "../../core";
-import type { GuNoStatementsPolicyProps } from "./base-policy";
 import { GuAllowPolicy } from "./base-policy";
 
 export class GuSSMRunCommandPolicy extends GuAllowPolicy {
-  constructor(scope: GuStack, id: string = "SSMRunCommandPolicy", props?: GuNoStatementsPolicyProps) {
-    super(scope, id, {
+  private static instance: GuSSMRunCommandPolicy | undefined;
+
+  // eslint-disable-next-line custom-rules/valid-constructors -- WIP
+  private constructor(scope: GuStack) {
+    super(scope, "SSMRunCommandPolicy", {
       policyName: "ssm-run-command-policy",
       resources: ["*"],
       actions: [
@@ -23,7 +25,18 @@ export class GuSSMRunCommandPolicy extends GuAllowPolicy {
         "ssmmessages:OpenControlChannel",
         "ssmmessages:OpenDataChannel",
       ],
-      ...props,
     });
+  }
+
+  public static getInstance(stack: GuStack): GuSSMRunCommandPolicy {
+    // Resources can only live in the same App so return a new `GuSSMRunCommandPolicy` where necessary.
+    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
+    const isSameStack = this.instance?.node.root === stack.node.root;
+
+    if (!this.instance || !isSameStack) {
+      this.instance = new GuSSMRunCommandPolicy(stack);
+    }
+
+    return this.instance;
   }
 }

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -230,6 +230,395 @@ Object {
 }
 `;
 
+exports[`The GuInstanceRole construct should be possible to create multiple instance roles in a single stack 1`] = `
+Object {
+  "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-first-app",
+          },
+          Object {
+            "Ref": "InstanceRoleMy-second-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyMyfirstapp9CD90B92": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/test-stack/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/my-first-app/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyMyfirstapp9CD90B92",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-first-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyMysecondappA8D9FE69": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/test-stack/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/my-second-app/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyMysecondappA8D9FE69",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-second-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-first-app",
+          },
+          Object {
+            "Ref": "InstanceRoleMy-second-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleMy-first-app": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-first-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "InstanceRoleMy-second-app": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-second-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ParameterStoreReadMyfirstappBCF3BB3A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/my-first-app",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-first-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreReadMysecondapp7B80ABE2": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/my-second-app",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-second-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SSMRunCommandPolicy244E1613": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-run-command-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleMy-first-app",
+          },
+          Object {
+            "Ref": "InstanceRoleMy-second-app",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+}
+`;
+
 exports[`The GuInstanceRole construct should create an additional logging policy if logging stream is specified 1`] = `
 Object {
   "Parameters": Object {

--- a/src/constructs/iam/roles/instance-role.test.ts
+++ b/src/constructs/iam/roles/instance-role.test.ts
@@ -36,4 +36,20 @@ describe("The GuInstanceRole construct", () => {
     expect(stack).toCountResources("AWS::IAM::Role", 1);
     expect(stack).toCountResources("AWS::IAM::Policy", 5);
   });
+
+  it("should be possible to create multiple instance roles in a single stack", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuInstanceRole(stack, {
+      app: "my-first-app",
+    });
+
+    new GuInstanceRole(stack, {
+      app: "my-second-app",
+    });
+
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    expect(stack).toCountResources("AWS::IAM::Role", 2);
+    expect(stack).toCountResources("AWS::IAM::Policy", 7); // 3 shared policies + 2 policies per role (3 + (2*2))
+  });
 });

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -28,7 +28,7 @@ export class GuInstanceRole extends GuRole {
     });
 
     this.policies = [
-      new GuSSMRunCommandPolicy(scope),
+      GuSSMRunCommandPolicy.getInstance(scope),
       new GuGetDistributablePolicy(scope, props),
       new GuDescribeEC2Policy(scope),
       new GuParameterStoreReadPolicy(scope, props),

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -30,7 +30,7 @@ export class GuInstanceRole extends GuRole {
     this.policies = [
       GuSSMRunCommandPolicy.getInstance(scope),
       new GuGetDistributablePolicy(scope, props),
-      new GuDescribeEC2Policy(scope),
+      GuDescribeEC2Policy.getInstance(scope),
       new GuParameterStoreReadPolicy(scope, props),
       ...(props.withoutLogShipping ? [] : [GuLogShippingPolicy.getInstance(scope)]),
       ...(props.additionalPolicies ? props.additionalPolicies : []),


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A `GuInstanceRole` provides the basic permissions needed by EC2, it grants access to:
- SSM
- Describing tags
- Writing to kinesis for log shipping

#326 started the work to support the declaration of multiple apps in a stack, where an app is a collection of ASG, LB etc. However, when actually attempting to use the updated constructs in reality, the synth step failed due to multiple constructs using the same ID.

This change follows #341 and #337 and converts `GuSSMRunCommandPolicy` and `GuDescribeEC2Policy` to singletons. This means these policies will only get created once regardless of how many roles use them - there will be one policy with multiple roles attached to it. This helps keep the stack DRY and also reduces the chance of reaching the max file size limits of cloudformation.

The commits have been crafted to be standalone, reviewing them one by one might make the overall review easier.

Requires #341.

BREAKING CHANGE:
* `GuSSMRunCommandPolicy` and `GuDescribeEC2Policy` can no longer be directly instantiated

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Ultimately no, as `GuInstanceRole` hasn't fundamentally changed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See new test!

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It's even more possible to declare multiple apps within a stack.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a