### PR TITLE
feat: make Wazuh access security group a singleton

### DIFF
--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -1,15 +1,10 @@
-import { SynthUtils } from "@aws-cdk/assert";
 import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
 import { Peer, Port, Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
-import { simpleGuStackForTesting } from "../../utils/test";
-import type { SynthedStack } from "../../utils/test";
-import {
-  GuHttpsEgressSecurityGroup,
-  GuPublicInternetAccessSecurityGroup,
-  GuSecurityGroup,
-  GuWazuhAccess,
-} from "./security-groups";
+import { simpleGuStackForTesting } from "../../../utils/test";
+import type { SynthedStack } from "../../../utils/test";
+import { GuHttpsEgressSecurityGroup, GuPublicInternetAccessSecurityGroup, GuSecurityGroup } from "./base";
 
 describe("The GuSecurityGroup class", () => {
   const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
@@ -108,68 +103,6 @@ describe("The GuSecurityGroup class", () => {
         ingresses: [{ range: Peer.anyIpv4(), description: "SSH access", port: 22 }],
       });
     }).toThrow(new Error("An ingress rule on port 22 is not allowed. Prefer to setup SSH via SSM."));
-  });
-});
-
-describe("The GuWazuhAccess class", () => {
-  const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
-    vpcId: "test",
-    availabilityZones: [""],
-    publicSubnetIds: [""],
-  });
-
-  it("sets props as expected", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc });
-
-    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "Wazuh agent registration and event logging",
-      SecurityGroupEgress: [
-        {
-          CidrIp: "0.0.0.0/0",
-          Description: "Wazuh event logging",
-          FromPort: 1514,
-          IpProtocol: "tcp",
-          ToPort: 1514,
-        },
-        {
-          CidrIp: "0.0.0.0/0",
-          Description: "Wazuh agent registration",
-          FromPort: 1515,
-          IpProtocol: "tcp",
-          ToPort: 1515,
-        },
-      ],
-    });
-  });
-
-  it("merges default and passed in props", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc, description: "This is a test" });
-
-    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "This is a test",
-    });
-  });
-
-  it("overrides the id if the prop is set to true", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("WazuhSecurityGroup");
-  });
-
-  it("does not overrides the id if the prop is set to false", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc, overrideId: false });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("WazuhSecurityGroup");
   });
 });
 

