### PR TITLE
feat!: make GuDistributionBucketParameter a singleton

### DIFF
--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -22,7 +22,7 @@ describe("GuUserData", () => {
     const props: GuUserDataProps = {
       app,
       distributable: {
-        bucket: new GuDistributionBucketParameter(stack),
+        bucket: GuDistributionBucketParameter.getInstance(stack),
         fileName: "my-app.deb",
         executionStatement: `dpkg -i /${app}/my-app.deb`,
       },
@@ -73,7 +73,7 @@ describe("GuUserData", () => {
     const props: GuUserDataProps = {
       app,
       distributable: {
-        bucket: new GuDistributionBucketParameter(stack),
+        bucket: GuDistributionBucketParameter.getInstance(stack),
         fileName: "my-app.deb",
         executionStatement: `dpkg -i /${app}/my-app.deb`,
       },

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -2,14 +2,27 @@ import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 
 export class GuDistributionBucketParameter extends GuStringParameter {
-  public static parameterName = "DistributionBucketName";
+  private static instance: GuDistributionBucketParameter | undefined;
 
-  constructor(scope: GuStack, id: string = GuDistributionBucketParameter.parameterName) {
-    super(scope, id, {
+  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
+  private constructor(scope: GuStack) {
+    super(scope, "DistributionBucketName", {
       description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
       default: "/account/services/artifact.bucket",
       fromSSM: true,
     });
+  }
+
+  public static getInstance(stack: GuStack): GuDistributionBucketParameter {
+    // Resources can only live in the same App so return a new instance where necessary.
+    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
+    const isSameStack = this.instance?.node.root === stack.node.root;
+
+    if (!this.instance || !isSameStack) {
+      this.instance = new GuDistributionBucketParameter(stack);
+    }
+
+    return this.instance;
   }
 }
 

--- a/src/constructs/iam/policies/s3-get-object.test.ts
+++ b/src/constructs/iam/policies/s3-get-object.test.ts
@@ -82,7 +82,7 @@ describe("The GuGetDistributablePolicy construct", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     const parameterKeys = Object.keys(json.Parameters);
-    const expectedKeys = ["Stage", GuDistributionBucketParameter.parameterName];
+    const expectedKeys = ["Stage", GuDistributionBucketParameter.getInstance(stack).id];
     expect(parameterKeys).toEqual(expectedKeys);
 
     expect(json.Parameters.DistributionBucketName).toEqual({

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -24,7 +24,7 @@ export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
     const path = [scope.stack, scope.stage, props.app, "*"].join("/");
     super(scope, AppIdentity.suffixText(props, "GetDistributablePolicy"), {
       ...props,
-      bucketName: new GuDistributionBucketParameter(scope).valueAsString,
+      bucketName: GuDistributionBucketParameter.getInstance(scope).valueAsString,
       paths: [path],
     });
     AppIdentity.taggedConstruct(props, this);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following #337 and part of a bigger bit of work in #332, this makes `GuDistributionBucketParameter` a singleton as we only ever want one of them in a stack.

BREAKING CHANGE:
* The removal of the static `parameterName` field means `GuDistributionBucketParameter.parameterName` becomes `GuDistributionBucketParameter.getInstance(stack).id`

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. The [Prism stack](https://github.com/guardian/prism/blob/956d4334ea13c3ce20ed33e7b337064f3e5c49fb/cdk/lib/prism.ts#L51) will need to be updated to the new format.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See existing tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A much simpler API and ground work for supporting multiple apps (for example a backend api and frontend web app microservice) within a single stack.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a