### PR TITLE
fix: use high resolution timer for GuSSMIdentityParameter id

### DIFF
--- a/src/constructs/core/index.ts
+++ b/src/constructs/core/index.ts
@@ -1,3 +1,4 @@
 export * from "./mappings";
 export * from "./parameters";
 export * from "./stack";
+export * from "./ssm";

--- a/src/constructs/core/ssm.test.ts
+++ b/src/constructs/core/ssm.test.ts
@@ -48,11 +48,21 @@ describe("SSM:", () => {
 
   describe("the id function", function () {
     it("creates a unique ID given a string", function () {
-      expect(id("NameOfConstruct", "some-parameter")).toMatch(/NameOfConstruct-someparameter/i);
+      const actual1 = id("NameOfConstruct", "some-parameter");
+      const actual2 = id("NameOfConstruct", "some-parameter");
+
+      expect(actual1).toMatch(/NameOfConstruct-someparameter/i);
+      expect(actual2).toMatch(/NameOfConstruct-someparameter/i);
+      expect(actual1).not.toEqual(actual2);
     });
 
     it("will substitute a CDK token for an acceptable string", function () {
-      expect(id("NameOfConstruct", "${TOKEN}foobar")).toMatch(/NameOfConstruct-token/i);
+      const actual1 = id("NameOfConstruct", "${TOKEN}foobar");
+      const actual2 = id("NameOfConstruct", "${TOKEN}foobar");
+
+      expect(actual1).toMatch(/NameOfConstruct-token/i);
+      expect(actual2).toMatch(/NameOfConstruct-token/i);
+      expect(actual1).not.toEqual(actual2);
     });
   });
 });

--- a/src/constructs/core/ssm.test.ts
+++ b/src/constructs/core/ssm.test.ts
@@ -1,6 +1,6 @@
 import "@aws-cdk/assert/jest";
 import { simpleGuStackForTesting } from "../../utils/test";
