### PR TITLE
fix: simplify props for `GuClassicLoadBalancer`

### DIFF
--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -46,18 +46,6 @@ describe("The GuClassicLoadBalancer class", () => {
     expect(Object.keys(json.Resources)).not.toContain("ClassicLoadBalancer");
   });
 
-  test("deletes any provided properties", () => {
-    const stack = simpleGuStackForTesting();
-    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
-      vpc,
-      overrideId: true,
-      propertiesToRemove: [GuClassicLoadBalancer.RemoveableProperties.SCHEME],
-    });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources.ClassicLoadBalancer.Properties)).not.toContain("Scheme");
-  });
-
   test("overrides any properties as required", () => {
     const stack = simpleGuStackForTesting();
     new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -9,20 +9,13 @@ import { Duration } from "@aws-cdk/core";
 import type { GuStack } from "../core";
 import { GuArnParameter } from "../core";
 
-enum RemoveableProperties {
-  SCHEME = "Scheme",
-}
-
 interface GuClassicLoadBalancerProps extends Omit<LoadBalancerProps, "healthCheck"> {
   overrideId?: boolean;
-  propertiesToRemove?: RemoveableProperties[];
   propertiesToOverride?: Record<string, unknown>;
   healthCheck?: Partial<HealthCheck>;
 }
 
 export class GuClassicLoadBalancer extends LoadBalancer {
-  static RemoveableProperties = RemoveableProperties;
-
   static DefaultHealthCheck = {
     port: 9000,
     path: "/healthcheck",
@@ -45,10 +38,6 @@ export class GuClassicLoadBalancer extends LoadBalancer {
 
     if (mergedProps.overrideId || (scope.migratedFromCloudFormation && mergedProps.overrideId !== false))
       cfnLb.overrideLogicalId(id);
-
-    mergedProps.propertiesToRemove?.forEach((key) => {
-      cfnLb.addPropertyDeletionOverride(key);
-    });
 
     mergedProps.propertiesToOverride &&
       Object.entries(mergedProps.propertiesToOverride).forEach(([key, value]) => cfnLb.addPropertyOverride(key, value));


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Removes the `propertiesToRemove` prop. It looks like we were using this to set the scheme on the load balancer, however this is already being driven by the `internetFacing` prop provided by AWS.

For a scheme of "internal", set `internetFacing` to `false`. For a scheme of "internet-facing", set `internetFacing` to `true`.

See:
- https://github.com/aws/aws-cdk/blob/fb6512314db1b11fc608cd62753090684ad0d3c4/packages/%40aws-cdk/aws-elasticloadbalancing/lib/load-balancer.ts#L249
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-scheme

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - the props to `GuClassicLoadBalancer` is changing, with `propertiesToRemove` disappearing, so stacks would need to migrate. The migration is just setting a boolean however, so not too bad.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler API to the construct.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a