### PR TITLE
fix: Update `GuKinesisStream` with revised logicalId logic 

### DIFF
--- a/src/constructs/kinesis/kinesis-stream.test.ts
+++ b/src/constructs/kinesis/kinesis-stream.test.ts
@@ -1,21 +1,19 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import type { SynthedStack } from "../../utils/test";
+import "../../utils/test/jest";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuKinesisStream } from "./kinesis-stream";
 
 describe("The GuKinesisStream construct", () => {
-  it("should not override the id by default", () => {
+  test("auto-generates the logicalId by default", () => {
     const stack = simpleGuStackForTesting();
-    new GuKinesisStream(stack, "my-kinesis-stream");
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("my-kinesis-stream");
+    new GuKinesisStream(stack, "LoggingStream");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", /^LoggingStream.+$/);
   });
 
-  it("should override the id with the overrideId prop set to true", () => {
-    const stack = simpleGuStackForTesting();
-    new GuKinesisStream(stack, "my-kinesis-stream", { overrideId: true });
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("my-kinesis-stream");
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuKinesisStream(stack, "LoggingStream", { existingLogicalId: "MyStream" });
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", "MyStream");
   });
 });

--- a/src/constructs/kinesis/kinesis-stream.ts
+++ b/src/constructs/kinesis/kinesis-stream.ts
@@ -1,15 +1,13 @@
-import type { CfnStream, StreamProps } from "@aws-cdk/aws-kinesis";
+import type { StreamProps } from "@aws-cdk/aws-kinesis";
 import { Stream } from "@aws-cdk/aws-kinesis";
+import { GuStatefulMigratableConstruct } from "../../utils/mixin";
 import type { GuStack } from "../core";
+import type { GuMigratingResource } from "../core/migrating";
 
-export interface GuKinesisStreamProps extends StreamProps {
-  overrideId?: boolean;
-}
+export interface GuKinesisStreamProps extends StreamProps, GuMigratingResource {}
 
-export class GuKinesisStream extends Stream {
+export class GuKinesisStream extends GuStatefulMigratableConstruct(Stream) {
   constructor(scope: GuStack, id: string, props?: GuKinesisStreamProps) {
     super(scope, id, props);
-    const cfnKinesisStream = this.node.defaultChild as CfnStream;
-    if (props?.overrideId) cfnKinesisStream.overrideLogicalId(id);
   }
 }

--- a/src/patterns/kinesis-lambda.test.ts
+++ b/src/patterns/kinesis-lambda.test.ts
@@ -32,8 +32,8 @@ describe("The GuKinesisLambda pattern", () => {
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 
-  it("should inherit an existing Kinesis stream correctly if logicalIdFromCloudFormation is passed in", () => {
-    const stack = simpleGuStackForTesting();
+  it("should inherit an existing Kinesis stream correctly if an existingLogicalId is passed via existingSnsTopic in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     const basicErrorHandling: StreamErrorHandlingProps = {
       bisectBatchOnError: false,
       retryBehaviour: StreamRetry.maxAttempts(1),
@@ -46,7 +46,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
-      existingKinesisStream: { logicalIdFromCloudFormation: "pre-existing-kinesis-stream" },
+      existingKinesisStream: { existingLogicalId: "pre-existing-kinesis-stream" },
       app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -6,6 +6,7 @@ import { KinesisEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
+import type { GuMigratingResource } from "../constructs/core/migrating";
 import type { GuKinesisStreamProps } from "../constructs/kinesis";
 import { GuKinesisStream } from "../constructs/kinesis";
 import type { GuFunctionProps } from "../constructs/lambda";
@@ -16,7 +17,7 @@ import { toAwsErrorHandlingProps } from "../utils/lambda";
 /**
  * Used to provide information about an existing Kinesis stream to the [[`GuKinesisLambda`]] pattern.
  *
- * Specify a `logicalIdFromCloudFormation` to inherit a Kinesis stream which has already
+ * Specify a `existingLogicalId` to inherit a Kinesis stream which has already
  * been created via a CloudFormation stack. This is necessary to avoid data loss and interruptions of
  * service when migrating stacks from CloudFormation to `cdk`.
  *
@@ -32,7 +33,7 @@ import { toAwsErrorHandlingProps } from "../utils/lambda";
  * ```
  * Inherit the Kinesis stream (rather than creating a new one) using:
  * ```typescript
- * existingKinesisStream: { logicalIdFromCloudFormation: "MyCloudFormedKinesisStream" }
+ * existingKinesisStream: { existingLogicalId: "MyCloudFormedKinesisStream" }
  * ```
  *
  * Alternatively, reference a Kinesis stream which belongs to another stack or pattern using:
@@ -40,8 +41,7 @@ import { toAwsErrorHandlingProps } from "../utils/lambda";
  * existingKinesisStream: { externalKinesisStreamName: "KinesisStreamFromAnotherStack" }
  * ```
  */
-export interface ExistingKinesisStream {
-  logicalIdFromCloudFormation?: string;
+export interface ExistingKinesisStream extends GuMigratingResource {
   externalKinesisStreamName?: string;
 }
 
@@ -104,11 +104,11 @@ export class GuKinesisLambda extends GuLambdaFunction {
       errorPercentageMonitoring: props.monitoringConfiguration.noMonitoring ? undefined : props.monitoringConfiguration,
     });
     const kinesisProps: GuKinesisStreamProps = {
-      overrideId: !!props.existingKinesisStream?.logicalIdFromCloudFormation,
+      existingLogicalId: props.existingKinesisStream?.existingLogicalId,
       encryption: StreamEncryption.MANAGED,
       ...props.kinesisStreamProps,
     };
-    const streamId = props.existingKinesisStream?.logicalIdFromCloudFormation ?? "KinesisStream";
+    const streamId = props.existingKinesisStream?.existingLogicalId ?? "KinesisStream";
 
     const kinesisStream = props.existingKinesisStream?.externalKinesisStreamName
       ? Stream.fromStreamArn(

--- a/src/utils/mixin/migratable-construct.ts
+++ b/src/utils/mixin/migratable-construct.ts
@@ -61,7 +61,7 @@ export function GuMigratableConstruct<TBase extends AnyConstructor>(BaseClass: T
         // the parent AWS constructor presents a common signature of `scope`, `id`, `props`
         if (args.length === 3) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- mixin
-          const [scope, id, props] = args;
+          const [scope, id, maybeProps] = args;
 
           const isAMigratingStack = isGuMigratingStack(scope);
           const isIdAString = typeof id === "string";
@@ -74,13 +74,16 @@ export function GuMigratableConstruct<TBase extends AnyConstructor>(BaseClass: T
            */
           const looksLikeAConstruct = isAMigratingStack && isIdAString;
 
+          // `props` can be undefined
+          const existingLogicalId = maybeProps ? (maybeProps as GuMigratingResource).existingLogicalId : undefined;
+
           if (looksLikeAConstruct) {
             GuMigratingResource.setLogicalId(
               this,
               {
                 migratedFromCloudFormation: (scope as GuMigratingStack).migratedFromCloudFormation,
               },
-              props
+              { existingLogicalId }
             );
           }
         }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we placed the logic of overriding a construct's logicalId into a single place.

In this change, we're updating the `GuKinesisStream` construct to adopt the new logic. As of #418 it's as simple as using the `GuStatefulMigratableConstruct` mixin!

This is another PR in this series. Favouring small PRs over the a massive one (#400).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuKinesisStream` changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.