### PR TITLE
fix: use traffic port for ALB healthcheck by default

### DIFF
--- a/src/constructs/loadbalancing/alb.test.ts
+++ b/src/constructs/loadbalancing/alb.test.ts
@@ -124,7 +124,6 @@ describe("The GuApplicationTargetGroup class", () => {
     expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
       HealthCheckIntervalSeconds: 30,
       HealthCheckPath: "/healthcheck",
-      HealthCheckPort: "9000",
       HealthCheckProtocol: "HTTP",
       HealthCheckTimeoutSeconds: 10,
       HealthyThresholdCount: 2,
@@ -138,6 +137,7 @@ describe("The GuApplicationTargetGroup class", () => {
       vpc,
       healthCheck: {
         path: "/test",
+        port: "9000",
       },
     });
 

--- a/src/constructs/loadbalancing/alb.ts
+++ b/src/constructs/loadbalancing/alb.ts
@@ -43,7 +43,6 @@ export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupPro
 
 export class GuApplicationTargetGroup extends ApplicationTargetGroup {
   static DefaultHealthCheck = {
-    port: "9000",
     path: "/healthcheck",
     protocol: Protocol.HTTP,
     healthyThresholdCount: 2,


### PR DESCRIPTION
## What does this change?
This simplifies the default healthcheck for ALBs by [defaulting to using the traffic port](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthcheckport), rather than defaulting to a commonly used (but hardcoded) value.

## Does this change require changes to existing projects or CDK CLI?
I think it's very unlikely that any existing projects will be affected by this change.*

## How to test
I think the updated unit tests are sufficient?

## How can we measure success?
When defining the EC2 App pattern, we'll no longer need to override this default when a different traffic/application port is specified.

## Have we considered potential risks?
*There is a small risk that a project is currently relying on this default to perform a healthcheck via port 9000 even though they are sending all other traffic to a different port. This strikes me as extremely unlikely, particularly given the low adoption levels for this project at this stage!