### PR TITLE
fix: Hardcode the logicalId for `GuWazuhAccess`

### DIFF
--- a/src/constructs/core/migrating.ts
+++ b/src/constructs/core/migrating.ts
@@ -1,6 +1,17 @@
 import type { CfnElement, IConstruct } from "@aws-cdk/core";
 import { Logger } from "../../utils/logger";
-import type { GuStack } from "./stack";
+
+export interface GuMigratingStack {
+  /**
+   * A flag to symbolise if a stack is being migrated from a previous format (eg YAML) into guardian/cdk.
+   * A value of `true` means resources in the stack can have custom logicalIds set using the property `existingLogicalId` (where available).
+   * A value of `false` or `undefined` means the stack is brand new. Any resource that gets created will have an auto-generated logicalId.
+   * Ideally, for use only by [[ `GuStack` ]].
+   * @see GuMigratingResource
+   * @see GuStack
+   */
+  migratedFromCloudFormation?: boolean;
+}
 
 export interface GuMigratingResource {
   /**
@@ -12,8 +23,8 @@ export interface GuMigratingResource {
    * Otherwise it will be created as something like `DotcomLoadbalancerABCDEF`,
    * is a new resource, and require any DNS entries to be updated accordingly.
    *
-   * @requires `migratedFromCloudFormation` to be true in [[ GuStack ]]
-   * @see GuStackProps
+   * @see GuMigratingStack
+   * @see GuStack
    */
   existingLogicalId?: string;
 }
@@ -30,7 +41,7 @@ function isGuStatefulConstruct(construct: any): construct is GuStatefulConstruct
 export const GuMigratingResource = {
   setLogicalId<T extends GuStatefulConstruct | IConstruct>(
     construct: T,
-    { migratedFromCloudFormation }: GuStack,
+    { migratedFromCloudFormation }: GuMigratingStack,
     { existingLogicalId }: GuMigratingResource
   ): void {
     const overrideLogicalId = (logicalId: string) => {

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -5,20 +5,12 @@ import { TrackingTag } from "../../constants/library-info";
 import type { StackStageIdentity } from "./identity";
 import type { GuStageDependentValue } from "./mappings";
 import { GuStageMapping } from "./mappings";
+import type { GuMigratingStack } from "./migrating";
 import type { GuParameter } from "./parameters";
 import { GuStageParameter } from "./parameters";
 
-export interface GuStackProps extends StackProps {
+export interface GuStackProps extends StackProps, GuMigratingStack {
   stack: string;
-
-  /**
-   * A flag to symbolise if a stack is being migrated from a previous format (eg YAML) into guardian/cdk.
-   * A value of `true` means resources in the stack can have custom logicalIds set using the property `existingLogicalId` (where available).
-   * A value of `false` or `undefined` means the stack is brand new. Any resource that gets created will have an auto-generated logicalId.
-   *
-   * @see GuMigratingResource
-   */
-  migratedFromCloudFormation?: boolean;
 }
 
 /**

--- a/src/constructs/ec2/security-groups/wazuh.test.ts
+++ b/src/constructs/ec2/security-groups/wazuh.test.ts
@@ -18,7 +18,7 @@ describe("The GuWazuhAccess class", () => {
     GuWazuhAccess.getInstance(stack, vpc);
 
     expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "Wazuh agent registration and event logging",
+      GroupDescription: "Allow outbound traffic from wazuh agent to manager",
       SecurityGroupEgress: [
         {
           CidrIp: "0.0.0.0/0",

--- a/src/constructs/ec2/security-groups/wazuh.test.ts
+++ b/src/constructs/ec2/security-groups/wazuh.test.ts
@@ -1,4 +1,5 @@
 import "@aws-cdk/assert/jest";
+import "../../../utils/test/jest";
 import { Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../utils/test";
@@ -35,5 +36,19 @@ describe("The GuWazuhAccess class", () => {
         },
       ],
     });
+  });
+
+  it("has the logicalId WazuhSecurityGroup in a new stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: false });
+    GuWazuhAccess.getInstance(stack, vpc);
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::EC2::SecurityGroup", "WazuhSecurityGroup");
+  });
+
+  it("has the logicalId WazuhSecurityGroup in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    GuWazuhAccess.getInstance(stack, vpc);
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::EC2::SecurityGroup", "WazuhSecurityGroup");
   });
 });

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -10,8 +10,14 @@ export class GuWazuhAccess extends GuBaseSecurityGroup {
   private constructor(scope: GuStack, vpc: IVpc) {
     super(scope, "WazuhSecurityGroup", {
       vpc,
-      description: "Wazuh agent registration and event logging",
-      overrideId: true,
+
+      /*
+      The group description of a security group is stateful.
+      Be careful about changing this!
+
+      See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-groupdescription
+       */
+      description: "Allow outbound traffic from wazuh agent to manager",
       allowAllOutbound: false,
       egresses: [
         { range: Peer.anyIpv4(), port: 1514, description: "Wazuh event logging" },

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -1,6 +1,7 @@
 import type { IVpc } from "@aws-cdk/aws-ec2";
 import { Peer } from "@aws-cdk/aws-ec2";
 import type { GuStack } from "../../core";
+import { GuMigratingResource } from "../../core/migrating";
 import { GuBaseSecurityGroup } from "./base";
 
 export class GuWazuhAccess extends GuBaseSecurityGroup {
@@ -17,6 +18,19 @@ export class GuWazuhAccess extends GuBaseSecurityGroup {
         { range: Peer.anyIpv4(), port: 1515, description: "Wazuh agent registration" },
       ],
     });
+
+    /*
+    Replacing in-use security groups is difficult as it requires careful orchestration with instances.
+    Fix the logicalId to "WazuhSecurityGroup" regardless of new or migrating stack.
+    This makes it:
+      - easier for YAML defined stacks to move to GuCDK as the resource will be kept
+      - easier for stacks already using GuCDK to upgrade versions
+     */
+    GuMigratingResource.setLogicalId(
+      this,
+      { migratedFromCloudFormation: true },
+      { existingLogicalId: "WazuhSecurityGroup" }
+    );
   }
 
   public static getInstance(stack: GuStack, vpc: IVpc): GuWazuhAccess {


### PR DESCRIPTION
Might be easiest to review commit by commit.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Replacing in-use security groups is difficult as it requires careful orchestration with instances.

Hardcoding the logicalId to "WazuhSecurityGroup" regardless of new or migrating stack makes it:
  - easier for YAML defined stacks to move to GuCDK as the resource will be kept
  - easier for stacks already using GuCDK to upgrade versions

Furthermore, the group description of a security group is [stateful](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-groupdescription):

> Update requires: Replacement

In order to reduce friction for teams migrating from YAML to GuCDK, change the description to match [the user guide](https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md#outbound-traffic-on-ports-1514-and-1515).
Else the security group will be replaced, which requires careful orchestration with running instances.

BREAKING CHANGES:
  * Hardcode the logicalId for `GuWazuhAccess` to `WazuhSecurityGroup`
  * Update `GuWazuhAccess` group description to follow guide

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Sadly, yes. The security group description has changed, which requires [replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement).

Replacing an in use security group requires a little orchestration with running instances, so this isn't trivial. I find it easiest to:
  1. Start a cfn update
  2. Wait until the security group change starts
  3. Perform an app deployment in RiffRaff to cycle instances around
  4. Observe the the cfn update run to completion

Without step 3, the cfn update hangs and eventually fails as it can't delete in-use resources.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Creating a simpler migration path for YAML to GuCDK.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

See above regarding how to apply this update to running stacks.