### PR TITLE
fix: Update `GuApplicationListener` with revised logicalId logic

### DIFF
--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -50,62 +50,31 @@ describe("The GuApplicationListener class", () => {
     );
   });
 
-  test("overrides the id if the prop is true", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuApplicationListener(stack, "ApplicationListener", {
-      ...app,
-      loadBalancer: getLoadBalancer(stack),
-      overrideId: true,
-      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
-      certificates: [{ certificateArn: "" }],
-    });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("ApplicationListener");
-  });
-
-  test("does not override the id if the prop is false", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuApplicationListener(stack, "ApplicationListener", {
-      ...app,
-      loadBalancer: getLoadBalancer(stack),
-      defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
-      certificates: [{ certificateArn: "" }],
-    });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("ApplicationListener");
-  });
-
-  test("overrides the id if the stack migrated value is true", () => {
+  test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
+      existingLogicalId: "AppListener",
       defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("ApplicationListener");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::ElasticLoadBalancingV2::Listener", "AppListener");
   });
 
-  test("does not override the id if the stack migrated value is true but the override id value is false", () => {
-    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+  test("auto-generates the logicalId by default", () => {
+    const stack = simpleGuStackForTesting();
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      overrideId: false,
       defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });
 
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("ApplicationListener");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::ElasticLoadBalancingV2::Listener", /^ApplicationListener.+$/);
   });
 
   test("sets default props", () => {

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -1,23 +1,20 @@
-import type { ApplicationListenerProps, CfnListener } from "@aws-cdk/aws-elasticloadbalancingv2";
+import type { ApplicationListenerProps } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { ApplicationListener, ApplicationProtocol, ListenerAction } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { RegexPattern } from "../../../constants";
+import { GuStatefulMigratableConstruct } from "../../../utils/mixin";
 import type { GuStack } from "../../core";
 import { GuCertificateArnParameter } from "../../core";
 import { AppIdentity } from "../../core/identity";
+import type { GuMigratingResource } from "../../core/migrating";
 import type { GuApplicationTargetGroup } from "./application-target-group";
 
-export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity {
-  overrideId?: boolean;
-}
+export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity, GuMigratingResource {}
 
-export class GuApplicationListener extends ApplicationListener {
+export class GuApplicationListener extends GuStatefulMigratableConstruct(ApplicationListener) {
   constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
-    const { app, overrideId } = props;
+    const { app } = props;
 
     super(scope, AppIdentity.suffixText({ app }, id), { port: 443, protocol: ApplicationProtocol.HTTPS, ...props });
-
-    if (overrideId || (scope.migratedFromCloudFormation && overrideId !== false))
-      (this.node.defaultChild as CfnListener).overrideLogicalId(id);
 
     /*
     AWS::ElasticLoadBalancingV2::Listener resources cannot be tagged.


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we placed the logic of overriding a construct's logicalId into a single place.

In this change, we're updating the `GuApplicationListener` construct to adopt the new logic. As of #418 it's as simple as using the `GuStatefulMigratableConstruct` mixin!

The logicalId logic currently in `GuApplicationListener` is very complicated with multiple paths to overriding the logicalId.

This is massively simplified, as evidenced in the updated tests.

This is the first in a series of PRs to adopt the new logic. Hopefully this multi PR approach is better than the previous monster PR (#400)!

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuApplicationListener` has changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.