### PR TITLE
fix: Update `GuPolicy` with revised logicalId logic 

### DIFF
--- a/src/constructs/iam/policies/base-policy.test.ts
+++ b/src/constructs/iam/policies/base-policy.test.ts
@@ -1,0 +1,104 @@
+import "@aws-cdk/assert/jest";
+import "../../../utils/test/jest";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../utils/test";
+import { GuAllowPolicy, GuDenyPolicy } from "./base-policy";
+
+describe("GuAllowPolicy", () => {
+  test("if a single action is provided, the resulting resource's action will be a single item", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(
+      stack,
+      new GuAllowPolicy(stack, "AllowS3GetObject", {
+        actions: ["s3:GetObject"],
+        resources: ["*"],
+      })
+    );
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "s3:GetObject",
+            Effect: "Allow",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+
+  test("if multiple actions are provided, the resulting resource's action will be an array", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(
+      stack,
+      new GuAllowPolicy(stack, "AllowS3GetObject", {
+        actions: ["s3:GetObject", "s3:ListBucket"],
+        resources: ["*"],
+      })
+    );
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: ["s3:GetObject", "s3:ListBucket"],
+            Effect: "Allow",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("GuDenyPolicy", () => {
+  test("if a single action is provided, the resulting resource's action will be a single item", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(
+      stack,
+      new GuDenyPolicy(stack, "DenyS3GetObject", {
+        actions: ["s3:GetObject"],
+        resources: ["*"],
+      })
+    );
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "s3:GetObject",
+            Effect: "Deny",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+
+  test("if multiple actions are provided, the resulting resource's action will be an array", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(
+      stack,
+      new GuDenyPolicy(stack, "DenyS3GetObject", {
+        actions: ["s3:GetObject", "s3:ListBucket"],
+        resources: ["*"],
+      })
+    );
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: ["s3:GetObject", "s3:ListBucket"],
+            Effect: "Deny",
+            Resource: "*",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/base-policy.test.ts
+++ b/src/constructs/iam/policies/base-policy.test.ts
@@ -51,6 +51,33 @@ describe("GuAllowPolicy", () => {
       },
     });
   });
+
+  test("auto-generates the logicalId by default", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(
+      stack,
+      new GuAllowPolicy(stack, "AllowS3GetObject", {
+        actions: ["s3:GetObject"],
+        resources: ["*"],
+      })
+    );
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Policy", /^AllowS3GetObject.+/);
+  });
+
+  test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    attachPolicyToTestRole(
+      stack,
+      new GuAllowPolicy(stack, "AllowS3GetObject", {
+        actions: ["s3:GetObject"],
+        resources: ["*"],
+        existingLogicalId: "MyAwesomeAllowPolicy",
+      })
+    );
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Policy", "MyAwesomeAllowPolicy");
+  });
 });
 
 describe("GuDenyPolicy", () => {
@@ -100,5 +127,32 @@ describe("GuDenyPolicy", () => {
         ],
       },
     });
+  });
+
+  test("auto-generates the logicalId by default", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(
+      stack,
+      new GuDenyPolicy(stack, "DenyS3GetObject", {
+        actions: ["s3:GetObject"],
+        resources: ["*"],
+      })
+    );
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Policy", /^DenyS3GetObject.+/);
+  });
+
+  test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    attachPolicyToTestRole(
+      stack,
+      new GuDenyPolicy(stack, "DenyS3GetObject", {
+        actions: ["s3:GetObject"],
+        resources: ["*"],
+        existingLogicalId: "MyAwesomeDenyPolicy",
+      })
+    );
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Policy", "MyAwesomeDenyPolicy");
   });
 });

--- a/src/constructs/iam/policies/base-policy.ts
+++ b/src/constructs/iam/policies/base-policy.ts
@@ -1,21 +1,16 @@
-import type { CfnPolicy, PolicyProps } from "@aws-cdk/aws-iam";
+import type { PolicyProps } from "@aws-cdk/aws-iam";
 import { Effect, Policy, PolicyStatement } from "@aws-cdk/aws-iam";
+import { GuMigratableConstruct } from "../../../utils/mixin";
 import type { GuStack } from "../../core";
+import type { GuMigratingResource } from "../../core/migrating";
 
-export interface GuPolicyProps extends PolicyProps {
-  overrideId?: boolean;
-}
+export interface GuPolicyProps extends PolicyProps, GuMigratingResource {}
 
 export type GuNoStatementsPolicyProps = Omit<GuPolicyProps, "statements">;
 
-export abstract class GuPolicy extends Policy {
+export abstract class GuPolicy extends GuMigratableConstruct(Policy) {
   protected constructor(scope: GuStack, id: string, props: GuPolicyProps) {
     super(scope, id, props);
-
-    if (props.overrideId) {
-      const child = this.node.defaultChild as CfnPolicy;
-      child.overrideLogicalId(id);
-    }
   }
 }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following #423, this change adopts the logicalId logic introduced in #364 into the `GuPolicy` policy.

`GuPolicy` is an abstract class, so testing has been added to the concrete classes `GuAllowPolicy` and `GuDenyPolicy`.

This change brings consistency to the implementation of logicalId overriding.

This is another PR in this series. Favouring small PRs over the a massive one (#400).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuAllowPolicy` and  `GuDenyPolicy` has changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests? There are quite  a few tests added, it might be easier to review the change on a commit by commit basis.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.