### PR TITLE
fix: Add multi app support to `GuApplicationTargetGroup`

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -8,6 +8,7 @@ import { Stage } from "../../constants";
 import { TrackingTag } from "../../constants/library-info";
 import type { SynthedStack } from "../../utils/test";
 import { alphabeticalTags, simpleGuStackForTesting } from "../../utils/test";
+import type { AppIdentity } from "../core/identity";
 import { GuSecurityGroup } from "../ec2";
 import { GuApplicationTargetGroup } from "../loadbalancing";
 import type { GuAutoScalingGroupProps } from "./asg";
@@ -20,7 +21,12 @@ describe("The GuAutoScalingGroup", () => {
     publicSubnetIds: [""],
   });
 
+  const app: AppIdentity = {
+    app: "testing",
+  };
+
   const defaultProps: GuAutoScalingGroupProps = {
+    ...app,
     vpc,
     userData: UserData.custom(["#!/bin/bash", "service some-dependency start", "service my-app start"].join("\n")),
     stageDependentProps: {
@@ -31,7 +37,6 @@ describe("The GuAutoScalingGroup", () => {
         minimumInstances: 3,
       },
     },
-    app: "testing",
   };
 
   test("Uses the AppIdentity to create the logicalId and tag the resource", () => {
@@ -142,6 +147,7 @@ describe("The GuAutoScalingGroup", () => {
     const stack = simpleGuStackForTesting();
 
     const targetGroup = new GuApplicationTargetGroup(stack, "TargetGroup", {
+      ...app,
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
       overrideId: true,

--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -25,19 +25,22 @@ const getLoadBalancer = (stack: GuStack): GuApplicationLoadBalancer => {
   return new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { vpc, ...app });
 };
 
+const getAppTargetGroup = (stack: GuStack): GuApplicationTargetGroup => {
+  return new GuApplicationTargetGroup(stack, "TargetGroup", {
+    ...app,
+    vpc,
+    protocol: ApplicationProtocol.HTTP,
+  });
+};
+
 describe("The GuApplicationListener class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "TargetGroup", {
-      vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
@@ -50,16 +53,11 @@ describe("The GuApplicationListener class", () => {
   test("overrides the id if the prop is true", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
       overrideId: true,
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
@@ -70,15 +68,10 @@ describe("The GuApplicationListener class", () => {
   test("does not override the id if the prop is false", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
@@ -89,15 +82,10 @@ describe("The GuApplicationListener class", () => {
   test("overrides the id if the stack migrated value is true", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
@@ -108,16 +96,11 @@ describe("The GuApplicationListener class", () => {
   test("does not override the id if the stack migrated value is true but the override id value is false", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
       overrideId: false,
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
@@ -128,15 +111,10 @@ describe("The GuApplicationListener class", () => {
   test("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
@@ -149,15 +127,10 @@ describe("The GuApplicationListener class", () => {
   test("merges default and passed in props", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      defaultAction: ListenerAction.forward([targetGroup]),
+      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
       port: 80,
     });
@@ -173,15 +146,10 @@ describe("The GuHttpsApplicationListener class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "TargetGroup", {
-      vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuHttpsApplicationListener(stack, "HttpsApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      targetGroup,
+      targetGroup: getAppTargetGroup(stack),
     });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId(
@@ -193,14 +161,9 @@ describe("The GuHttpsApplicationListener class", () => {
   test("sets default props", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       loadBalancer: getLoadBalancer(stack),
-      targetGroup,
+      targetGroup: getAppTargetGroup(stack),
       ...app,
     });
 
@@ -210,7 +173,7 @@ describe("The GuHttpsApplicationListener class", () => {
       DefaultActions: [
         {
           TargetGroupArn: {
-            Ref: "GrafanaInternalTargetGroup837A1034",
+            Ref: "TargetGroupTesting29B71ABC",
           },
           Type: "forward",
         },
@@ -221,14 +184,9 @@ describe("The GuHttpsApplicationListener class", () => {
   test("creates certificate prop if no value passed in", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       loadBalancer: getLoadBalancer(stack),
-      targetGroup,
+      targetGroup: getAppTargetGroup(stack),
       ...app,
     });
 
@@ -255,16 +213,11 @@ describe("The GuHttpsApplicationListener class", () => {
   test("passing in an invalid ACM ARN", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     expect(
       () =>
         new GuHttpsApplicationListener(stack, "ApplicationListener", {
           loadBalancer: getLoadBalancer(stack),
-          targetGroup,
+          targetGroup: getAppTargetGroup(stack),
           certificate: "test",
           ...app,
         })
@@ -274,14 +227,9 @@ describe("The GuHttpsApplicationListener class", () => {
   test("does not create certificate prop if a value passed in", () => {
     const stack = simpleGuStackForTesting();
 
-    const targetGroup = new GuApplicationTargetGroup(stack, "GrafanaInternalTargetGroup", {
-      vpc: vpc,
-      protocol: ApplicationProtocol.HTTP,
-    });
-
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       loadBalancer: getLoadBalancer(stack),
-      targetGroup,
+      targetGroup: getAppTargetGroup(stack),
       certificate: "arn:aws:acm:eu-west-1:000000000000:certificate/123abc-0000-0000-0000-123abc",
       ...app,
     });

--- a/src/constructs/loadbalancing/alb/application-target-group.test.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.test.ts
@@ -3,8 +3,9 @@ import "../../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
+import { TrackingTag } from "../../../constants/library-info";
 import type { SynthedStack } from "../../../utils/test";
-import { simpleGuStackForTesting } from "../../../utils/test";
+import { alphabeticalTags, simpleGuStackForTesting } from "../../../utils/test";
 import type { AppIdentity } from "../../core/identity";
 import { GuApplicationTargetGroup } from "./application-target-group";
 
@@ -27,6 +28,28 @@ describe("The GuApplicationTargetGroup class", () => {
       "AWS::ElasticLoadBalancingV2::TargetGroup",
       /^ApplicationTargetGroupTesting.+/
     );
+  });
+
+  it("should apply the App tag", () => {
+    const stack = simpleGuStackForTesting();
+    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { ...app, vpc });
+
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Tags: alphabeticalTags([
+        { Key: "App", Value: app.app },
+        {
+          Key: "Stack",
+          Value: stack.stack,
+        },
+        {
+          Key: "Stage",
+          Value: {
+            Ref: "Stage",
+          },
+        },
+        TrackingTag,
+      ]),
+    });
   });
 
   test("overrides the id if the prop is true", () => {

--- a/src/constructs/loadbalancing/alb/application-target-group.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.ts
@@ -30,5 +30,7 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
 
     if (mergedProps.overrideId || (scope.migratedFromCloudFormation && mergedProps.overrideId !== false))
       (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
+
+    AppIdentity.taggedConstruct({ app }, this);
   }
 }

--- a/src/constructs/loadbalancing/alb/application-target-group.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.ts
@@ -2,8 +2,9 @@ import type { ApplicationTargetGroupProps, CfnTargetGroup } from "@aws-cdk/aws-e
 import { ApplicationTargetGroup, Protocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Duration } from "@aws-cdk/core";
 import type { GuStack } from "../../core";
+import { AppIdentity } from "../../core/identity";
 
-export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupProps {
+export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupProps, AppIdentity {
   overrideId?: boolean;
 }
 
@@ -18,12 +19,14 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
   };
 
   constructor(scope: GuStack, id: string, props: GuApplicationTargetGroupProps) {
+    const { app } = props;
+
     const mergedProps = {
       ...props,
       healthCheck: { ...GuApplicationTargetGroup.DefaultHealthCheck, ...props.healthCheck },
     };
 
-    super(scope, id, mergedProps);
+    super(scope, AppIdentity.suffixText({ app }, id), mergedProps);
 
     if (mergedProps.overrideId || (scope.migratedFromCloudFormation && mergedProps.overrideId !== false))
       (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);


### PR DESCRIPTION
Requires https://github.com/guardian/cdk/pull/410.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Make `GuApplicationTargetGroup` consistent with other constructs by adding `AppIdentity` to its props and adding a suffix to its logicalId and ensure it is tagged appropriately too.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. The auto-generated logicalIds for the `GuApplicationTargetGroup` constructs has an updated naming scheme.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See additional tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Consistency across the project.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a