### PR TITLE
chore: use v1.0.0 of release action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -24,7 +24,7 @@ jobs:
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           ./script/cd
       - name: post-release
-        uses: guardian/actions-merge-release-changes-to-protected-branch@main
+        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.0.0
         with:
           # This action will raise a PR to edit package.json.
           # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,6 @@ jobs:
     needs: [CI]
     steps:
       - name: Validate, approve and merge release PRs
-        uses: guardian/actions-merge-release-changes-to-protected-branch@main
+        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this change?

The [guardian/actions-merge-release-changes-to-protected-branch](https://github.com/guardian/actions-merge-release-changes-to-protected-branch) action now has a `v1.0.0` release. This PR updates the workflow files to use this, rather than pulling in from the `main` branch.

## Does this change require changes to existing projects or CDK CLI?

No

## How to test

Merge a PR and confirm that the auto publish process still works as expected

## How can we measure success?

The auto publish process continues to work as expected but now the repository has control over the version of the action used.
