### PR TITLE
fix: silence alarms in CODE and handle missing data correctly

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -2,6 +2,16 @@
 
 exports[`The GuLambdaErrorPercentageAlarm pattern should create the correct alarm resource with minimal config 1`] = `
 Object {
+  "Mappings": Object {
+    "stagemapping": Object {
+      "CODE": Object {
+        "alarmActionsEnabled": false,
+      },
+      "PROD": Object {
+        "alarmActionsEnabled": true,
+      },
+    },
+  },
   "Parameters": Object {
     "Stage": Object {
       "AllowedValues": Array [
@@ -160,6 +170,15 @@ Object {
     },
     "mylambdafunction8D341B54": Object {
       "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
         "AlarmActions": Array [
           Object {
             "Fn::Join": Array [

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -283,6 +283,7 @@ Object {
           },
         ],
         "Threshold": 80,
+        "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -2,7 +2,8 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { ComparisonOperator } from "@aws-cdk/aws-cloudwatch";
 import { Runtime } from "@aws-cdk/aws-lambda";
-import { simpleGuStackForTesting, SynthedStack } from "../../utils/test";
+import type { SynthedStack } from "../../utils/test";
+import { simpleGuStackForTesting } from "../../utils/test";
 import { GuLambdaFunction } from "../lambda";
 import { GuAlarm } from "./alarm";
 

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -1,7 +1,8 @@
 import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
 import { ComparisonOperator } from "@aws-cdk/aws-cloudwatch";
 import { Runtime } from "@aws-cdk/aws-lambda";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { simpleGuStackForTesting, SynthedStack } from "../../utils/test";
 import { GuLambdaFunction } from "../lambda";
 import { GuAlarm } from "./alarm";
 
@@ -62,6 +63,67 @@ describe("The GuAlarm class", () => {
           ],
         },
       ],
+    });
+  });
+
+  it("should enable alarm actions in PROD and disable them in CODE, by default", () => {
+    const stack = simpleGuStackForTesting();
+    const lambda = new GuLambdaFunction(stack, "lambda", {
+      code: { bucket: "bucket1", key: "folder/to/key" },
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_12_X,
+      app: "testing",
+    });
+    new GuAlarm(stack, "alarm", {
+      alarmName: `Alarm in ${stack.stage}`,
+      alarmDescription: "It's broken",
+      metric: lambda.metricErrors(),
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      snsTopicName: "alerts-topic",
+    });
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Mappings).toEqual({
+      stagemapping: {
+        CODE: {
+          alarmActionsEnabled: false,
+        },
+        PROD: {
+          alarmActionsEnabled: true,
+        },
+      },
+    });
+  });
+
+  it("should allow users to manually enable alarm notifications in CODE", () => {
+    const stack = simpleGuStackForTesting();
+    const lambda = new GuLambdaFunction(stack, "lambda", {
+      code: { bucket: "bucket1", key: "folder/to/key" },
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_12_X,
+      app: "testing",
+    });
+    new GuAlarm(stack, "alarm", {
+      actionsEnabledInCode: true,
+      alarmName: `Alarm in ${stack.stage}`,
+      alarmDescription: "It's broken",
+      metric: lambda.metricErrors(),
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      snsTopicName: "alerts-topic",
+    });
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Mappings).toEqual({
+      stagemapping: {
+        CODE: {
+          alarmActionsEnabled: true,
+        },
+        PROD: {
+          alarmActionsEnabled: true,
+        },
+      },
     });
   });
 });

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -3,15 +3,24 @@ import { Alarm } from "@aws-cdk/aws-cloudwatch";
 import { SnsAction } from "@aws-cdk/aws-cloudwatch-actions";
 import type { ITopic } from "@aws-cdk/aws-sns";
 import { Topic } from "@aws-cdk/aws-sns";
-import type { GuStack } from "../core";
+import { Stage } from "../../constants";
+import type { GuStack, GuStageDependentValue } from "../core";
 
 export interface GuAlarmProps extends AlarmProps {
   snsTopicName: string;
+  actionsEnabledInCode?: boolean;
 }
 
 export class GuAlarm extends Alarm {
   constructor(scope: GuStack, id: string, props: GuAlarmProps) {
-    super(scope, id, props);
+    const actionsEnabled: GuStageDependentValue<boolean> = {
+      variableName: "alarmActionsEnabled",
+      stageValues: {
+        [Stage.CODE]: props.actionsEnabledInCode ?? false,
+        [Stage.PROD]: true,
+      },
+    };
+    super(scope, id, { ...props, actionsEnabled: scope.withStageDependentValue(actionsEnabled) });
     const topicArn: string = `arn:aws:sns:${scope.region}:${scope.account}:${props.snsTopicName}`;
     const snsTopic: ITopic = Topic.fromTopicArn(scope, "sns-topic-for-alarm-notifications", topicArn);
     this.addAlarmAction(new SnsAction(snsTopic));

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -1,4 +1,4 @@
-import { ComparisonOperator, MathExpression } from "@aws-cdk/aws-cloudwatch";
+import { ComparisonOperator, MathExpression, TreatMissingData } from "@aws-cdk/aws-cloudwatch";
 import type { GuStack } from "../core";
 import type { GuLambdaFunction } from "../lambda";
 import type { GuAlarmProps } from "./alarm";
@@ -8,7 +8,7 @@ import { GuAlarm } from "./alarm";
  * Creates an alarm which is triggered whenever the error percentage specified is exceeded.
  */
 export interface GuLambdaErrorPercentageMonitoringProps
-  extends Omit<GuAlarmProps, "metric" | "threshold" | "comparisonOperator" | "evaluationPeriods"> {
+  extends Omit<GuAlarmProps, "metric" | "threshold" | "comparisonOperator" | "evaluationPeriods" | "treatMissingData"> {
   toleratedErrorPercentage: number;
   numberOfFiveMinutePeriodsToEvaluate?: number;
   noMonitoring?: false;
@@ -30,6 +30,7 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
     const alarmProps = {
       ...props,
       metric: mathExpression,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
       threshold: props.toleratedErrorPercentage,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       evaluationPeriods: props.numberOfFiveMinutePeriodsToEvaluate ?? 1,


### PR DESCRIPTION
## What does this change?

This PR makes two improvements to our alarms:
1. Disables alarm actions in `CODE` by default. This prevents us from spamming teams with alerts about their `CODE` environments (in my experience these just generate unactionable noise, as `CODE` environments are expected to break sometimes).
2. Handles missing data correctly for lambda-error-percentage alarms. No data in this scenario is fine; it just means that the lambda has not been invoked at all.

## Does this change require changes to existing projects or CDK CLI?
No. Any user who wants to keep (or temporarily test) alarm actions in their `CODE` environment can still do so if they wish by setting `actionsEnabledInCode` to `true`.

## How to test
I've tried upgrading https://github.com/guardian/tag-janitor/blob/main/cdk/lib/cdk-stack.ts (locally) in order to use this change and confirmed that the changes set looks sensible in AWS. I haven't tested actually deploying the change as there is no `CODE` environment for this stack. I'll finish the upgrade and check the deployment in `PROD` after releasing this change.

## How can we measure success?
* We should receive fewer unactionable alarms
* Lambda-error-percentage alarms will be considered `OK` in scenarios where the lambda is not being invoked

## Have we considered potential risks?
There is a small risk that disabling these alarm actions in `CODE` (by default) will prevent us from noticing problems with alarm configuration. I think using the [`ActionsEnabled` property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-actionsenabled) allows us to minimise this risk as much as possible.
