### PR TITLE
fix: use `Math.random` to generate a uid for `GuSSMParameter`

### DIFF
--- a/src/constructs/core/ssm.ts
+++ b/src/constructs/core/ssm.ts
@@ -24,12 +24,11 @@ export class GuSSMParameter extends Construct implements IGrantable {
   readonly grantPrincipal: IPrincipal;
 
   static id = (prefix: string, parameter: string): string => {
-    const now = Date.now().toString();
     // We need to create UIDs for the resources in this construct, as otherwise CFN will not trigger the lambda on updates for resources that appear to be the same
-    const uid = now.substr(now.length - 4);
+    const randomNumberBetweenOneAndTenThousand = Math.floor(Math.random() * 10000) + 1;
     return parameter.toUpperCase().includes("TOKEN")
-      ? `${prefix}-token-${uid}`
-      : `${prefix}-${stripped(parameter)}-${uid}`;
+      ? `${prefix}-token-${randomNumberBetweenOneAndTenThousand}`
+      : `${prefix}-${stripped(parameter)}-${randomNumberBetweenOneAndTenThousand}`;
   };
 
   constructor(scope: GuStack, props: GuSSMParameterProps) {

--- a/src/constructs/core/ssm.ts
+++ b/src/constructs/core/ssm.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "fs";
 import { join } from "path";
-import { performance } from "perf_hooks";
 import type { IGrantable, IPrincipal } from "@aws-cdk/aws-iam";
 import { Policy, PolicyStatement } from "@aws-cdk/aws-iam";
 import { Code, Runtime, SingletonFunction } from "@aws-cdk/aws-lambda";
@@ -25,10 +24,7 @@ export class GuSSMParameter extends Construct implements IGrantable {
   readonly grantPrincipal: IPrincipal;
 
   static id = (prefix: string, parameter: string): string => {
-    // `performance.now()` provides a high resolution timer.
-    // We've seen tests failing in this area with `Date.now()`, the increased resolution should increase uniqueness.
-    // See https://stackoverflow.com/a/21120901/3868241
-    const now: string = performance.now().toString();
+    const now = Date.now().toString();
     // We need to create UIDs for the resources in this construct, as otherwise CFN will not trigger the lambda on updates for resources that appear to be the same
     const uid = now.substr(now.length - 4);
     return parameter.toUpperCase().includes("TOKEN")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This reverts commit 660da8a47d3ccbf93cc424acc370c554c4a5647d as it [hasn't had the desired effect](https://github.com/guardian/cdk/pull/374#issuecomment-811846159) of making the tests more deterministic. Using the clock (via `Date.now()` or `performance.now()`) isn't reliably producing unique numbers, switch to `Math.random`.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Erm, the tests are no worse?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a