### PR TITLE
fix: Update `GuSnsTopic` with revised logicalId logic 

### DIFF
--- a/src/constructs/sns/sns-topic.test.ts
+++ b/src/constructs/sns/sns-topic.test.ts
@@ -1,21 +1,18 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
-import type { SynthedStack } from "../../utils/test";
+import "../../utils/test/jest";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuSnsTopic } from "./sns-topic";
 
 describe("The GuSnsTopic construct", () => {
   it("should not override the id by default", () => {
     const stack = simpleGuStackForTesting();
-    new GuSnsTopic(stack, "my-sns-topic");
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).not.toContain("my-sns-topic");
+    new GuSnsTopic(stack, "MySnsTopic");
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", /MySnsTopic.+/);
   });
 
-  it("should override the id with the overrideId prop set to true", () => {
-    const stack = simpleGuStackForTesting();
-    new GuSnsTopic(stack, "my-sns-topic", { overrideId: true });
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(Object.keys(json.Resources)).toContain("my-sns-topic");
+  it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuSnsTopic(stack, "my-sns-topic", { existingLogicalId: "TheSnsTopic" });
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", "TheSnsTopic");
   });
 });

--- a/src/constructs/sns/sns-topic.ts
+++ b/src/constructs/sns/sns-topic.ts
@@ -1,15 +1,13 @@
 import { Topic } from "@aws-cdk/aws-sns";
-import type { CfnTopic, TopicProps } from "@aws-cdk/aws-sns";
+import type { TopicProps } from "@aws-cdk/aws-sns";
+import { GuStatefulMigratableConstruct } from "../../utils/mixin";
 import type { GuStack } from "../core";
+import type { GuMigratingResource } from "../core/migrating";
 
-interface GuSnsTopicProps extends TopicProps {
-  overrideId?: boolean;
-}
+interface GuSnsTopicProps extends TopicProps, GuMigratingResource {}
 
-export class GuSnsTopic extends Topic {
+export class GuSnsTopic extends GuStatefulMigratableConstruct(Topic) {
   constructor(scope: GuStack, id: string, props?: GuSnsTopicProps) {
     super(scope, id, props);
-    const cfnSnsTopic = this.node.defaultChild as CfnTopic;
-    if (props?.overrideId) cfnSnsTopic.overrideLogicalId(id);
   }
 }

--- a/src/utils/mixin/migratable-construct.ts
+++ b/src/utils/mixin/migratable-construct.ts
@@ -61,7 +61,7 @@ export function GuMigratableConstruct<TBase extends AnyConstructor>(BaseClass: T
         // the parent AWS constructor presents a common signature of `scope`, `id`, `props`
         if (args.length === 3) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- mixin
-          const [scope, id, props] = args;
+          const [scope, id, maybeProps] = args;
 
           const isAMigratingStack = isGuMigratingStack(scope);
           const isIdAString = typeof id === "string";
@@ -74,13 +74,16 @@ export function GuMigratableConstruct<TBase extends AnyConstructor>(BaseClass: T
            */
           const looksLikeAConstruct = isAMigratingStack && isIdAString;
 
+          // `props` can be undefined
+          const existingLogicalId = maybeProps ? (maybeProps as GuMigratingResource).existingLogicalId : undefined;
+
           if (looksLikeAConstruct) {
             GuMigratingResource.setLogicalId(
               this,
               {
                 migratedFromCloudFormation: (scope as GuMigratingStack).migratedFromCloudFormation,
               },
-              props
+              { existingLogicalId }
             );
           }
         }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we placed the logic of overriding a construct's logicalId into a single place.

In this change, we're updating the `GuSnsTopic` construct to adopt the new logic. As of #418 it's as simple as using the `GuStatefulMigratableConstruct` mixin!

This is another PR in this series. Favouring small PRs over the a massive one (#400).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuSnsTopic` changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.