-import { GuSSMIdentityParameter, GuSSMParameter, id } from "./ssm";
+import { GuSSMIdentityParameter, GuSSMParameter } from "./ssm";
 
 describe("SSM:", () => {
   describe("The GuSSMIdentityParameter construct", () => {
@@ -48,8 +48,8 @@ describe("SSM:", () => {
 
   describe("the id function", function () {
     it("creates a unique ID given a string", function () {
-      const actual1 = id("NameOfConstruct", "some-parameter");
-      const actual2 = id("NameOfConstruct", "some-parameter");
+      const actual1 = GuSSMParameter.id("NameOfConstruct", "some-parameter");
+      const actual2 = GuSSMParameter.id("NameOfConstruct", "some-parameter");
 
       expect(actual1).toMatch(/NameOfConstruct-someparameter/i);
       expect(actual2).toMatch(/NameOfConstruct-someparameter/i);
@@ -57,8 +57,8 @@ describe("SSM:", () => {
     });
 
     it("will substitute a CDK token for an acceptable string", function () {
-      const actual1 = id("NameOfConstruct", "${TOKEN}foobar");
-      const actual2 = id("NameOfConstruct", "${TOKEN}foobar");
+      const actual1 = GuSSMParameter.id("NameOfConstruct", "${TOKEN}foobar");
+      const actual2 = GuSSMParameter.id("NameOfConstruct", "${TOKEN}foobar");
 
       expect(actual1).toMatch(/NameOfConstruct-token/i);
       expect(actual2).toMatch(/NameOfConstruct-token/i);

--- a/src/constructs/core/ssm.ts
+++ b/src/constructs/core/ssm.ts
@@ -20,25 +20,27 @@ export interface GuSSMIdentityParameterProps extends GuSSMParameterProps, AppIde
 
 const stripped = (str: string) => str.replace(/[-/]/g, "");
 
-export function id(id: string, parameter: string): string {
-  // `performance.now()` provides a high resolution timer.
-  // We've seen tests failing in this area with `Date.now()`, the increased resolution should increase uniqueness.
-  // See https://stackoverflow.com/a/21120901/3868241
-  const now: string = performance.now().toString();
-  // We need to create UIDs for the resources in this construct, as otherwise CFN will not trigger the lambda on updates for resources that appear to be the same
-  const uid = now.substr(now.length - 4);
-  return parameter.toUpperCase().includes("TOKEN") ? `${id}-token-${uid}` : `${id}-${stripped(parameter)}-${uid}`;
-}
-
 export class GuSSMParameter extends Construct implements IGrantable {
   private readonly customResource: CustomResource;
   readonly grantPrincipal: IPrincipal;
 
+  static id = (prefix: string, parameter: string): string => {
+    // `performance.now()` provides a high resolution timer.
+    // We've seen tests failing in this area with `Date.now()`, the increased resolution should increase uniqueness.
+    // See https://stackoverflow.com/a/21120901/3868241
+    const now: string = performance.now().toString();
+    // We need to create UIDs for the resources in this construct, as otherwise CFN will not trigger the lambda on updates for resources that appear to be the same
+    const uid = now.substr(now.length - 4);
+    return parameter.toUpperCase().includes("TOKEN")
+      ? `${prefix}-token-${uid}`
+      : `${prefix}-${stripped(parameter)}-${uid}`;
+  };
+
   constructor(scope: GuStack, props: GuSSMParameterProps) {
-    super(scope, id("GuSSMParameter", props.parameter));
+    super(scope, GuSSMParameter.id("GuSSMParameter", props.parameter));
     const { parameter } = props;
 
-    const provider = new SingletonFunction(scope, id("Provider", parameter), {
+    const provider = new SingletonFunction(scope, GuSSMParameter.id("Provider", parameter), {
       code: Code.fromInline(readFileSync(join(__dirname, "/custom-resources/runtime/lambda.js")).toString()),
       runtime: Runtime.NODEJS_12_X,
       handler: "index.handler",
@@ -49,7 +51,7 @@ export class GuSSMParameter extends Construct implements IGrantable {
 
     this.grantPrincipal = provider.grantPrincipal;
 
-    const policy = new Policy(scope, id("CustomResourcePolicy", parameter), {
+    const policy = new Policy(scope, GuSSMParameter.id("CustomResourcePolicy", parameter), {
       statements: [
         new PolicyStatement({
           actions: ["ssm:getParameter"],
@@ -66,7 +68,7 @@ export class GuSSMParameter extends Construct implements IGrantable {
       apiRequest: { Name: parameter, WithDecryption: props.secure },
     };
 
-    this.customResource = new CustomResource(this, id("Resource", parameter), {
+    this.customResource = new CustomResource(this, GuSSMParameter.id("Resource", parameter), {
       resourceType: "Custom::GuGetSSMParameter",
       serviceToken: provider.functionArn,
       pascalCaseProperties: false,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We're seeing the `GuSSMIdentityParameter` tests sporadically fail (for example, [here](https://github.com/guardian/cdk/runs/2234965115?check_suite_focus=true#step:4:104)).

From the code:

> We need to create UIDs for the resources in this construct, as otherwise CFN will not trigger the lambda on updates for resources that appear to be the same

This PR switches to use `performance.now()` for a [high resolution timer](https://www.w3.org/TR/hr-time/) which provides more accuracy than `Date.now()` and thus increases the chance of uniqueness.

I suspect we could also use `Math.random`, but not sure.

This change also adds `ssm`'s exports to `core` and  moves the `id` function to a static function on `GuSSMIdentityParameter` to provide a more explicit namespace. This means usage becomes:

```typescript
import { GuSSMIdentityParameter } from "constructs/core";

GuSSMIdentityParameter.id(???)
```

vs.

```typescript
import { id } from "constructs/core";

id(???)
```

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No, the changes are to the internal interfaces of the project.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We no longer see the sporadic failure of tests 🙏🏽 .

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a