### PR TITLE
fix: Update `GuApplicationTargetGroup` with revised logicalId logic

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -152,7 +152,6 @@ describe("The GuAutoScalingGroup", () => {
       ...app,
       vpc: vpc,
       protocol: ApplicationProtocol.HTTP,
-      overrideId: true,
     });
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
@@ -163,7 +162,7 @@ describe("The GuAutoScalingGroup", () => {
     expect(stack).toHaveResource("AWS::AutoScaling::AutoScalingGroup", {
       TargetGroupARNs: [
         {
-          Ref: "TargetGroup",
+          Ref: "TargetGroupTesting29B71ABC",
         },
       ],
     });

--- a/src/constructs/loadbalancing/alb/application-target-group.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.ts
@@ -1,14 +1,14 @@
-import type { ApplicationTargetGroupProps, CfnTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
+import type { ApplicationTargetGroupProps } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { ApplicationProtocol, ApplicationTargetGroup, Protocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Duration } from "@aws-cdk/core";
+import { GuStatefulMigratableConstruct } from "../../../utils/mixin";
 import type { GuStack } from "../../core";
 import { AppIdentity } from "../../core/identity";
+import type { GuMigratingResource } from "../../core/migrating";
 
-export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupProps, AppIdentity {
-  overrideId?: boolean;
-}
+export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupProps, AppIdentity, GuMigratingResource {}
 
-export class GuApplicationTargetGroup extends ApplicationTargetGroup {
+export class GuApplicationTargetGroup extends GuStatefulMigratableConstruct(ApplicationTargetGroup) {
   static DefaultHealthCheck = {
     path: "/healthcheck",
     protocol: Protocol.HTTP,
@@ -28,9 +28,6 @@ export class GuApplicationTargetGroup extends ApplicationTargetGroup {
     };
 
     super(scope, AppIdentity.suffixText({ app }, id), mergedProps);
-
-    if (mergedProps.overrideId || (scope.migratedFromCloudFormation && mergedProps.overrideId !== false))
-      (this.node.defaultChild as CfnTargetGroup).overrideLogicalId(id);
 
     AppIdentity.taggedConstruct({ app }, this);
   }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #364 we placed the logic of overriding a construct's logicalId into a single place.

In this change, we're updating the `GuApplicationTargetGroup` construct to adopt the new logic. As of #418 it's as simple as using the `GuStatefulMigratableConstruct` mixin!

This is another PR in this series. Favouring small PRs over the a massive one (#400).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Possibly.

The overriding logic in `GuApplicationTargetGroup` changed. If stacks are making use of the current (broken?) logic, they will need to be attended to.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, DRYer, more consistent code base?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As noted above, the path to update to the next version of the library might require a bit of attention.