### PR TITLE
chore: add sensible defaults to GuAutoScalingGroup and GuApplicationLoadBalancer

### DIFF
--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -140,6 +140,21 @@ describe("The GuApplicationListener class", () => {
       Protocol: "HTTPS",
     });
   });
+
+  test("Can override default protocol with prop", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuApplicationListener(stack, "Listener", {
+      loadBalancer: getLoadBalancer(stack),
+      defaultTargetGroups: [getAppTargetGroup(stack)],
+      ...app,
+      protocol: ApplicationProtocol.HTTP,
+    });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::Listener", {
+      Protocol: "HTTP",
+    });
+  });
 });
 
 describe("The GuHttpsApplicationListener class", () => {

--- a/src/constructs/loadbalancing/alb/application-target-group.test.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.test.ts
@@ -2,6 +2,7 @@ import "@aws-cdk/assert/jest";
 import "../../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Vpc } from "@aws-cdk/aws-ec2";
+import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stack } from "@aws-cdk/core";
 import { TrackingTag } from "../../../constants/library-info";
 import type { SynthedStack } from "../../../utils/test";
@@ -120,6 +121,30 @@ describe("The GuApplicationTargetGroup class", () => {
       HealthCheckTimeoutSeconds: 10,
       HealthyThresholdCount: 2,
       UnhealthyThresholdCount: 5,
+    });
+  });
+
+  test("uses HTTP protocol by default", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuApplicationTargetGroup(stack, "TargetGroup", { vpc, ...app });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Protocol: "HTTP",
+    });
+  });
+
+  test("Can override default protocol with prop", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuApplicationTargetGroup(stack, "TargetGroup", {
+      vpc,
+      ...app,
+      protocol: ApplicationProtocol.HTTPS,
+    });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Protocol: "HTTPS",
     });
   });
 });

--- a/src/constructs/loadbalancing/alb/application-target-group.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.ts
@@ -1,5 +1,5 @@
 import type { ApplicationTargetGroupProps, CfnTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
-import { ApplicationTargetGroup, Protocol } from "@aws-cdk/aws-elasticloadbalancingv2";
+import { ApplicationProtocol, ApplicationTargetGroup, Protocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Duration } from "@aws-cdk/core";
 import type { GuStack } from "../../core";
 import { AppIdentity } from "../../core/identity";
@@ -22,6 +22,7 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
     const { app } = props;
 
     const mergedProps = {
+      protocol: ApplicationProtocol.HTTP, // We terminate HTTPS at the load balancer level, so load balancer to ASG/EC2 traffic can be over HTTP
       ...props,
       healthCheck: { ...GuApplicationTargetGroup.DefaultHealthCheck, ...props.healthCheck },
     };


### PR DESCRIPTION
## What does this change?

This adds a few sensible defaults:

### 1. `GuInstanceRole`

We want/intend our autoscaling groups to have required permissions (eg AssumeRole for SSM) by default. This PR adds the role to the ASG construct so that you get it for free. When developing our EC2 pattern, it would be great to [have it created by default without explicitly specifying it in our pattern description](https://github.com/guardian/cdk/pull/399/files#r609673294).

### 2. `stageDependentProps` for `minimumInstances`

We also benefit from having sensible defaults for how we scale our instances based on stages. This adds a `minimumInstances` count of 1 for CODE (and therefore maximum of 2) and 3 for PROD (and therefore maximum of 6).

### 3. `ApplicationProtocol.HTTP` for `GuApplicationLoadBalancer`

By default, load balancers talk to autoscaling groups/instances via HTTP. This adds a sensible default to use HTTP that can be overridden.


## Does this change require changes to existing projects or CDK CLI?

I don't think so. I think you'd get a new role if you were to use the `GuAutoScalingGroup` construct _and_ didn't specify a role, but [every usage of this construct so far explicitly specifies a role](https://github.com/search?q=org%3Aguardian+%22new+GuAutoScalingGroup%22&type=code) so I think we're fine.

## How to test

`./script/test` from the top of the repository.

## How can we measure success?

Less effort and work to get SSM & other goodies for free!

## Have we considered potential risks?

Can't think of any so far.