### PR TITLE
refactor(GuLogShippingPolicy)!: make GuLogShippingPolicy a singleton

### DIFF
--- a/src/constructs/core/parameters/log-shipping.ts
+++ b/src/constructs/core/parameters/log-shipping.ts
@@ -1,0 +1,27 @@
+import type { GuStack } from "../stack";
+import { GuStringParameter } from "./base";
+
+export class GuLoggingStreamNameParameter extends GuStringParameter {
+  private static instance: GuStringParameter | undefined;
+
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  private constructor(scope: GuStack) {
+    super(scope, "LoggingStreamName", {
+      description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      default: "/account/services/logging.stream.name",
+      fromSSM: true,
+    });
+  }
+
+  public static getInstance(stack: GuStack): GuLoggingStreamNameParameter {
+    // Resources can only live in the same App so return a new `GuSSMRunCommandPolicy` where necessary.
+    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
+    const isSameStack = this.instance?.node.root === stack.node.root;
+
+    if (!this.instance || !isSameStack) {
+      this.instance = new GuLoggingStreamNameParameter(stack);
+    }
+
+    return this.instance;
+  }
+}

--- a/src/constructs/iam/policies/__snapshots__/log-shipping.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/log-shipping.test.ts.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuLogShippingPolicy singleton class will only be defined once in a stack, even when attached to multiple roles 1`] = `
+Object {
+  "Parameters": Object {
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "MyFirstRoleAF66ED75",
+          },
+          Object {
+            "Ref": "MySecondRoleB9F57405",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "MyFirstRoleAF66ED75": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MySecondRoleB9F57405": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;

--- a/src/constructs/iam/policies/log-shipping.test.ts
+++ b/src/constructs/iam/policies/log-shipping.test.ts
@@ -1,59 +1,25 @@
 import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import type { SynthedStack } from "../../../../test/utils";
 import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../../test/utils";
 import { GuLogShippingPolicy } from "./log-shipping";
 
 describe("The GuLogShippingPolicy class", () => {
-  it("sets default props", () => {
+  it("creates a policy restricted to a kinesis stream defined in a parameter", () => {
     const stack = simpleGuStackForTesting();
 
     const logShippingPolicy = new GuLogShippingPolicy(stack);
-
     attachPolicyToTestRole(stack, logShippingPolicy);
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Parameters.LoggingStreamName).toEqual({
+      Type: "AWS::SSM::Parameter::Value<String>",
+      Default: "/account/services/logging.stream.name",
+      Description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
+    });
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyName: "GuLogShippingPolicy981BFE5A",
-      PolicyDocument: {
-        Version: "2012-10-17",
-        Statement: [
-          {
-            Action: ["kinesis:Describe*", "kinesis:Put*"],
-            Effect: "Allow",
-            Resource: {
-              "Fn::Join": [
-                "",
-                [
-                  "arn:aws:kinesis:",
-                  {
-                    Ref: "AWS::Region",
-                  },
-                  ":",
-                  {
-                    Ref: "AWS::AccountId",
-                  },
-                  ":stream/",
-                  {
-                    Ref: "LoggingStreamName",
-                  },
-                ],
-              ],
-            },
-          },
-        ],
-      },
-    });
-  });
-
-  it("merges defaults and passed in props", () => {
-    const stack = simpleGuStackForTesting();
-
-    const logShippingPolicy = new GuLogShippingPolicy(stack, "LogShippingPolicy", {
-      policyName: "test",
-    });
-
-    attachPolicyToTestRole(stack, logShippingPolicy);
-
-    expect(stack).toHaveResource("AWS::IAM::Policy", {
-      PolicyName: "test",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -3,8 +3,10 @@ import { GuLoggingStreamNameParameter } from "../../core/parameters/log-shipping
 import { GuAllowPolicy } from "./base-policy";
 
 export class GuLogShippingPolicy extends GuAllowPolicy {
+  private static instance: GuLogShippingPolicy | undefined;
+
   // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
-  constructor(scope: GuStack) {
+  private constructor(scope: GuStack) {
     super(scope, "GuLogShippingPolicy", {
       actions: ["kinesis:Describe*", "kinesis:Put*"],
       resources: [
@@ -13,5 +15,17 @@ export class GuLogShippingPolicy extends GuAllowPolicy {
         }`,
       ],
     });
+  }
+
+  public static getInstance(stack: GuStack): GuLogShippingPolicy {
+    // Resources can only live in the same App so return a new `GuSSMRunCommandPolicy` where necessary.
+    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
+    const isSameStack = this.instance?.node.root === stack.node.root;
+
+    if (!this.instance || !isSameStack) {
+      this.instance = new GuLogShippingPolicy(stack);
+    }
+
+    return this.instance;
   }
 }

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -1,25 +1,17 @@
-import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
-import { GuStringParameter } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
-import { GuPolicy } from "./base-policy";
+import { GuLoggingStreamNameParameter } from "../../core/parameters/log-shipping";
+import { GuAllowPolicy } from "./base-policy";
 
-export class GuLogShippingPolicy extends GuPolicy {
-  constructor(scope: GuStack, id: string = "GuLogShippingPolicy", props?: GuPolicyProps) {
-    super(scope, id, { ...props });
-
-    const loggingStreamNameParam = new GuStringParameter(scope, "LoggingStreamName", {
-      description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
-      default: "/account/services/logging.stream.name",
-      fromSSM: true,
+export class GuLogShippingPolicy extends GuAllowPolicy {
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  constructor(scope: GuStack) {
+    super(scope, "GuLogShippingPolicy", {
+      actions: ["kinesis:Describe*", "kinesis:Put*"],
+      resources: [
+        `arn:aws:kinesis:${scope.region}:${scope.account}:stream/${
+          GuLoggingStreamNameParameter.getInstance(scope).valueAsString
+        }`,
+      ],
     });
-
-    this.addStatements(
-      new PolicyStatement({
-        effect: Effect.ALLOW,
-        actions: ["kinesis:Describe*", "kinesis:Put*"],
-        resources: [`arn:aws:kinesis:${scope.region}:${scope.account}:stream/${loggingStreamNameParam.valueAsString}`],
-      })
-    );
   }
 }

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -32,7 +32,7 @@ export class GuInstanceRole extends GuRole {
       new GuGetDistributablePolicy(scope, props),
       new GuDescribeEC2Policy(scope),
       new GuParameterStoreReadPolicy(scope, props),
-      ...(props.withoutLogShipping ? [] : [new GuLogShippingPolicy(scope)]),
+      ...(props.withoutLogShipping ? [] : [GuLogShippingPolicy.getInstance(scope)]),
       ...(props.additionalPolicies ? props.additionalPolicies : []),
     ];
 

--- a/test/utils/attach-policy-to-test-role.ts
+++ b/test/utils/attach-policy-to-test-role.ts
@@ -4,10 +4,10 @@ import type { Stack } from "@aws-cdk/core";
 import { Tags } from "@aws-cdk/core";
 
 // IAM Policies need to be attached to a role, group or user to be created in a stack
-export const attachPolicyToTestRole = (stack: Stack, policy: Policy, app: string = "testing"): void => {
-  const role = new Role(stack, "TestRole", {
+export const attachPolicyToTestRole = (stack: Stack, policy: Policy, id: string = "TestRole"): void => {
+  const role = new Role(stack, id, {
     assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
   });
-  Tags.of(role).add("App", app);
+  Tags.of(role).add("App", "testing");
   policy.attachToRole(role);
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This is ultimately part of https://github.com/guardian/cdk/pull/332.

This policy is now a [singleton](https://en.wikipedia.org/wiki/Singleton_pattern) as we only ever want one per stack. If there are multiple roles defined in this stack that require log shipping permissions, a single policy will be defined and attached to the roles.

This DRYness helps keep within the file size limits of cloudformation too.

Also included in this change is a new `GuLoggingStreamNameParameter`, also written as a singleton for the same reasons.

To make the review easier, each commit can be read in sequence as they have been crafted to tell the story.

Usage hasn't really changed as this policy will never really be used by consumer stacks as they'l be using `GuInstanceRole` instead, which adds this policy by default. However, usage looks roughly like this:

```typescript
const stack = new GuStack();
const myRole = new GuRole(stack);

const policy = GuLogShippingPolicy.getInstance(stack);
policy.attachToRole(myRole);
```

It's worth noting that https://github.com/guardian/cdk/pull/92 was a naive implementation of singleton parameters and this new style removes the need to have the `getParam` helper function on the `GuStack`.

BREAKING CHANGE:
* The API for `GuLogShippingPolicy` has changed. It is now a singleton and direct instantiation is not possible.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. They'll need a version bump by as `GuLogShippingPolicy` is provided [through the `GuInstanceRole`](https://github.com/guardian/cdk/blob/fa6a0d3d99953c8f0f3009f03525161bdc060864/src/constructs/iam/roles/instance-role.ts#L35), this should be a no-op.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See updated and new tests. Either by running them or observing CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A much simpler API and ground work for supporting multiple apps (for example a backend api and frontend web app microservice) within a single stack.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a