### PR TITLE
feat: revise custom lint rule

### DIFF
--- a/docs/architecture-decision-records/002-component-constuctors.md
+++ b/docs/architecture-decision-records/002-component-constuctors.md
@@ -20,7 +20,7 @@ This project contains a large number of classes, making up the various construct
 
    By having a consistent style for constructors, users will know what to expect every time they use a class from the library. This makes the developer experience easier and faster as users do not have to check what is required for each class.
 
-2. Constrctors should be the best fit for each class
+2. Constructors should be the best fit for each class
 
    In the case of this library, this mainly means either missing out the id or changing the order of the id and props inputs. In scenarios where a sensible id can either be hardcoded or defaulted, this would prevent users from having to add ids everywhere, reducing the amount of code they have to write.
 
@@ -30,13 +30,13 @@ This project contains a large number of classes, making up the various construct
 
 Constructors should follow the following rules for consistency.
 
-1. Constructors should all accept a `scope` of type `GuStack` and an `id` of type `string`
+1. The first parameter should be a `scope` of type `GuStack`:
 
    :white_check_mark: Valid
 
    ```ts
    class MyConstruct {
-     constructor(scope: GuStack, id: string) {
+     constructor(scope: GuStack) {
        ...
      }
    }
@@ -46,13 +46,39 @@ Constructors should follow the following rules for consistency.
 
    ```ts
    class MyConstruct {
-     constructor(scope: Stack, id: string) {
+     constructor(scope: Stack) {
        ...
      }
    }
    ```
 
-2. They can also take a `props` object which should be correctly typed
+   The construct/pattern will then have a static `id` as it will never change, for example the `Stage` parameter.
+
+2. They can also take a `props` object which should be correctly typed:
+
+   :white_check_mark: Valid
+
+   ```ts
+   class MyConstruct {
+     constructor(scope: GuStack, props: MyConstructProps) {
+       ...
+     }
+   }
+   ```
+
+   :x: Invalid
+
+   ```ts
+   class MyConstruct {
+     constructor(scope: Stack, props: object) {
+       ...
+     }
+   }
+   ```
+
+   The construct/pattern will then derive `id` from `props` as it will never change, for example `InstanceTypeFor${props.app}`.
+
+3. They can also take an `id` of type string and a `props` object which should be correctly typed
 
    :white_check_mark: Valid
 
@@ -70,13 +96,13 @@ Constructors should follow the following rules for consistency.
 
    ```ts
    class MyConstruct {
-     constructor(scope: GuStack, id: string, props: object) {
+     constructor(scope: GuStack, id: any, props: object) {
        ...
      }
    }
    ```
 
-3. Where all `props` are optional, the `props` object should be optional as a whole
+4. Where all `props` are optional, the `props` object should be optional as a whole
 
    :white_check_mark: Valid
 
@@ -103,35 +129,6 @@ Constructors should follow the following rules for consistency.
 
    class MyConstruct {
      constructor(scope: GuStack, id: string, props: MyConstructProps) {
-       ...
-     }
-   }
-   ```
-
-4. Where `props` are optional, a default value for the `id` can be provided where appropriate
-
-   :white_check_mark: Valid
-
-   ```ts
-   interface MyConstructProps {
-     prop1?: string;
-     prop2?: string
-   }
-
-   class MyConstruct {
-     constructor(scope: GuStack, id: string = "MyConstruct", props?: MyConstructProps) {
-       ...
-     }
-   }
-   ```
-
-   :x: Invalid
-
-   ```ts
-   interface MyConstructProps {...}
-
-   class MyConstruct {
-     constructor(scope: GuStack, id: string = "MyConstruct", props: MyConstructProps) {
        ...
      }
    }

--- a/eslint/rules/valid-constructors.js
+++ b/eslint/rules/valid-constructors.js
@@ -1,36 +1,100 @@
-// Rules
-// 1. Must be at least 2 parameters
-// 2. Can't be more than 3 parameters
-// 3. First parameter must be called scope
-// 4. First parameter must be of type GuStack
-// 5. Second parameter must be called id
-// 6. Second parameter must be of type string
-// 7. Third parameter (if exists) must called props
-// 8. If third parameter is present and non-optional then the second parameter should not be initialised
-// TODO: 9. If all values in third type are optional then parameter should be optional
-// 10. Third parameter type should be custom
+/*
+RULES
+1. Private constructors don't get linted
+2. Must be 1, 2 or 3 parameters
+3. First parameter must be called scope
+4. First parameter must be of type GuStack
+5. If 2 parameters:
+   - The second parameter must be called props
+   - The second parameter must be a custom type
+6. If 3 parameters:
+   - The second parameter must be called id
+   - The second parameter must be of type string
+   - The third parameter must be called props
+   - The third parameter must be a custom type
+7. Only the third parameter can be optional or have a default value
 
-const getPath = (node, path) => {
-  const keys = path.split(".");
-  let value = node;
+See `valid-constructors.test.ts` and `npm run test:custom-lint-rule`
 
-  for (const key of keys) {
-    if (!value) break;
-    value = value[key];
+TODO: If all values in third type are optional then parameter should be optional
+ */
+
+const NO_LINT_ERRORS = null;
+
+const lintParameter = (param, node, context, { name, type, allowOptional, allowDefault, position }) => {
+  const hasDefault = param.type === "AssignmentPattern";
+  if (hasDefault && !allowDefault) {
+    return context.report({
+      node,
+      loc: param.loc,
+      message: `The ${position} parameter in a constructor cannot have a default`,
+    });
   }
 
-  return value;
+  const isOptional = param.optional;
+  if (isOptional && !allowOptional) {
+    return context.report({
+      node,
+      loc: param.loc,
+      message: `The ${position} parameter in a constructor cannot be optional`,
+    });
+  }
+
+  const currentName = param.name ?? param.left.name;
+
+  if (currentName !== name) {
+    return context.report({
+      node,
+      loc: param.loc,
+      message: `The ${position} parameter in a constructor must be called ${name} (currently ${currentName})`,
+    });
+  }
+
+  const tsType = param.typeAnnotation?.typeAnnotation.type ?? param.left.typeAnnotation.typeAnnotation.type;
+  const customType =
+    param.typeAnnotation?.typeAnnotation.typeName?.name ?? param.left?.typeAnnotation.typeAnnotation.typeName.name;
+
+  const currentType = type.startsWith("TS") ? tsType : customType;
+
+  if (currentType !== type) {
+    return context.report({
+      node,
+      loc: param.typeAnnotation.loc,
+      message: `The ${position} parameter in a constructor must be of type ${type} (currently ${currentType})`,
+    });
+  }
 };
 
-const getStandardOrLeftProp = (node, path) => {
-  switch (node.type) {
-    case "Identifier":
-      return getPath(node, path);
-    case "AssignmentPattern":
-      return getPath(node, `left.${path}`);
-    default:
-      return false;
-  }
+const scopeParamSpec = {
+  name: "scope",
+  type: "GuStack",
+  allowOptional: false,
+  allowDefault: false,
+  position: "first",
+};
+
+const idParamSpec = {
+  name: "id",
+  type: "TSStringKeyword",
+  allowOptional: false,
+  allowDefault: false,
+  position: "second",
+};
+
+const propsAsSecondParamSpec = {
+  name: "props",
+  type: "TSTypeReference",
+  allowOptional: false,
+  allowDefault: false,
+  position: "second",
+};
+
+const propsAsThirdParamSpec = {
+  name: "props",
+  type: "TSTypeReference",
+  allowOptional: true,
+  allowDefault: true,
+  position: "third",
 };
 
 module.exports = {
@@ -47,100 +111,50 @@ module.exports = {
   create(context) {
     return {
       MethodDefinition(node) {
-        if (node.kind !== "constructor") return null;
+        if (node.kind !== "constructor") return NO_LINT_ERRORS;
+        if (node.accessibility === "private") return NO_LINT_ERRORS;
 
         const params = node.value.params;
 
-        // 1. Must be at least 2 parameters
-        if (!Array.isArray(params) || params.length < 2) {
-          return context.report(
+        if (!Array.isArray(params)) {
+          return context.report({
             node,
-            params.loc,
-            "Construct or pattern constructors must take at least a scope and an id parameter"
-          );
+            message: "Constructors must take at least one parameter",
+            loc: params.loc,
+          });
         }
 
-        // 2. Can't be more than 3 parameters
-        if (params.length > 3) {
-          return context.report(
-            node,
-            params.loc,
-            "Construct or pattern constructors can only take scope, id and props parameters"
-          );
-        }
+        switch (params.length) {
+          case 1: {
+            const [scope] = params;
+            return lintParameter(scope, node, context, scopeParamSpec) ?? NO_LINT_ERRORS;
+          }
+          case 2: {
+            const [scope, props] = params;
 
-        const scope = params[0];
-
-        // 3. First parameter must be called scope
-        if (scope.name !== "scope") {
-          return context.report(
-            node,
-            scope.loc,
-            `The first parameter in a construct or pattern contructor must be called scope`
-          );
-        }
-
-        // 4. First parameter must be of type GuStack
-        if (scope.typeAnnotation.typeAnnotation.typeName.name !== "GuStack") {
-          return context.report(
-            node,
-            scope.typeAnnotation.loc,
-            `The first parameter in a construct or pattern contructor must be of type GuStack`
-          );
-        }
-
-        const id = params[1];
-
-        // 5. Second parameter must be called id
-        if (getStandardOrLeftProp(id, "name") !== "id") {
-          return context.report(
-            node,
-            id.loc,
-            `The second parameter in a construct or pattern contructor must be called id`
-          );
-        }
-
-        // 6. Second parameter must be of type string
-        if (getStandardOrLeftProp(id, "typeAnnotation.typeAnnotation.type") !== "TSStringKeyword") {
-          return context.report(
-            node,
-            getStandardOrLeftProp(id, "typeAnnotation.loc"),
-            `The second parameter in a construct or pattern contructor must be of type string`
-          );
-        }
-
-        const props = params[2];
-
-        if (props) {
-          // 7. Third parameter (if exists) must called props
-          if (getStandardOrLeftProp(props, "name") !== "props") {
-            return context.report(
-              node,
-              props.loc,
-              `The third parameter in a construct or pattern contructor must be called props`
+            return (
+              lintParameter(scope, node, context, scopeParamSpec) ??
+              lintParameter(props, node, context, propsAsSecondParamSpec) ??
+              NO_LINT_ERRORS
             );
           }
+          case 3: {
+            const [scope, id, props] = params;
 
-          // 8. If third parameter is present and non-optional then the second parameter should not be initialised
-          if (props.type !== "AssignmentPattern" && !props.optional && id.type === "AssignmentPattern") {
-            return context.report(
-              node,
-              id.loc,
-              `The second parameter cannot be initialised if there is a non-optional third parameter`
+            return (
+              lintParameter(scope, node, context, scopeParamSpec) ??
+              lintParameter(id, node, context, idParamSpec) ??
+              lintParameter(props, node, context, propsAsThirdParamSpec) ??
+              NO_LINT_ERRORS
             );
           }
-
-          // 10. Third parameter type should be custom
-          if (getStandardOrLeftProp(props, "typeAnnotation.typeAnnotation.type") !== "TSTypeReference") {
-            return context.report(
+          default:
+            return context.report({
               node,
-              getStandardOrLeftProp(props, "typeAnnotation.loc"),
-              `The third parameter in a construct or pattern contructor must be a custom type`
-            );
-          }
+              message: `Constructors can take a maximum of three parameters - there are ${params.length} params here!`,
+              loc: params.loc,
+            });
         }
-
-        return null;
       },
     };
   },

--- a/eslint/rules/valid-constructors.test.ts
+++ b/eslint/rules/valid-constructors.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- testing file */
+
+import type { GuStack } from "../../src/constructs/core";
+
+interface MyProps {
+  name: string;
+}
+
+const defaultProps: MyProps = { name: "guardian" };
+
+class OneParamConstructor {
+  constructor(scope: GuStack) {
+    console.log(scope);
+  }
+}
+
+class TwoParamConstructor {
+  constructor(scope: GuStack, props: MyProps) {
+    console.log(scope);
+    console.log(props);
+  }
+}
+
+class ThreeParamConstructor {
+  constructor(scope: GuStack, id: string, props: MyProps) {
+    console.log(scope);
+    console.log(id);
+    console.log(props);
+  }
+}
+
+class AnotherThreeParamConstructor {
+  constructor(scope: GuStack, id: string, props?: MyProps) {
+    console.log(scope);
+    console.log(id);
+    console.log(props);
+  }
+}
+
+class YetAnotherThreeParamConstructor {
+  constructor(scope: GuStack, id: string, props: MyProps = defaultProps) {
+    console.log(scope);
+    console.log(id);
+    console.log(props);
+  }
+}
+
+class PrivateConstructor {
+  private constructor(number: number) {
+    console.log(number);
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
     "^.+\\.tsx?$": "ts-jest",
   },
   setupFilesAfterEnv: ["./jest.setup.js"],
+
+  // ignore this file as it's used to demonstrate custom lint rule and Jest flags unused declarations
+  testPathIgnorePatterns: ["<rootDir>/eslint/rules/valid-constructors.test.ts"],
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write \"(src|test)/**/*.ts\"",
     "watch": "tsc -w",
     "test": "jest --detectOpenHandles --runInBand",
+    "test:custom-lint-rule": "eslint eslint/rules/valid-constructors.test.ts",
     "test:dev": "jest --detectOpenHandles --runInBand --watch",
     "prepare": "tsc",
     "release": "semantic-release",

--- a/script/ci
+++ b/script/ci
@@ -15,6 +15,7 @@ main() {
   npm ci
   npm run build
   npm run lint
+  npm run test:custom-lint-rule
   npm run test
 }
 

--- a/script/lint
+++ b/script/lint
@@ -8,4 +8,5 @@ if [ $CI ] ; then
   npm ci
 fi
 
+npm run test:custom-lint-rule
 npm run lint

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -65,7 +65,6 @@ export class GuUserData {
     });
   }
 
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO only lint for things that extend IConstruct
   constructor(scope: GuStack, props: GuUserDataProps) {
     this._userData = UserData.forLinux();
 

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -8,7 +8,7 @@ export interface GuStageDependentValue<T extends string | number | boolean> {
 }
 
 export class GuStageMapping extends CfnMapping {
-  constructor(scope: GuStack, id: string = "stage-mapping") {
-    super(scope, id);
+  constructor(scope: GuStack) {
+    super(scope, "stage-mapping");
   }
 }

--- a/src/constructs/core/parameters/acm.ts
+++ b/src/constructs/core/parameters/acm.ts
@@ -1,15 +1,14 @@
 import { RegexPattern } from "../../../constants";
+import { AppIdentity } from "../identity";
 import type { GuStack } from "../stack";
-import type { GuNoTypeParameterProps } from "./base";
 import { GuStringParameter } from "./base";
 
 export class GuCertificateArnParameter extends GuStringParameter {
-  constructor(scope: GuStack, id: string = "TLSCertificate", props?: GuNoTypeParameterProps) {
-    super(scope, id, {
+  constructor(scope: GuStack, props: AppIdentity) {
+    super(scope, AppIdentity.suffixText(props, "TLSCertificate"), {
       allowedPattern: RegexPattern.ACM_ARN,
       constraintDescription: "Must be an ACM ARN resource",
       description: "The ARN of an ACM certificate for use on a load balancer",
-      ...props,
     });
   }
 }

--- a/src/constructs/core/parameters/ec2.ts
+++ b/src/constructs/core/parameters/ec2.ts
@@ -4,7 +4,6 @@ import type { GuNoTypeParameterPropsWithAppIdentity } from "./base";
 import { GuParameter } from "./base";
 
 export class GuInstanceTypeParameter extends GuParameter {
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   constructor(scope: GuStack, props: GuNoTypeParameterPropsWithAppIdentity) {
     super(scope, AppIdentity.suffixText(props, "InstanceType"), {
       type: "String",
@@ -16,7 +15,6 @@ export class GuInstanceTypeParameter extends GuParameter {
 }
 
 export class GuAmiParameter extends GuParameter {
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   constructor(scope: GuStack, props: GuNoTypeParameterPropsWithAppIdentity) {
     super(scope, AppIdentity.suffixText(props, "AMI"), {
       type: "AWS::EC2::Image::Id",

--- a/src/constructs/core/parameters/identity.ts
+++ b/src/constructs/core/parameters/identity.ts
@@ -3,9 +3,8 @@ import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 
 export class GuStageParameter extends GuStringParameter {
-  public static readonly defaultId = "Stage";
-  constructor(scope: GuStack, id: string = GuStageParameter.defaultId) {
-    super(scope, id, {
+  constructor(scope: GuStack) {
+    super(scope, "Stage", {
       description: "Stage name",
       allowedValues: Stages,
       default: Stage.CODE,
@@ -14,9 +13,8 @@ export class GuStageParameter extends GuStringParameter {
 }
 
 export class GuStackParameter extends GuStringParameter {
-  public static readonly defaultId = "Stack";
-  constructor(scope: GuStack, id: string = GuStackParameter.defaultId) {
-    super(scope, id, {
+  constructor(scope: GuStack) {
+    super(scope, "Stack", {
       description: "Name of this stack",
       default: "deploy",
     });

--- a/src/constructs/core/parameters/log-shipping.ts
+++ b/src/constructs/core/parameters/log-shipping.ts
@@ -4,7 +4,6 @@ import { GuStringParameter } from "./base";
 export class GuLoggingStreamNameParameter extends GuStringParameter {
   private static instance: GuStringParameter | undefined;
 
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   private constructor(scope: GuStack) {
     super(scope, "LoggingStreamName", {
       description: "SSM parameter containing the Name (not ARN) on the kinesis stream",

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -4,7 +4,6 @@ import { GuStringParameter } from "./base";
 export class GuDistributionBucketParameter extends GuStringParameter {
   private static instance: GuDistributionBucketParameter | undefined;
 
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   private constructor(scope: GuStack) {
     super(scope, "DistributionBucketName", {
       description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -29,8 +28,8 @@ export class GuDistributionBucketParameter extends GuStringParameter {
 export class GuPrivateConfigBucketParameter extends GuStringParameter {
   public static parameterName = "PrivateConfigBucketName";
 
-  constructor(scope: GuStack, id: string = GuPrivateConfigBucketParameter.parameterName) {
-    super(scope, id, {
+  constructor(scope: GuStack) {
+    super(scope, GuPrivateConfigBucketParameter.parameterName, {
       description: "SSM parameter containing the S3 bucket name holding the app's private configuration",
       default: "/account/services/private.config.bucket",
       fromSSM: true,

--- a/src/constructs/core/parameters/ses.ts
+++ b/src/constructs/core/parameters/ses.ts
@@ -1,12 +1,10 @@
 import { RegexPattern } from "../../../constants";
 import type { GuStack } from "../stack";
-import type { GuNoTypeParameterProps } from "./base";
 import { GuStringParameter } from "./base";
 
 export class GuGuardianEmailSenderParameter extends GuStringParameter {
-  constructor(scope: GuStack, id: string = "EmailSenderAddress", props?: GuNoTypeParameterProps) {
-    super(scope, id, {
-      ...props,
+  constructor(scope: GuStack) {
+    super(scope, "EmailSenderAddress", {
       allowedPattern: RegexPattern.GUARDIAN_EMAIL,
       constraintDescription: "Must be an @theguardian.com email address",
       description: "The sender of emails sent using SES.",

--- a/src/constructs/iam/policies/cloudwatch.ts
+++ b/src/constructs/iam/policies/cloudwatch.ts
@@ -13,13 +13,15 @@ abstract class GuCloudwatchPolicy extends GuAllowPolicy {
 }
 
 export class GuGetCloudwatchMetricsPolicy extends GuCloudwatchPolicy {
-  constructor(scope: GuStack, id: string = "GuGetCloudwatchMetricsPolicy") {
-    super(scope, id, { actions: ["ListMetrics", "GetMetricData", "GetMetricStatistics", "DescribeAlarmsForMetric"] });
+  constructor(scope: GuStack) {
+    super(scope, "GuGetCloudwatchMetricsPolicy", {
+      actions: ["ListMetrics", "GetMetricData", "GetMetricStatistics", "DescribeAlarmsForMetric"],
+    });
   }
 }
 
 export class GuPutCloudwatchMetricsPolicy extends GuCloudwatchPolicy {
-  constructor(scope: GuStack, id: string = "GuPutCloudwatchMetricsPolicy") {
-    super(scope, id, { actions: ["PutMetricData"] });
+  constructor(scope: GuStack) {
+    super(scope, "GuPutCloudwatchMetricsPolicy", { actions: ["PutMetricData"] });
   }
 }

--- a/src/constructs/iam/policies/describe-ec2.ts
+++ b/src/constructs/iam/policies/describe-ec2.ts
@@ -5,7 +5,6 @@ import { GuPolicy } from "./base-policy";
 export class GuDescribeEC2Policy extends GuPolicy {
   private static instance: GuPolicy | undefined;
 
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   private constructor(scope: GuStack) {
     super(scope, "DescribeEC2Policy", {
       policyName: "describe-ec2-policy",

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -5,7 +5,6 @@ import { GuAllowPolicy } from "./base-policy";
 export class GuLogShippingPolicy extends GuAllowPolicy {
   private static instance: GuLogShippingPolicy | undefined;
 
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   private constructor(scope: GuStack) {
     super(scope, "GuLogShippingPolicy", {
       actions: ["kinesis:Describe*", "kinesis:Put*"],

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -4,7 +4,6 @@ import { AppIdentity } from "../../core/identity";
 import { GuPolicy } from "./base-policy";
 
 export class GuParameterStoreReadPolicy extends GuPolicy {
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   constructor(scope: GuStack, props: AppIdentity) {
     super(scope, AppIdentity.suffixText(props, "ParameterStoreRead"), {
       policyName: "parameter-store-read-policy",

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -19,7 +19,6 @@ export class GuGetS3ObjectsPolicy extends GuAllowPolicy {
 }
 
 export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   constructor(scope: GuStack, props: AppIdentity) {
     const path = [scope.stack, scope.stage, props.app, "*"].join("/");
     super(scope, AppIdentity.suffixText(props, "GetDistributablePolicy"), {

--- a/src/constructs/iam/policies/ses.ts
+++ b/src/constructs/iam/policies/ses.ts
@@ -1,22 +1,14 @@
-import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
 import { GuGuardianEmailSenderParameter } from "../../core";
-import type { GuPolicyProps } from "./base-policy";
-import { GuPolicy } from "./base-policy";
+import { GuAllowPolicy } from "./base-policy";
 
-export class GuSESSenderPolicy extends GuPolicy {
-  constructor(scope: GuStack, id: string = "GuSESSenderPolicy", props?: GuPolicyProps) {
-    super(scope, id, { ...props });
-
+export class GuSESSenderPolicy extends GuAllowPolicy {
+  constructor(scope: GuStack) {
     const emailSenderParam = new GuGuardianEmailSenderParameter(scope);
 
-    this.addStatements(
-      // see https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-policies.html
-      new PolicyStatement({
-        effect: Effect.ALLOW,
-        actions: ["ses:SendEmail"],
-        resources: [`arn:aws:ses:${scope.region}:${scope.account}:identity/${emailSenderParam.valueAsString}`],
-      })
-    );
+    super(scope, "GuSESSenderPolicy", {
+      actions: ["ses:SendEmail"],
+      resources: [`arn:aws:ses:${scope.region}:${scope.account}:identity/${emailSenderParam.valueAsString}`],
+    });
   }
 }

--- a/src/constructs/iam/policies/ssm.ts
+++ b/src/constructs/iam/policies/ssm.ts
@@ -4,7 +4,6 @@ import { GuAllowPolicy } from "./base-policy";
 export class GuSSMRunCommandPolicy extends GuAllowPolicy {
   private static instance: GuSSMRunCommandPolicy | undefined;
 
-  // eslint-disable-next-line custom-rules/valid-constructors -- WIP
   private constructor(scope: GuStack) {
     super(scope, "SSMRunCommandPolicy", {
       policyName: "ssm-run-command-policy",

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -17,7 +17,6 @@ interface GuInstanceRoleProps extends AppIdentity {
 }
 
 export class GuInstanceRole extends GuRole {
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO be better
   constructor(scope: GuStack, props: GuInstanceRoleProps) {
     super(scope, AppIdentity.suffixText(props, "InstanceRole"), {
       overrideId: true,

--- a/src/constructs/loadbalancing/alb.ts
+++ b/src/constructs/loadbalancing/alb.ts
@@ -18,6 +18,7 @@ import { Duration } from "@aws-cdk/core";
 import { RegexPattern } from "../../constants";
 import type { GuStack } from "../core";
 import { GuCertificateArnParameter } from "../core";
+import type { AppIdentity } from "../core/identity";
 
 interface GuApplicationLoadBalancerProps extends ApplicationLoadBalancerProps {
   overrideId?: boolean;
@@ -78,7 +79,8 @@ export class GuApplicationListener extends ApplicationListener {
 }
 
 export interface GuHttpsApplicationListenerProps
-  extends Omit<GuApplicationListenerProps, "defaultAction" | "certificates"> {
+  extends Omit<GuApplicationListenerProps, "defaultAction" | "certificates">,
+    AppIdentity {
   targetGroup: GuApplicationTargetGroup;
   certificate?: string;
 }
@@ -98,11 +100,7 @@ export class GuHttpsApplicationListener extends ApplicationListener {
       ...props,
       certificates: [
         {
-          certificateArn:
-            props.certificate ??
-            new GuCertificateArnParameter(scope, "TLSCertificate", {
-              description: `Certificate ARN for ${id}`,
-            }).valueAsString,
+          certificateArn: props.certificate ?? new GuCertificateArnParameter(scope, props).valueAsString,
         },
       ],
       defaultAction: ListenerAction.forward([props.targetGroup]),

--- a/src/utils/lambda/event-source.ts
+++ b/src/utils/lambda/event-source.ts
@@ -72,7 +72,7 @@ export class StreamRetry {
   }
   private readonly amount: number;
   readonly retryType: RetryType;
-  // eslint-disable-next-line custom-rules/valid-constructors -- TODO only lint for things that extend IConstruct
+
   private constructor(amount: number, type: RetryType) {
     this.amount = amount;
     this.retryType = type;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/**/*",
-    "test/**/*"
+    "test/**/*",
+    "eslint/rules/valid-constructors.test.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We have a lint rule for constructors [because](https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/002-component-constuctors.md):

> This project contains a large number of classes, making up the various constructs and patterns. The project is intended to be used as a component library and, therefore, used by a number of people who don't have extensive knowledge of either the CDK or this library. It is therefore important to make the experience of using these classes as intuitive as possible.

We have a few too many instances of `// eslint-disable-next-line custom-rules/valid-constructors` 😅 .

It looks like this is mainly because the `id` field is static (for example the [`Stage` parameter](https://github.com/guardian/cdk/blob/0c32dbe8a73333b6ebf39d24c3e11d935845cfc0/src/constructs/core/parameters/identity.ts#L5-L14)) or generated by the `props` passed in (for example [`InstanceType`](https://github.com/guardian/cdk/blob/0c32dbe8a73333b6ebf39d24c3e11d935845cfc0/src/constructs/core/parameters/ec2.ts#L6-L16)).

This PR revises the rules to be:

1. Private constructors don't get linted
2. Must be 1, 2 or 3 parameters
3. First parameter must be called scope
4. First parameter must be of type GuStack
5. If 2 parameters:
   - The second parameter must be called props
   - The second parameter must be a custom type
6. If 3 parameters:
   - The second parameter must be called id
   - The second parameter must be of type string
   - The third parameter must be called props
   - The third parameter must be a custom type
7. Only the third parameter can be optional or have a default value

The rules can be seen in practice in the file `eslint/rules/valid-constructors.test.ts`.

It might be easier to review this change commit by commit.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No. A few constructors have been changed, but the way in which they're being used hasn't; that is default parameters are now removed and inlined in the constructor body. I think this makes it ok for this to be a minor release (via feat: prefix in PR title)?

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The custom lint rule reflects reality.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a