--- a/src/constructs/ec2/security-groups/base.ts
+++ b/src/constructs/ec2/security-groups/base.ts
@@ -1,6 +1,6 @@
 import type { CfnSecurityGroup, IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { Peer, Port, SecurityGroup } from "@aws-cdk/aws-ec2";
-import type { GuStack } from "../core";
+import type { GuStack } from "../../core";
 
 /**
  * A way to describe an ingress or egress rule for a security group.
@@ -64,27 +64,6 @@ export class GuSecurityGroup extends SecurityGroup {
     props.egresses?.forEach(({ range, port, description }) => {
       const connection: Port = typeof port === "number" ? Port.tcp(port) : port;
       this.addEgressRule(range, connection, description);
-    });
-  }
-}
-
-export class GuWazuhAccess extends GuSecurityGroup {
-  private static getDefaultProps(): Partial<GuSecurityGroupProps> {
-    return {
-      description: "Wazuh agent registration and event logging",
-      overrideId: true,
-      allowAllOutbound: false,
-      egresses: [
-        { range: Peer.anyIpv4(), port: 1514, description: "Wazuh event logging" },
-        { range: Peer.anyIpv4(), port: 1515, description: "Wazuh agent registration" },
-      ],
-    };
-  }
-
-  constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
-    super(scope, id, {
-      ...GuWazuhAccess.getDefaultProps(),
-      ...props,
     });
   }
 }

--- a/src/constructs/ec2/security-groups/index.ts
+++ b/src/constructs/ec2/security-groups/index.ts
@@ -1,0 +1,2 @@
+export * from "./base";
+export * from "./wazuh";

--- a/src/constructs/ec2/security-groups/wazuh.test.ts
+++ b/src/constructs/ec2/security-groups/wazuh.test.ts
@@ -1,8 +1,6 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert";
 import { Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
-import type { SynthedStack } from "../../../utils/test";
 import { simpleGuStackForTesting } from "../../../utils/test";
 import { GuWazuhAccess } from "./wazuh";
 
@@ -16,7 +14,7 @@ describe("The GuWazuhAccess class", () => {
   it("sets props as expected", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc });
+    GuWazuhAccess.getInstance(stack, vpc);
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
       GroupDescription: "Wazuh agent registration and event logging",
@@ -37,33 +35,5 @@ describe("The GuWazuhAccess class", () => {
         },
       ],
     });
-  });
-
-  it("merges default and passed in props", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc, description: "This is a test" });
-
-    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "This is a test",
-    });
-  });
-
-  it("overrides the id if the prop is set to true", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("WazuhSecurityGroup");
-  });
-
-  it("does not overrides the id if the prop is set to false", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc, overrideId: false });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("WazuhSecurityGroup");
   });
 });

--- a/src/constructs/ec2/security-groups/wazuh.test.ts
+++ b/src/constructs/ec2/security-groups/wazuh.test.ts
@@ -1,0 +1,69 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { Vpc } from "@aws-cdk/aws-ec2";
+import { Stack } from "@aws-cdk/core";
+import type { SynthedStack } from "../../../utils/test";
+import { simpleGuStackForTesting } from "../../../utils/test";
+import { GuWazuhAccess } from "./wazuh";
+
+describe("The GuWazuhAccess class", () => {
+  const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
+    vpcId: "test",
+    availabilityZones: [""],
+    publicSubnetIds: [""],
+  });
+
+  it("sets props as expected", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc });
+
+    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
+      GroupDescription: "Wazuh agent registration and event logging",
+      SecurityGroupEgress: [
+        {
+          CidrIp: "0.0.0.0/0",
+          Description: "Wazuh event logging",
+          FromPort: 1514,
+          IpProtocol: "tcp",
+          ToPort: 1514,
+        },
+        {
+          CidrIp: "0.0.0.0/0",
+          Description: "Wazuh agent registration",
+          FromPort: 1515,
+          IpProtocol: "tcp",
+          ToPort: 1515,
+        },
+      ],
+    });
+  });
+
+  it("merges default and passed in props", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc, description: "This is a test" });
+
+    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
+      GroupDescription: "This is a test",
+    });
+  });
+
+  it("overrides the id if the prop is set to true", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).toContain("WazuhSecurityGroup");
+  });
+
+  it("does not overrides the id if the prop is set to false", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuWazuhAccess(stack, "WazuhSecurityGroup", { vpc, overrideId: false });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources)).not.toContain("WazuhSecurityGroup");
+  });
+});

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -1,0 +1,25 @@
+import { Peer } from "@aws-cdk/aws-ec2";
+import type { GuStack } from "../../core";
+import type { GuSecurityGroupProps } from "./base";
+import { GuSecurityGroup } from "./base";
+
+export class GuWazuhAccess extends GuSecurityGroup {
+  private static getDefaultProps(): Partial<GuSecurityGroupProps> {
+    return {
+      description: "Wazuh agent registration and event logging",
+      overrideId: true,
+      allowAllOutbound: false,
+      egresses: [
+        { range: Peer.anyIpv4(), port: 1514, description: "Wazuh event logging" },
+        { range: Peer.anyIpv4(), port: 1515, description: "Wazuh agent registration" },
+      ],
+    };
+  }
+
+  constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
+    super(scope, id, {
+      ...GuWazuhAccess.getDefaultProps(),
+      ...props,
+    });
+  }
+}

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -17,7 +17,7 @@ export class GuLogShippingPolicy extends GuAllowPolicy {
   }
 
   public static getInstance(stack: GuStack): GuLogShippingPolicy {
-    // Resources can only live in the same App so return a new `GuSSMRunCommandPolicy` where necessary.
+    // Resources can only live in the same App so return a new instance where necessary.
     // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
     const isSameStack = this.instance?.node.root === stack.node.root;
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We'd only ever want one of these resources defined in a stack as it can be re-used by anything that needs it. This helps keep the overall size of the template down and thus reduces chance of reaching the file size limits of cloudformation.

This change also refactors the security groups, splitting them across multiple files to make them easier to reason about.

Reviewing commit by commit might be easiest.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. Usage of the Wazuh security group would need to change.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler API and reduced chance of reaching the file size limits of cloudformation

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a