### PR TITLE
fix: Add multi app support to `GuApplicationLoadBalancer`

### DIFF
--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -7,6 +7,7 @@ import { Stack } from "@aws-cdk/core";
 import { RegexPattern } from "../../../constants";
 import type { SynthedStack } from "../../../utils/test";
 import { simpleGuStackForTesting } from "../../../utils/test";
+import type { GuStack } from "../../core";
 import type { AppIdentity } from "../../core/identity";
 import { GuApplicationListener, GuHttpsApplicationListener } from "./application-listener";
 import { GuApplicationLoadBalancer } from "./application-load-balancer";
@@ -20,11 +21,14 @@ const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
 
 const app: AppIdentity = { app: "testing" };
 
+const getLoadBalancer = (stack: GuStack): GuApplicationLoadBalancer => {
+  return new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, ...app });
+};
+
 describe("The GuApplicationListener class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "TargetGroup", {
       vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -32,7 +36,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
     });
@@ -46,7 +50,6 @@ describe("The GuApplicationListener class", () => {
   test("overrides the id if the prop is true", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -54,7 +57,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       overrideId: true,
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
@@ -67,7 +70,6 @@ describe("The GuApplicationListener class", () => {
   test("does not override the id if the prop is false", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -75,7 +77,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
     });
@@ -87,7 +89,6 @@ describe("The GuApplicationListener class", () => {
   test("overrides the id if the stack migrated value is true", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -95,7 +96,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
     });
@@ -107,7 +108,6 @@ describe("The GuApplicationListener class", () => {
   test("does not override the id if the stack migrated value is true but the override id value is false", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -115,7 +115,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       overrideId: false,
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
@@ -128,7 +128,6 @@ describe("The GuApplicationListener class", () => {
   test("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -136,7 +135,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
     });
@@ -150,7 +149,6 @@ describe("The GuApplicationListener class", () => {
   test("merges default and passed in props", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -158,7 +156,7 @@ describe("The GuApplicationListener class", () => {
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       defaultAction: ListenerAction.forward([targetGroup]),
       certificates: [{ certificateArn: "" }],
       port: 80,
@@ -175,7 +173,6 @@ describe("The GuHttpsApplicationListener class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "TargetGroup", {
       vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -183,7 +180,7 @@ describe("The GuHttpsApplicationListener class", () => {
 
     new GuHttpsApplicationListener(stack, "HttpsApplicationListener", {
       ...app,
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       targetGroup,
     });
 
@@ -196,14 +193,13 @@ describe("The GuHttpsApplicationListener class", () => {
   test("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
     });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       targetGroup,
       ...app,
     });
@@ -225,14 +221,13 @@ describe("The GuHttpsApplicationListener class", () => {
   test("creates certificate prop if no value passed in", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
     });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       targetGroup,
       ...app,
     });
@@ -260,7 +255,6 @@ describe("The GuHttpsApplicationListener class", () => {
   test("passing in an invalid ACM ARN", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
@@ -269,7 +263,7 @@ describe("The GuHttpsApplicationListener class", () => {
     expect(
       () =>
         new GuHttpsApplicationListener(stack, "ApplicationListener", {
-          loadBalancer,
+          loadBalancer: getLoadBalancer(stack),
           targetGroup,
           certificate: "test",
           ...app,
@@ -280,14 +274,13 @@ describe("The GuHttpsApplicationListener class", () => {
   test("does not create certificate prop if a value passed in", () => {
     const stack = simpleGuStackForTesting();
 
-    const loadBalancer = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc });
     const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
     });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
-      loadBalancer,
+      loadBalancer: getLoadBalancer(stack),
       targetGroup,
       certificate: "arn:aws:acm:eu-west-1:000000000000:certificate/123abc-0000-0000-0000-123abc",
       ...app,

--- a/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
@@ -3,8 +3,9 @@ import "../../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
+import { TrackingTag } from "../../../constants/library-info";
 import type { SynthedStack } from "../../../utils/test";
-import { simpleGuStackForTesting } from "../../../utils/test";
+import { alphabeticalTags, simpleGuStackForTesting } from "../../../utils/test";
 import type { AppIdentity } from "../../core/identity";
 import { GuApplicationLoadBalancer } from "./application-load-balancer";
 
@@ -27,6 +28,28 @@ describe("The GuApplicationLoadBalancer class", () => {
       "AWS::ElasticLoadBalancingV2::LoadBalancer",
       /^ApplicationLoadBalancerTesting.+/
     );
+  });
+
+  it("should apply the App tag", () => {
+    const stack = simpleGuStackForTesting();
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      Tags: alphabeticalTags([
+        { Key: "App", Value: app.app },
+        {
+          Key: "Stack",
+          Value: stack.stack,
+        },
+        {
+          Key: "Stage",
+          Value: {
+            Ref: "Stage",
+          },
+        },
+        TrackingTag,
+      ]),
+    });
   });
 
   test("overrides the id with the overrideId prop", () => {

--- a/src/constructs/loadbalancing/alb/application-load-balancer.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.ts
@@ -1,14 +1,17 @@
 import type { ApplicationLoadBalancerProps, CfnLoadBalancer } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { ApplicationLoadBalancer } from "@aws-cdk/aws-elasticloadbalancingv2";
 import type { GuStack } from "../../core";
+import { AppIdentity } from "../../core/identity";
 
-interface GuApplicationLoadBalancerProps extends ApplicationLoadBalancerProps {
+interface GuApplicationLoadBalancerProps extends ApplicationLoadBalancerProps, AppIdentity {
   overrideId?: boolean;
 }
 
 export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
   constructor(scope: GuStack, id: string, props: GuApplicationLoadBalancerProps) {
-    super(scope, id, { deletionProtection: true, ...props });
+    const { app } = props;
+
+    super(scope, AppIdentity.suffixText({ app }, id), { deletionProtection: true, ...props });
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 

--- a/src/constructs/loadbalancing/alb/application-load-balancer.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.ts
@@ -19,5 +19,7 @@ export class GuApplicationLoadBalancer extends ApplicationLoadBalancer {
       cfnLb.overrideLogicalId(id);
 
     cfnLb.addPropertyDeletionOverride("Type");
+
+    AppIdentity.taggedConstruct({ app }, this);
   }
 }


### PR DESCRIPTION
Requires https://github.com/guardian/cdk/pull/409.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Make `GuApplicationLoadBalancer` consistent with other constructs by adding `AppIdentity` to its props and adding a suffix to its logicalId and ensure it is tagged appropriately too.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. The auto-generated logicalIds for `GuApplicationLoadBalancer` and GuHttpsApplicationListener constructs have an updated naming scheme.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See additional tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Consistency across the project.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a