### PR TITLE
fix: Adopt new logicalId override logic across the constructs

### DIFF
--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -1,4 +1,5 @@
 import "@aws-cdk/assert/jest";
+import "../../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Peer, Port, Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
@@ -13,13 +14,11 @@ describe("The GuSecurityGroup class", () => {
     publicSubnetIds: [""],
   });
 
-  it("overrides the id if the prop is set to true", () => {
-    const stack = simpleGuStackForTesting();
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc, existingLogicalId: "TestSG", app: "testing" });
 
-    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc, overrideId: true, app: "testing" });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("TestSecurityGroupTesting");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::EC2::SecurityGroup", "TestSG");
   });
 
   it("does not overrides the id if the prop is set to false", () => {

--- a/src/constructs/iam/policies/base-policy.ts
+++ b/src/constructs/iam/policies/base-policy.ts
@@ -1,21 +1,16 @@
-import type { CfnPolicy, PolicyProps } from "@aws-cdk/aws-iam";
+import type { PolicyProps } from "@aws-cdk/aws-iam";
 import { Effect, Policy, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
+import { GuMigratingResource } from "../../core/migrating";
 
-export interface GuPolicyProps extends PolicyProps {
-  overrideId?: boolean;
-}
+export interface GuPolicyProps extends PolicyProps, GuMigratingResource {}
 
 export type GuNoStatementsPolicyProps = Omit<GuPolicyProps, "statements">;
 
 export abstract class GuPolicy extends Policy {
   protected constructor(scope: GuStack, id: string, props: GuPolicyProps) {
     super(scope, id, props);
-
-    if (props.overrideId) {
-      const child = this.node.defaultChild as CfnPolicy;
-      child.overrideLogicalId(id);
-    }
+    GuMigratingResource.setLogicalId(this, scope, props);
   }
 }
 

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -39,7 +39,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -60,7 +60,7 @@ Object {
         "PolicyName": "GetConfigPolicy6F934A1C",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -96,13 +96,13 @@ Object {
         "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleTesting": Object {
+    "InstanceRoleTestingCB7BD146": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -184,7 +184,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -220,7 +220,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -274,10 +274,10 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -313,7 +313,7 @@ Object {
         "PolicyName": "GetDistributablePolicyMyfirstappB56CBAB1",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
         ],
       },
@@ -349,7 +349,7 @@ Object {
         "PolicyName": "GetDistributablePolicyMysecondapp5096BFDB",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -391,16 +391,16 @@ Object {
         "PolicyName": "GuLogShippingPolicy981BFE5A",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleMyfirstapp": Object {
+    "InstanceRoleMyfirstapp5C11A22B": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -448,7 +448,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "InstanceRoleMysecondapp": Object {
+    "InstanceRoleMysecondapp48DD15D7": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -530,7 +530,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
         ],
       },
@@ -570,7 +570,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -606,10 +606,10 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -663,7 +663,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -699,7 +699,7 @@ Object {
         "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -741,13 +741,13 @@ Object {
         "PolicyName": "GuLogShippingPolicy981BFE5A",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleTesting": Object {
+    "InstanceRoleTestingCB7BD146": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -829,7 +829,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -865,7 +865,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -914,7 +914,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -950,13 +950,13 @@ Object {
         "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleTesting": Object {
+    "InstanceRoleTestingCB7BD146": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1038,7 +1038,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -1074,7 +1074,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -19,7 +19,6 @@ interface GuInstanceRoleProps extends AppIdentity {
 export class GuInstanceRole extends GuRole {
   constructor(scope: GuStack, props: GuInstanceRoleProps) {
     super(scope, AppIdentity.suffixText(props, "InstanceRole"), {
-      overrideId: true,
       path: "/",
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
     });

--- a/src/constructs/iam/roles/roles.test.ts
+++ b/src/constructs/iam/roles/roles.test.ts
@@ -1,21 +1,21 @@
-import { SynthUtils } from "@aws-cdk/assert";
 import "@aws-cdk/assert/jest";
+import "../../../utils/test/jest";
+import { SynthUtils } from "@aws-cdk/assert";
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
 import { simpleGuStackForTesting } from "../../../utils/test";
 import type { SynthedStack } from "../../../utils/test";
 import { GuRole } from "./roles";
 
 describe("The GuRole class", () => {
-  it("overrides id if prop set to true", () => {
-    const stack = simpleGuStackForTesting();
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
     new GuRole(stack, "TestRole", {
-      overrideId: true,
+      existingLogicalId: "MyRole",
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
     });
 
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("TestRole");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Role", "MyRole");
   });
 
   it("does not override id if prop set to false", () => {

--- a/src/constructs/iam/roles/roles.ts
+++ b/src/constructs/iam/roles/roles.ts
@@ -1,21 +1,18 @@
 import type { CfnRole, RoleProps } from "@aws-cdk/aws-iam";
 import { Role } from "@aws-cdk/aws-iam";
 import type { GuStack } from "../../core";
+import { GuMigratingResource } from "../../core/migrating";
 
-export interface GuRoleProps extends RoleProps {
-  overrideId?: boolean;
-}
+export interface GuRoleProps extends RoleProps, GuMigratingResource {}
 
 export class GuRole extends Role {
   private child: CfnRole;
 
   constructor(scope: GuStack, id: string, props: GuRoleProps) {
     super(scope, id, props);
+    GuMigratingResource.setLogicalId(this, scope, props);
 
     this.child = this.node.defaultChild as CfnRole;
-    if (props.overrideId) {
-      this.child.overrideLogicalId(id);
-    }
   }
 
   get ref(): string {

--- a/src/constructs/kinesis/kinesis-stream.test.ts
+++ b/src/constructs/kinesis/kinesis-stream.test.ts
@@ -1,6 +1,5 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import type { SynthedStack } from "../../utils/test";
+import "../../utils/test/jest";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuKinesisStream } from "./kinesis-stream";
 
@@ -8,14 +7,14 @@ describe("The GuKinesisStream construct", () => {
   it("should not override the id by default", () => {
     const stack = simpleGuStackForTesting();
     new GuKinesisStream(stack, "my-kinesis-stream");
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("my-kinesis-stream");
+
+    expect(stack).not.toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", "my-kinesis-stream");
   });
 
-  it("should override the id with the overrideId prop set to true", () => {
-    const stack = simpleGuStackForTesting();
-    new GuKinesisStream(stack, "my-kinesis-stream", { overrideId: true });
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("my-kinesis-stream");
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuKinesisStream(stack, "my-kinesis-stream", { existingLogicalId: "MyStream" });
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", "MyStream");
   });
 });

--- a/src/constructs/kinesis/kinesis-stream.ts
+++ b/src/constructs/kinesis/kinesis-stream.ts
@@ -1,15 +1,13 @@
-import type { CfnStream, StreamProps } from "@aws-cdk/aws-kinesis";
+import type { StreamProps } from "@aws-cdk/aws-kinesis";
 import { Stream } from "@aws-cdk/aws-kinesis";
 import type { GuStack } from "../core";
+import { GuMigratingResource } from "../core/migrating";
 
-export interface GuKinesisStreamProps extends StreamProps {
-  overrideId?: boolean;
-}
+export interface GuKinesisStreamProps extends StreamProps, GuMigratingResource {}
 
 export class GuKinesisStream extends Stream {
   constructor(scope: GuStack, id: string, props?: GuKinesisStreamProps) {
     super(scope, id, props);
-    const cfnKinesisStream = this.node.defaultChild as CfnStream;
-    if (props?.overrideId) cfnKinesisStream.overrideLogicalId(id);
+    props && GuMigratingResource.setLogicalId(this, scope, props);
   }
 }

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -1,17 +1,23 @@
 import { InstanceType } from "@aws-cdk/aws-ec2";
-import type { CfnDBInstance, DatabaseInstanceProps, IParameterGroup } from "@aws-cdk/aws-rds";
+import type { DatabaseInstanceProps, IParameterGroup } from "@aws-cdk/aws-rds";
 import { DatabaseInstance, ParameterGroup } from "@aws-cdk/aws-rds";
 import { Fn } from "@aws-cdk/core";
 import type { GuStack } from "../core";
 import { AppIdentity } from "../core/identity";
+import { GuMigratingResource } from "../core/migrating";
+import type { GuStatefulConstruct } from "../core/migrating";
 
-export interface GuDatabaseInstanceProps extends Omit<DatabaseInstanceProps, "instanceType">, AppIdentity {
-  overrideId?: boolean;
+export interface GuDatabaseInstanceProps
+  extends Omit<DatabaseInstanceProps, "instanceType">,
+    AppIdentity,
+    GuMigratingResource {
   instanceType: string;
   parameters?: Record<string, string>;
 }
 
-export class GuDatabaseInstance extends DatabaseInstance {
+export class GuDatabaseInstance extends DatabaseInstance implements GuStatefulConstruct {
+  public readonly isStatefulConstruct: true;
+
   constructor(scope: GuStack, id: string, props: GuDatabaseInstanceProps) {
     // CDK just wants "t3.micro" format, whereas
     // some CFN yaml might have the older "db.t3.micro" with the "db." prefix
@@ -34,10 +40,8 @@ export class GuDatabaseInstance extends DatabaseInstance {
       instanceType,
       ...(parameterGroup && { parameterGroup }),
     });
-
-    if (props.overrideId || (scope.migratedFromCloudFormation && props.overrideId !== false)) {
-      (this.node.defaultChild as CfnDBInstance).overrideLogicalId(id);
-    }
+    this.isStatefulConstruct = true;
+    GuMigratingResource.setLogicalId(this, scope, props);
 
     parameterGroup && AppIdentity.taggedConstruct(props, parameterGroup);
     AppIdentity.taggedConstruct(props, this);

--- a/src/constructs/sns/sns-topic.test.ts
+++ b/src/constructs/sns/sns-topic.test.ts
@@ -1,21 +1,20 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import type { SynthedStack } from "../../utils/test";
+import "../../utils/test/jest";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuSnsTopic } from "./sns-topic";
 
 describe("The GuSnsTopic construct", () => {
   it("should not override the id by default", () => {
     const stack = simpleGuStackForTesting();
-    new GuSnsTopic(stack, "my-sns-topic");
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("my-sns-topic");
+    new GuSnsTopic(stack, "MySnsTopic");
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", /MySnsTopic.+/);
   });
 
-  it("should override the id with the overrideId prop set to true", () => {
-    const stack = simpleGuStackForTesting();
-    new GuSnsTopic(stack, "my-sns-topic", { overrideId: true });
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("my-sns-topic");
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuSnsTopic(stack, "my-sns-topic", { existingLogicalId: "TheSnsTopic" });
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", "TheSnsTopic");
   });
 });

--- a/src/constructs/sns/sns-topic.ts
+++ b/src/constructs/sns/sns-topic.ts
@@ -1,15 +1,13 @@
 import { Topic } from "@aws-cdk/aws-sns";
-import type { CfnTopic, TopicProps } from "@aws-cdk/aws-sns";
+import type { TopicProps } from "@aws-cdk/aws-sns";
 import type { GuStack } from "../core";
+import { GuMigratingResource } from "../core/migrating";
 
-interface GuSnsTopicProps extends TopicProps {
-  overrideId?: boolean;
-}
+interface GuSnsTopicProps extends TopicProps, GuMigratingResource {}
 
 export class GuSnsTopic extends Topic {
   constructor(scope: GuStack, id: string, props?: GuSnsTopicProps) {
     super(scope, id, props);
-    const cfnSnsTopic = this.node.defaultChild as CfnTopic;
-    if (props?.overrideId) cfnSnsTopic.overrideLogicalId(id);
+    props && GuMigratingResource.setLogicalId(this, scope, props);
   }
 }

--- a/src/patterns/kinesis-lambda.test.ts
+++ b/src/patterns/kinesis-lambda.test.ts
@@ -32,8 +32,8 @@ describe("The GuKinesisLambda pattern", () => {
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 
-  it("should inherit an existing Kinesis stream correctly if logicalIdFromCloudFormation is passed in", () => {
-    const stack = simpleGuStackForTesting();
+  it("should inherit an existing Kinesis stream correctly if an existingLogicalId is passed via existingSnsTopic in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     const basicErrorHandling: StreamErrorHandlingProps = {
       bisectBatchOnError: false,
       retryBehaviour: StreamRetry.maxAttempts(1),
@@ -46,7 +46,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
-      existingKinesisStream: { logicalIdFromCloudFormation: "pre-existing-kinesis-stream" },
+      existingKinesisStream: { existingLogicalId: "pre-existing-kinesis-stream" },
       app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -6,6 +6,7 @@ import { KinesisEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
+import type { GuMigratingResource } from "../constructs/core/migrating";
 import type { GuKinesisStreamProps } from "../constructs/kinesis";
 import { GuKinesisStream } from "../constructs/kinesis";
 import type { GuFunctionProps } from "../constructs/lambda";
@@ -40,8 +41,7 @@ import { toAwsErrorHandlingProps } from "../utils/lambda";
  * existingKinesisStream: { externalKinesisStreamName: "KinesisStreamFromAnotherStack" }
  * ```
  */
-export interface ExistingKinesisStream {
-  logicalIdFromCloudFormation?: string;
+export interface ExistingKinesisStream extends GuMigratingResource {
   externalKinesisStreamName?: string;
 }
 
@@ -104,11 +104,11 @@ export class GuKinesisLambda extends GuLambdaFunction {
       errorPercentageMonitoring: props.monitoringConfiguration.noMonitoring ? undefined : props.monitoringConfiguration,
     });
     const kinesisProps: GuKinesisStreamProps = {
-      overrideId: !!props.existingKinesisStream?.logicalIdFromCloudFormation,
+      existingLogicalId: props.existingKinesisStream?.existingLogicalId,
       encryption: StreamEncryption.MANAGED,
       ...props.kinesisStreamProps,
     };
-    const streamId = props.existingKinesisStream?.logicalIdFromCloudFormation ?? "KinesisStream";
+    const streamId = props.existingKinesisStream?.existingLogicalId ?? "KinesisStream";
 
     const kinesisStream = props.existingKinesisStream?.externalKinesisStreamName
       ? Stream.fromStreamArn(

--- a/src/patterns/sns-lambda.test.ts
+++ b/src/patterns/sns-lambda.test.ts
@@ -22,8 +22,8 @@ describe("The GuSnsLambda pattern", () => {
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 
-  it("should inherit an existing SNS topic correctly if a logicalIdFromCloudFormation is passed via existingSnsTopic", () => {
-    const stack = simpleGuStackForTesting();
+  it("should inherit an existing SNS topic correctly if an existingLogicalId is passed via existingSnsTopic in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     const noMonitoring: NoMonitoring = { noMonitoring: true };
     const props = {
       code: { bucket: "test-dist", key: "lambda.zip" },
@@ -31,7 +31,7 @@ describe("The GuSnsLambda pattern", () => {
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
       monitoringConfiguration: noMonitoring,
-      existingSnsTopic: { logicalIdFromCloudFormation: "in-use-sns-topic" },
+      existingSnsTopic: { existingLogicalId: "in-use-sns-topic" },
       app: "testing",
     };
     new GuSnsLambda(stack, "my-lambda-function", props);

--- a/src/utils/test/jest.ts
+++ b/src/utils/test/jest.ts
@@ -1,6 +1,5 @@
-import { SynthUtils } from "@aws-cdk/assert";
 import type { GuStack } from "../../constructs/core";
-import type { SynthedStack } from "./synthed-stack";
+import { findResourceByTypeAndLogicalId } from "./synthed-stack";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace -- custom Jest matcher
@@ -20,13 +19,7 @@ expect.extend({
    * @param logicalId a string or regex pattern to match against the resource's logicalId
    */
   toHaveResourceOfTypeAndLogicalId(stack: GuStack, resourceType: string, logicalId: string | RegExp) {
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    const matchResult = Object.entries(json.Resources).find(([key, { Type }]) => {
-      const logicalIdMatch = logicalId instanceof RegExp ? logicalId.test(key) : key === logicalId;
-      const typeMatch = Type === resourceType;
-      return logicalIdMatch && typeMatch;
-    });
+    const matchResult = findResourceByTypeAndLogicalId(stack, resourceType, logicalId);
 
     return matchResult
       ? {

--- a/src/utils/test/synthed-stack.ts
+++ b/src/utils/test/synthed-stack.ts
@@ -1,17 +1,47 @@
+import { SynthUtils } from "@aws-cdk/assert";
 import type { Stage } from "../../constants";
+import type { GuStack } from "../../constructs/core";
 
-interface Parameter {
+export interface Parameter {
   Type: string;
   Description: string;
   Default?: string | number;
   AllowedValues?: Array<string | number>;
 }
 
-type ResourceProperty = Record<string, unknown>;
-type Resource = Record<string, { Type: string; Properties: ResourceProperty }>;
+export type ResourceProperty = Record<string, unknown>;
+export type Resource = Record<string, { Type: string; Properties: ResourceProperty; UpdatePolicy?: unknown }>;
 
 export interface SynthedStack {
   Parameters: Record<string, Parameter>;
   Mappings: Record<Stage, unknown>;
   Resources: Resource;
 }
+
+/**
+ * A helper function to find a resource of a particular type and logicalId within a stack.
+ * Useful for when the logicalId is auto-generated.
+ * @param stack the stack to search in
+ * @param resourceType the AWS resource type string, for example "AWS::AutoScaling::AutoScalingGroup"
+ * @param logicalIdPattern a string or regex pattern to match against the resource's logicalId
+ */
+export const findResourceByTypeAndLogicalId = (
+  stack: GuStack,
+  resourceType: string,
+  logicalIdPattern: string | RegExp
+): Resource | undefined => {
+  const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+  const match = Object.entries(json.Resources).find(([key, { Type }]) => {
+    const logicalIdMatch = logicalIdPattern instanceof RegExp ? logicalIdPattern.test(key) : key === logicalIdPattern;
+    const typeMatch = Type === resourceType;
+    return logicalIdMatch && typeMatch;
+  });
+
+  if (match) {
+    const [logicalId, resource] = match;
+    return { [logicalId]: resource };
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we simplified and encapsulated the logic to override a construct's logicalId.

This change adopts the new logic into the constructs.

As a consequence to this a number of tests have been moved to using the auto-generated logicalId. This reduces the variables in play in our tests and therefore simplifies them.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - the `overrideId` prop is being removed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See updated tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

DRYer code and greater consistency in behaviour across constructs.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a