### PR TITLE
fix: change to output as ES modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ES2020",
     "moduleResolution": "node",
     "declaration": true,
+    "declarationMap": true,
     "esModuleInterop": true,
     "strict": true,
     "noUnusedLocals": true,
@@ -14,7 +15,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "typeRoots": ["./node_modules/@types"],
-    "outDir": "lib",
+    "outDir": "lib"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "src/**/*.test.ts", "src/**/__snapshots__/**", "src/**/__mocks__/**"]


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This library is broken since v6.0.1 after PR #356. Users face this stack trace:

```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/philip_mcmahon/code/editions/projects/aws/node_modules/read-pkg-up/index.js
require() of ES modules is not supported.
require() of /Users/philip_mcmahon/code/editions/projects/aws/node_modules/read-pkg-up/index.js from /Users/philip_mcmahon/code/editions/projects/aws/node_modules/@guardian/cdk/lib/constants/library-info.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /Users/philip_mcmahon/code/editions/projects/aws/node_modules/read-pkg-up/package.json.
```

This change updates tsconfig to output as ES modules rather than commonjs. This slightly goes against the recommendations (https://github.com/guardian/recommendations/blob/master/npm-packages.md#compiling), however as the library only gets used in controlled environments, this should be fine.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Checkout the branch
- npm link the project
- Update an existing project to use the linked version of `@guardian/cdk`
- Synth a stack
- Observe no errors

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The library can be used again!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a