### PR TITLE
chore(deps): configure dependabot for the integration-test project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,14 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: "chore(deps): "
+  - package-ecosystem: 'npm'
+    directory: '/integration-test'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: "chore(deps): "
+    # The version of @aws-cdk/* libraries must match those from @guardian/cdk.
+    # We'd never be able to update them here independently, so just ignore them.
+    ignore:
+      - dependency-name: "aws-cdk"
+      - dependency-name: "@aws-cdk/*"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The integration-test directory holds an... integration test.

It is a standalone project that:
  - installs @guardian/cdk from a relative path
  - defines a stack
  - synths the stack

This is to observe any regressions in the packaging of @guardian/cdk.

This change adds dependabot to the integration test project, as it is a project after all and its dependencies need to kept up to date.

See:
  - #367

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More dependencies are kept up to date.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a