### PR TITLE
feat: Include `__mocks__` in TS output (and published library)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "outDir": "lib"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/__snapshots__/**", "src/**/__mocks__/**"]
+  "exclude": ["node_modules", "src/**/*.test.ts", "src/**/__snapshots__/**"]
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #223 (and #233) we started adding a tag (`gu:cdk:version`) to track which version of `@guardian/cdk` is being used.

This tag helps us measure adoption:
  - the presence of the tag tells us the library is being used
  - the value of the tag tells us the version of the library being used

Whilst this is really useful, it does somewhat block users from using tools such as dependabot. This is because the snapshot tests will _always_ fail due to the value of the tag changing between version numbers.

In this repository, we have configured a global mock for this tag to ensure its value is static and thus simplifying the tests.

This change updates the TypeScript configuration to include (more specifically stop excluding) the `__mocks__` directories.

This results in all mocks making their way into the published library which can then be used within client stacks,
to also have a static value.

We currently have a single mock in the repository. If we add more, we may want to be more selective about which of them get published.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Keeping up to date with releases automatically becomes more viable. This reduces risk and [scary changes](https://github.com/guardian/prism/pull/155).

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We, one day, add more mocks and start publishing them too?