### PR TITLE
refactor: Make `findResourceByTypeAndLogicalId` standalone

### DIFF
--- a/src/utils/test/jest.ts
+++ b/src/utils/test/jest.ts
@@ -1,6 +1,5 @@
-import { SynthUtils } from "@aws-cdk/assert";
 import type { GuStack } from "../../constructs/core";
-import type { SynthedStack } from "./synthed-stack";
+import { findResourceByTypeAndLogicalId } from "./synthed-stack";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace -- custom Jest matcher
@@ -20,13 +19,7 @@ expect.extend({
    * @param logicalId a string or regex pattern to match against the resource's logicalId
    */
   toHaveResourceOfTypeAndLogicalId(stack: GuStack, resourceType: string, logicalId: string | RegExp) {
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    const matchResult = Object.entries(json.Resources).find(([key, { Type }]) => {
-      const logicalIdMatch = logicalId instanceof RegExp ? logicalId.test(key) : key === logicalId;
-      const typeMatch = Type === resourceType;
-      return logicalIdMatch && typeMatch;
-    });
+    const matchResult = findResourceByTypeAndLogicalId(stack, resourceType, logicalId);
 
     return matchResult
       ? {

--- a/src/utils/test/synthed-stack.ts
+++ b/src/utils/test/synthed-stack.ts
@@ -1,17 +1,47 @@
+import { SynthUtils } from "@aws-cdk/assert";
 import type { Stage } from "../../constants";
+import type { GuStack } from "../../constructs/core";
 
-interface Parameter {
+export interface Parameter {
   Type: string;
   Description: string;
   Default?: string | number;
   AllowedValues?: Array<string | number>;
 }
 
-type ResourceProperty = Record<string, unknown>;
-type Resource = Record<string, { Type: string; Properties: ResourceProperty }>;
+export type ResourceProperty = Record<string, unknown>;
+export type Resource = Record<string, { Type: string; Properties: ResourceProperty; UpdatePolicy?: unknown }>;
 
 export interface SynthedStack {
   Parameters: Record<string, Parameter>;
   Mappings: Record<Stage, unknown>;
   Resources: Resource;
 }
+
+/**
+ * A helper function to find a resource of a particular type and logicalId within a stack.
+ * Useful for when the logicalId is auto-generated.
+ * @param stack the stack to search in
+ * @param resourceType the AWS resource type string, for example "AWS::AutoScaling::AutoScalingGroup"
+ * @param logicalIdPattern a string or regex pattern to match against the resource's logicalId
+ */
+export const findResourceByTypeAndLogicalId = (
+  stack: GuStack,
+  resourceType: string,
+  logicalIdPattern: string | RegExp
+): Resource | undefined => {
+  const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+  const match = Object.entries(json.Resources).find(([key, { Type }]) => {
+    const logicalIdMatch = logicalIdPattern instanceof RegExp ? logicalIdPattern.test(key) : key === logicalIdPattern;
+    const typeMatch = Type === resourceType;
+    return logicalIdMatch && typeMatch;
+  });
+
+  if (match) {
+    const [logicalId, resource] = match;
+    return { [logicalId]: resource };
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The `findResourceByTypeAndLogicalId` function is useful in other contexts than just assertions.

This is partly inspired by the AWS CDK library.

See:
  - https://github.com/aws/aws-cdk/blob/ecc9bf386ca088ca82a332c649f13613b9793628/packages/%40aws-cdk/assert/jest.ts#L63

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No, just a refactor.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

`findResourceByTypeAndLogicalId` becomes available to use (see https://github.com/guardian/cdk/pull/400).

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a