### PR TITLE
refactor: Stop producing migration messages in TEST

### DIFF
--- a/src/constructs/core/migrating.test.ts
+++ b/src/constructs/core/migrating.test.ts
@@ -2,6 +2,7 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import type { BucketProps } from "@aws-cdk/aws-s3";
 import { Bucket } from "@aws-cdk/aws-s3";
+import { Logger } from "../../utils/logger";
 import type { SynthedStack } from "../../utils/test";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { GuStatefulConstruct } from "./migrating";
@@ -23,11 +24,8 @@ We're calling it here to test the function in isolation.
  */
 
 describe("GuMigratingResource", () => {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function -- we are testing `console.info` being called, we don't need to see the message
-  const info = jest.spyOn(console, "info").mockImplementation(() => {});
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function -- we are testing `console.warn` being called, we don't need to see the message
-  const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  const info = jest.spyOn(Logger, "info");
+  const warn = jest.spyOn(Logger, "warn");
 
   afterEach(() => {
     warn.mockReset();

--- a/src/constructs/core/migrating.ts
+++ b/src/constructs/core/migrating.ts
@@ -1,4 +1,5 @@
 import type { CfnElement, IConstruct } from "@aws-cdk/core";
+import { Logger } from "../../utils/logger";
 import type { GuStack } from "./stack";
 
 export interface GuMigratingResource {
@@ -46,19 +47,19 @@ export const GuMigratingResource = {
       }
 
       if (isStateful) {
-        console.warn(
+        Logger.warn(
           `GuStack has 'migratedFromCloudFormation' set to true. ${id} is a stateful construct and 'existingLogicalId' has not been set. ${id}'s logicalId will be auto-generated and consequently AWS will create a new resource rather than inheriting an existing one. This is not advised as downstream services, such as DNS, will likely need updating.`
         );
       }
     } else {
       if (existingLogicalId) {
-        console.warn(
+        Logger.warn(
           `GuStack has 'migratedFromCloudFormation' set to false. ${id} has an 'existingLogicalId' set to ${existingLogicalId}. This will have no effect - the logicalId will be auto-generated. Set 'migratedFromCloudFormation' to true for 'existingLogicalId' to be observed.`
         );
       }
 
       if (isStateful) {
-        console.info(
+        Logger.info(
           `GuStack has 'migratedFromCloudFormation' set to false. ${id} is a stateful construct, it's logicalId will be auto-generated and AWS will create a new resource.`
         );
       }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,18 @@
+/**
+ * A small wrapper around `console`.
+ *
+ * Messages will only get printed if NODE_ENV is not test.
+ * This is to reduce noise in a test environment.
+ * Jest's `--silent` flag isn't used as that has a global impact.
+ */
+export class Logger {
+  private static isTest = process.env.NODE_ENV === "test";
+
+  static info(message: string): void {
+    !Logger.isTest && console.info(message);
+  }
+
+  static warn(message: string): void {
+    !Logger.isTest && console.warn(message);
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As we migrate to the new logicalId logic introduced in #364, we'll see the migration messages more and more.
As these messages are expected, we can afford to stop producing them in TEST to avoid the build log becoming too noisy.

An example of noisy build log can be seen [here](https://github.com/guardian/cdk/runs/2294779782?check_suite_focus=true#step:4:45).

![image](https://user-images.githubusercontent.com/836140/113993252-26c03800-984c-11eb-90aa-b82b04bd9d7c.png)

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See the build log?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A quieter build log will highlight any genuine errors more easily.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a