### PR TITLE
fix: Update `GuRole` with revised logicalId logic

### DIFF
--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -39,7 +39,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -60,7 +60,7 @@ Object {
         "PolicyName": "GetConfigPolicy6F934A1C",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -96,13 +96,13 @@ Object {
         "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleTesting": Object {
+    "InstanceRoleTestingCB7BD146": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -184,7 +184,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -220,7 +220,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -274,10 +274,10 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -313,7 +313,7 @@ Object {
         "PolicyName": "GetDistributablePolicyMyfirstappB56CBAB1",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
         ],
       },
@@ -349,7 +349,7 @@ Object {
         "PolicyName": "GetDistributablePolicyMysecondapp5096BFDB",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -391,16 +391,16 @@ Object {
         "PolicyName": "GuLogShippingPolicy981BFE5A",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleMyfirstapp": Object {
+    "InstanceRoleMyfirstapp5C11A22B": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -448,7 +448,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "InstanceRoleMysecondapp": Object {
+    "InstanceRoleMysecondapp48DD15D7": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -530,7 +530,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
         ],
       },
@@ -570,7 +570,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -606,10 +606,10 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleMyfirstapp",
+            "Ref": "InstanceRoleMyfirstapp5C11A22B",
           },
           Object {
-            "Ref": "InstanceRoleMysecondapp",
+            "Ref": "InstanceRoleMysecondapp48DD15D7",
           },
         ],
       },
@@ -663,7 +663,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -699,7 +699,7 @@ Object {
         "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -741,13 +741,13 @@ Object {
         "PolicyName": "GuLogShippingPolicy981BFE5A",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleTesting": Object {
+    "InstanceRoleTestingCB7BD146": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -829,7 +829,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -865,7 +865,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -914,7 +914,7 @@ Object {
         "PolicyName": "describe-ec2-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -950,13 +950,13 @@ Object {
         "PolicyName": "GetDistributablePolicyTestingF9D43A3E",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "InstanceRoleTesting": Object {
+    "InstanceRoleTestingCB7BD146": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1038,7 +1038,7 @@ Object {
         "PolicyName": "parameter-store-read-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },
@@ -1074,7 +1074,7 @@ Object {
         "PolicyName": "ssm-run-command-policy",
         "Roles": Array [
           Object {
-            "Ref": "InstanceRoleTesting",
+            "Ref": "InstanceRoleTestingCB7BD146",
           },
         ],
       },

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -19,9 +19,9 @@ interface GuInstanceRoleProps extends AppIdentity {
 export class GuInstanceRole extends GuRole {
   constructor(scope: GuStack, props: GuInstanceRoleProps) {
     super(scope, AppIdentity.suffixText(props, "InstanceRole"), {
-      overrideId: true,
       path: "/",
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+      // not setting existingLogicalId results in the logicalId always being auto-generated
     });
 
     const sharedPolicies = [

--- a/src/constructs/iam/roles/roles.test.ts
+++ b/src/constructs/iam/roles/roles.test.ts
@@ -1,32 +1,29 @@
-import { SynthUtils } from "@aws-cdk/assert";
+import "../../../utils/test/jest";
 import "@aws-cdk/assert/jest";
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
 import { simpleGuStackForTesting } from "../../../utils/test";
-import type { SynthedStack } from "../../../utils/test";
 import { GuRole } from "./roles";
 
 describe("The GuRole class", () => {
-  it("overrides id if prop set to true", () => {
-    const stack = simpleGuStackForTesting();
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
     new GuRole(stack, "TestRole", {
-      overrideId: true,
+      existingLogicalId: "MyRole",
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
     });
 
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("TestRole");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Role", "MyRole");
   });
 
-  it("does not override id if prop set to false", () => {
+  test("auto-generates the logicalId by default", () => {
     const stack = simpleGuStackForTesting();
 
     new GuRole(stack, "TestRole", {
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
     });
 
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("TestRole");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::IAM::Role", /^TestRole.+$/);
   });
 
   it("returns a string value for the child ref", () => {

--- a/src/constructs/iam/roles/roles.ts
+++ b/src/constructs/iam/roles/roles.ts
@@ -1,23 +1,21 @@
 import type { CfnRole, RoleProps } from "@aws-cdk/aws-iam";
 import { Role } from "@aws-cdk/aws-iam";
+import { GuMigratableConstruct } from "../../../utils/mixin";
 import type { GuStack } from "../../core";
+import type { GuMigratingResource } from "../../core/migrating";
 
-export interface GuRoleProps extends RoleProps {
-  overrideId?: boolean;
-}
+export interface GuRoleProps extends RoleProps, GuMigratingResource {}
 
-export class GuRole extends Role {
+export class GuRole extends GuMigratableConstruct(Role) {
   private child: CfnRole;
 
   constructor(scope: GuStack, id: string, props: GuRoleProps) {
     super(scope, id, props);
 
     this.child = this.node.defaultChild as CfnRole;
-    if (props.overrideId) {
-      this.child.overrideLogicalId(id);
-    }
   }
 
+  // TODO is this needed? We don't do this in other constructs...
   get ref(): string {
     return this.child.ref;
   }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we placed the logic of overriding a construct's logicalId into a single place.

In this change, we're updating the `GuRole` construct to adopt the new logic. As of #418 it's as simple as using the `GuMigratableConstruct` mixin!

As a by-product, `GuInstanceRole`'s tests need updating. The snapshot tests are updated to reflect the fact that `GuInstanceRole` doesn't set `existingLogicalId` when calling `GuRole`, therefore the logicalId will always be auto-generated.

This is another PR in this series. Favouring small PRs over the a massive one (#400).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuRole` and `GuInstanceRole` has changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.