### PR TITLE
chore(release): 8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/cdk",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/cdk",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
Updating the version number in the repository following the release of v8.0.1. [This step failed in CD](https://github.com/guardian/cdk/runs/2305782006?check_suite_focus=true) (hence the manual PR).

