### PR TITLE
fix: Improve GuAutoScalingGroup's support of a multi-app stack

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -6,7 +6,7 @@ import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2
 import { Stage } from "../../constants";
 import type { GuStack } from "../core";
 import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
-import type { AppIdentity } from "../core/identity";
+import { AppIdentity } from "../core/identity";
 import { GuHttpsEgressSecurityGroup } from "../ec2";
 
 // Since we want to override the types of what gets passed in for the below props,
@@ -104,7 +104,7 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
       securityGroup: GuHttpsEgressSecurityGroup.forVpc(scope, props),
     };
 
-    super(scope, id, mergedProps);
+    super(scope, AppIdentity.suffixText(props, id), mergedProps);
 
     mergedProps.targetGroup && this.attachToApplicationTargetGroup(mergedProps.targetGroup);
 
@@ -117,5 +117,7 @@ export class GuAutoScalingGroup extends AutoScalingGroup {
     cfnAsg.addDeletionOverride("UpdatePolicy");
 
     if (mergedProps.overrideId) cfnAsg.overrideLogicalId(id);
+
+    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/utils/test/alphabetical-tags.ts
+++ b/src/utils/test/alphabetical-tags.ts
@@ -1,6 +1,7 @@
 interface Tag {
   Key: string;
   Value: unknown;
+  PropagateAtLaunch?: boolean;
 }
 
 export function alphabeticalTags(tags: Tag[]): Tag[] {

--- a/src/utils/test/jest.ts
+++ b/src/utils/test/jest.ts
@@ -1,0 +1,41 @@
+import { SynthUtils } from "@aws-cdk/assert";
+import type { GuStack } from "../../constructs/core";
+import type { SynthedStack } from "./synthed-stack";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- custom Jest matcher
+  namespace jest {
+    interface Matchers<R> {
+      toHaveResourceOfTypeAndLogicalId(resourceType: string, logicalId: string | RegExp): R;
+    }
+  }
+}
+
+expect.extend({
+  /**
+   * A helper function to assert a stack has a resource of a particular type and logicalId.
+   * Useful for when the logicalId is auto-generated.
+   * @param stack the stack to make an assertion on
+   * @param resourceType the AWS resource type string, for example "AWS::AutoScaling::AutoScalingGroup"
+   * @param logicalId a string or regex pattern to match against the resource's logicalId
+   */
+  toHaveResourceOfTypeAndLogicalId(stack: GuStack, resourceType: string, logicalId: string | RegExp) {
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    const matchResult = Object.entries(json.Resources).find(([key, { Type }]) => {
+      const logicalIdMatch = logicalId instanceof RegExp ? logicalId.test(key) : key === logicalId;
+      const typeMatch = Type === resourceType;
+      return logicalIdMatch && typeMatch;
+    });
+
+    return matchResult
+      ? {
+          pass: true,
+          message: () => "",
+        }
+      : {
+          pass: false,
+          message: () => `No resource found matching logicalId ${logicalId.toString()} and Type ${resourceType}`,
+        };
+  },
+});

--- a/src/utils/test/synthed-stack.ts
+++ b/src/utils/test/synthed-stack.ts
@@ -1,5 +1,17 @@
+import type { Stage } from "../../constants";
+
+interface Parameter {
+  Type: string;
+  Description: string;
+  Default?: string | number;
+  AllowedValues?: Array<string | number>;
+}
+
+type ResourceProperty = Record<string, unknown>;
+type Resource = Record<string, { Type: string; Properties: ResourceProperty }>;
+
 export interface SynthedStack {
-  Parameters: Record<string, { Properties: Record<string, unknown> }>;
-  Mappings: Record<string, unknown>;
-  Resources: Record<string, { Properties: Record<string, unknown> }>;
+  Parameters: Record<string, Parameter>;
+  Mappings: Record<Stage, unknown>;
+  Resources: Resource;
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

For consistency with other constructs, suffix the `id` of `GuAutoScalingGroup` with the `app`. This ensures the logicalId is unique both on the auto-generated path and the `existingLogicalId` path.

Also adds a [custom Jest matcher](https://jestjs.io/docs/expect#custom-matchers-api) to simplify logicalId testing. It is fairly common to want to test the logicalId of a resource. This can be tricky as:
  - constructs that have an `AppIdentity` will suffix the `id` with the app value
  - not every construct supports static logicalIds and will always be auto-generated

Rather than passing in the `id` with a combination of `migratedFromCloudFormation` and `existingLogicalId` to get a static/deterministic logicalId, we can pass a regex to the new `toHaveResourceOfTypeAndLogicalId` matcher, asserting the stack has a resource of type x with logicalId y.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. Their ASG's will have updated logicalIds (if auto-generated) and an additional tag.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See new test.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More deterministic behaviour across the constructs in the library.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a