### PR TITLE
fix: improve support for GuUserData in EC2 App pattern

### DIFF
--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -5,7 +5,7 @@ import { Stage } from "../../constants";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuDistributionBucketParameter, GuPrivateConfigBucketParameter } from "../core";
 import { GuAutoScalingGroup } from "./asg";
-import type { GuUserDataProps } from "./user-data";
+import type { GuUserDataPropsWithApp } from "./user-data";
 import { GuUserData } from "./user-data";
 
 describe("GuUserData", () => {
@@ -19,7 +19,7 @@ describe("GuUserData", () => {
     const stack = simpleGuStackForTesting();
     const app = "testing";
 
-    const props: GuUserDataProps = {
+    const props: GuUserDataPropsWithApp = {
       app,
       distributable: {
         bucket: GuDistributionBucketParameter.getInstance(stack),
@@ -70,7 +70,7 @@ describe("GuUserData", () => {
     const stack = simpleGuStackForTesting();
     const app = "testing";
 
-    const props: GuUserDataProps = {
+    const props: GuUserDataPropsWithApp = {
       app,
       distributable: {
         bucket: GuDistributionBucketParameter.getInstance(stack),

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -16,7 +16,8 @@ export interface GuUserDataS3DistributableProps {
   executionStatement: string; // TODO can we detect this and auto generate it? Maybe from the file extension?
 }
 
-export interface GuUserDataProps extends AppIdentity {
+export type GuUserDataPropsWithApp = GuUserDataProps & AppIdentity;
+export interface GuUserDataProps {
   distributable: GuUserDataS3DistributableProps;
   configuration?: GuPrivateS3ConfigurationProps;
 }
@@ -65,7 +66,7 @@ export class GuUserData {
     });
   }
 
-  constructor(scope: GuStack, props: GuUserDataProps) {
+  constructor(scope: GuStack, props: GuUserDataPropsWithApp) {
     this._userData = UserData.forLinux();
 
     if (props.configuration) {

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -54,7 +54,7 @@ export class GuEc2App {
     const maybePrivateConfigPolicy =
       typeof props.userData !== "string" && props.userData.configuration
         ? [new GuGetPrivateConfigPolicy(scope, "GetPrivateConfigFromS3Policy", props.userData.configuration)]
-        : undefined;
+        : [];
 
     const asg = new GuAutoScalingGroup(scope, "AutoScalingGroup", {
       app,


### PR DESCRIPTION
## What does this change?
Our [first draft of the EC2 App pattern](https://github.com/guardian/cdk/pull/399) works fine if `userData` is provided as a `string`. This PR fixes a [todo](https://github.com/guardian/cdk/pull/399#discussion_r609663035) so that our custom `userData` type (`GuUserDataProps`) can be used more easily. More specifically, if the user informs us that they need to download private config from s3, we now ensure that EC2 instances will (automatically) have the permissions to do this.

## Does this change require changes to existing projects or CDK CLI?
No.

## How to test
I've added a unit test to cover this scenario. We should probably start testing this pattern with a 'real' application soon too!

## How can we measure success?
Users won't need to manually add permissions in a case like this, where we can figure out the permissions needed automatically.

## Have we considered potential risks?
I can't think of any...
