### PR TITLE
fix: Update `GuBaseSecurityGroup` with revised logicalId logic

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -173,9 +173,10 @@ describe("The GuAutoScalingGroup", () => {
     const app = "Testing";
     const stack = simpleGuStackForTesting();
 
-    const securityGroup = new GuSecurityGroup(stack, "SecurityGroup", { vpc, overrideId: true, app });
-    const securityGroup1 = new GuSecurityGroup(stack, "SecurityGroup1", { vpc, overrideId: true, app });
-    const securityGroup2 = new GuSecurityGroup(stack, "SecurityGroup2", { vpc, overrideId: true, app });
+    // not passing `existingLogicalId`, so logicalId will be auto-generated
+    const securityGroup = new GuSecurityGroup(stack, "SecurityGroup", { vpc, app });
+    const securityGroup1 = new GuSecurityGroup(stack, "SecurityGroup1", { vpc, app });
+    const securityGroup2 = new GuSecurityGroup(stack, "SecurityGroup2", { vpc, app });
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       ...defaultProps,
@@ -188,13 +189,13 @@ describe("The GuAutoScalingGroup", () => {
           "Fn::GetAtt": [`GuHttpsEgressSecurityGroup${app}89CDDA4B`, "GroupId"],
         },
         {
-          "Fn::GetAtt": [`SecurityGroup${app}`, "GroupId"],
+          "Fn::GetAtt": ["SecurityGroupTestingA32D34F9", "GroupId"], // auto-generated logicalId
         },
         {
-          "Fn::GetAtt": [`SecurityGroup1${app}`, "GroupId"],
+          "Fn::GetAtt": ["SecurityGroup1TestingCA3A17A4", "GroupId"], // auto-generated logicalId
         },
         {
-          "Fn::GetAtt": [`SecurityGroup2${app}`, "GroupId"],
+          "Fn::GetAtt": ["SecurityGroup2Testing6436C75B", "GroupId"], // auto-generated logicalId
         },
       ],
     });

--- a/src/constructs/ec2/security-groups/base.ts
+++ b/src/constructs/ec2/security-groups/base.ts
@@ -1,7 +1,9 @@
-import type { CfnSecurityGroup, IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
+import type { IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { Peer, Port, SecurityGroup } from "@aws-cdk/aws-ec2";
+import { GuMigratableConstruct } from "../../../utils/mixin";
 import type { GuStack } from "../../core";
 import { AppIdentity } from "../../core/identity";
+import type { GuMigratingResource } from "../../core/migrating";
 
 /**
  * A way to describe an ingress or egress rule for a security group.
@@ -28,8 +30,7 @@ export interface SecurityGroupAccessRule {
   description: string;
 }
 
-export interface GuBaseSecurityGroupProps extends SecurityGroupProps {
-  overrideId?: boolean;
+export interface GuBaseSecurityGroupProps extends SecurityGroupProps, GuMigratingResource {
   ingresses?: SecurityGroupAccessRule[];
   egresses?: SecurityGroupAccessRule[];
 }
@@ -46,13 +47,9 @@ export interface GuSecurityGroupProps extends GuBaseSecurityGroupProps, AppIdent
  * - [[GuPublicInternetAccessSecurityGroup]]
  * - [[GuHttpsEgressSecurityGroup]]
  */
-export abstract class GuBaseSecurityGroup extends SecurityGroup {
+export abstract class GuBaseSecurityGroup extends GuMigratableConstruct(SecurityGroup) {
   protected constructor(scope: GuStack, id: string, props: GuBaseSecurityGroupProps) {
     super(scope, id, props);
-
-    if (props.overrideId) {
-      (this.node.defaultChild as CfnSecurityGroup).overrideLogicalId(id);
-    }
 
     props.ingresses?.forEach(({ range, port, description }) => {
       const connection: Port = typeof port === "number" ? Port.tcp(port) : port;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we placed the logic of overriding a construct's logicalId into a single place.

In this change, we're updating the `GuBaseSecurityGroup` construct to adopt the new logic. As of #418 it's as simple as using the `GuMigratableConstruct` mixin!

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuBaseSecurityGroup` has changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.