### PR TITLE
feat: allow GuSecurityGroup to be specified at the app level

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -122,11 +122,12 @@ describe("The GuAutoScalingGroup", () => {
   });
 
   test("adds any security groups passed through props", () => {
+    const app = "Testing";
     const stack = simpleGuStackForTesting();
 
-    const securityGroup = new GuSecurityGroup(stack, "SecurityGroup", { vpc, overrideId: true });
-    const securityGroup1 = new GuSecurityGroup(stack, "SecurityGroup1", { vpc, overrideId: true });
-    const securityGroup2 = new GuSecurityGroup(stack, "SecurityGroup2", { vpc, overrideId: true });
+    const securityGroup = new GuSecurityGroup(stack, "SecurityGroup", { vpc, overrideId: true, app });
+    const securityGroup1 = new GuSecurityGroup(stack, "SecurityGroup1", { vpc, overrideId: true, app });
+    const securityGroup2 = new GuSecurityGroup(stack, "SecurityGroup2", { vpc, overrideId: true, app });
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       ...defaultProps,
@@ -136,16 +137,16 @@ describe("The GuAutoScalingGroup", () => {
     expect(stack).toHaveResource("AWS::AutoScaling::LaunchConfiguration", {
       SecurityGroups: [
         {
-          "Fn::GetAtt": ["GuHttpsEgressSecurityGroupF63CDA96", "GroupId"],
+          "Fn::GetAtt": [`GuHttpsEgressSecurityGroup${app}89CDDA4B`, "GroupId"],
         },
         {
-          "Fn::GetAtt": ["SecurityGroup", "GroupId"],
+          "Fn::GetAtt": [`SecurityGroup${app}`, "GroupId"],
         },
         {
-          "Fn::GetAtt": ["SecurityGroup1", "GroupId"],
+          "Fn::GetAtt": [`SecurityGroup1${app}`, "GroupId"],
         },
         {
-          "Fn::GetAtt": ["SecurityGroup2", "GroupId"],
+          "Fn::GetAtt": [`SecurityGroup2${app}`, "GroupId"],
         },
       ],
     });

--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -16,16 +16,16 @@ describe("The GuSecurityGroup class", () => {
   it("overrides the id if the prop is set to true", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc, overrideId: true });
+    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc, overrideId: true, app: "testing" });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("TestSecurityGroup");
+    expect(Object.keys(json.Resources)).toContain("TestSecurityGroupTesting");
   });
 
   it("does not overrides the id if the prop is set to false", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc });
+    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc, app: "testing" });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources)).not.toContain("TestSecurityGroup");
@@ -40,6 +40,7 @@ describe("The GuSecurityGroup class", () => {
         { range: Peer.ipv4("127.0.0.1/24"), description: "ingress1", port: 443 },
         { range: Peer.ipv4("127.0.0.2/8"), description: "ingress2", port: 443 },
       ],
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
@@ -72,6 +73,7 @@ describe("The GuSecurityGroup class", () => {
         { range: Peer.ipv4("127.0.0.1/24"), port: Port.tcp(8000), description: "egress1" },
         { range: Peer.ipv4("127.0.0.2/8"), port: Port.tcp(9000), description: "egress2" },
       ],
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
@@ -101,6 +103,7 @@ describe("The GuSecurityGroup class", () => {
       new GuSecurityGroup(stack, "TestSecurityGroup", {
         vpc,
         ingresses: [{ range: Peer.anyIpv4(), description: "SSH access", port: 22 }],
+        app: "testing",
       });
     }).toThrow(new Error("An ingress rule on port 22 is not allowed. Prefer to setup SSH via SSM."));
   });
@@ -118,6 +121,7 @@ describe("The GuPublicInternetAccessSecurityGroup class", () => {
 
     new GuPublicInternetAccessSecurityGroup(stack, "InternetAccessGroup", {
       vpc,
+      app: "testing",
     });
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
@@ -145,7 +149,7 @@ describe("The GuHttpsEgressSecurityGroup class", () => {
   it("adds global access on 443 by default", () => {
     const stack = simpleGuStackForTesting();
 
-    GuHttpsEgressSecurityGroup.forVpc(stack, { vpc });
+    GuHttpsEgressSecurityGroup.forVpc(stack, { vpc, app: "testing" });
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
       GroupDescription: "Allow all outbound HTTPS traffic",

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -1,9 +1,9 @@
 import type { IVpc } from "@aws-cdk/aws-ec2";
 import { Peer } from "@aws-cdk/aws-ec2";
 import type { GuStack } from "../../core";
-import { GuSecurityGroup } from "./base";
+import { GuBaseSecurityGroup } from "./base";
 
-export class GuWazuhAccess extends GuSecurityGroup {
+export class GuWazuhAccess extends GuBaseSecurityGroup {
   private static instance: GuWazuhAccess | undefined;
 
   private constructor(scope: GuStack, vpc: IVpc) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Refactor `GuSecurityGroup` into the vanilla abstract class `GuBaseSecurityGroup` and the concrete class `GuSecurityGroup` which has an `AppIdentity`.

This allows a stack to create a security group scoped to a particular app within a multi app stack.

`GuWazuhAccess` now extends `GuBaseSecurityGroup` as it is a singleton and applies to all apps within a stack.

Follows https://github.com/guardian/cdk/pull/326.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes, they will need to pass in an `AppIdentity` as the props for `GuSecurityGroup` have changed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

No new tests added. Existing tests should pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is possible to define a security group for a specific app within a stack and have it tagged with the `App` tag.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a