### PR TITLE
refactor!: Improve Mappings helper function(s)

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -62,13 +62,18 @@ export class GuStack extends Stack implements StackStageIdentity {
     return this._mappings ?? (this._mappings = new GuStageMapping(this));
   }
 
-  setStageDependentValue<T extends string | number | boolean>(stageDependentValue: GuStageDependentValue<T>): void {
+  /**
+   * A helper function to switch between different values depending on the Stage being CloudFormed (e.g.
+   * use 1 in `CODE` or 3 in `PROD`).
+   *
+   * Note: Standard conditional logic which references a CloudFormation Parameter's value will not work
+   * as Parameters are not resolved at synth-time. This helper function creates CloudFormation
+   * Mappings to work around this limitation.
+   */
+  withStageDependentValue<T extends string | number | boolean>(stageDependentValue: GuStageDependentValue<T>): T {
     this.mappings.setValue(Stage.CODE, stageDependentValue.variableName, stageDependentValue.stageValues.CODE);
     this.mappings.setValue(Stage.PROD, stageDependentValue.variableName, stageDependentValue.stageValues.PROD);
-  }
-
-  getStageDependentValue<T>(key: string): T {
-    return (this.mappings.findInMap(this.stage, key) as unknown) as T;
+    return (this.mappings.findInMap(this.stage, stageDependentValue.variableName) as unknown) as T;
   }
 
   /**


### PR DESCRIPTION
## What does this change?

The `setStageDependentValue` and `getStageDependentValue` helper functions have been removed. In order to reduce boilerplate, the same functionality is now provided via a single function (`withStageDependentValue`).

## Does this change require changes to existing projects or CDK CLI?

Yes, this is a breaking change. Stacks which use `setStageDependentValue` and `getStageDependentValue` directly will need to use `withStageDependentValue` instead. Stacks which use this functionality via the ASG construct should be unaffected.

## How to test

[Existing ASG unit tests](https://github.com/guardian/cdk/blob/3bbd3124819876ef0dc1a4c8a3e361d7481e01c8/src/constructs/autoscaling/asg.test.ts#L181-L258) already validate this behaviour (and they still pass!).

## How can we measure success?

* Less boilerplate is needed to use stage-dependent values.

## Have we considered potential risks?

As mentioned above, this is a breaking change. However, as this functionality is not widely adopted yet I think it's relatively low risk to make the change at this early stage of development.
