### PR TITLE
chore: Use regex to update deps with ncu

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "semantic-release",
     "release:docs": "rm -rf target && typedoc && gh-pages -d target -u \"github-actions-bot <support+actions@github.com>\"",
     "serve:docs": "rm -rf target && typedoc && serve target",
-    "update-aws-cdk": "ncu \"/^@aws-cdk/.*$/\", aws-cdk --upgrade --deep && npm install"
+    "update-aws-cdk": "ncu \"/^@?aws-cdk(/.*)?$/\" --upgrade --deep && npm install"
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.5.0",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #420 we updated the arguments to `ncu` to update the aws-cdk libraries.

Having run the command to try to update to @aws-cdk/* v 1.98.0, it is only updating the library "aws-cdk" rather than "@aws-cdk/*" and "aws-cdk".

This change switches to a regex pattern rather than multiple inputs to `ncu` and things seem much happier.

```console
➜ ./script/update-aws-cdk

> @guardian/cdk@8.3.0 update-aws-cdk /Users/akash_askoolum/code/cdk
> ncu "/^@?aws-cdk(/.*)?$/" --upgrade --deep && npm install

Upgrading /Users/akash_askoolum/code/cdk/package.json
[====================] 15/15 100%

 @aws-cdk/assert                      1.97.0  →  1.98.0
 @aws-cdk/aws-apigateway              1.97.0  →  1.98.0
 @aws-cdk/aws-autoscaling             1.97.0  →  1.98.0
 @aws-cdk/aws-cloudwatch-actions      1.97.0  →  1.98.0
 @aws-cdk/aws-ec2                     1.97.0  →  1.98.0
 @aws-cdk/aws-elasticloadbalancing    1.97.0  →  1.98.0
 @aws-cdk/aws-elasticloadbalancingv2  1.97.0  →  1.98.0
 @aws-cdk/aws-events-targets          1.97.0  →  1.98.0
 @aws-cdk/aws-iam                     1.97.0  →  1.98.0
 @aws-cdk/aws-kinesis                 1.97.0  →  1.98.0
 @aws-cdk/aws-lambda                  1.97.0  →  1.98.0
 @aws-cdk/aws-lambda-event-sources    1.97.0  →  1.98.0
 @aws-cdk/aws-rds                     1.97.0  →  1.98.0
 @aws-cdk/aws-s3                      1.97.0  →  1.98.0
 @aws-cdk/core                        1.97.0  →  1.98.0

Run npm install to install new versions.

Upgrading /Users/akash_askoolum/code/cdk/eslint/package.json

No dependencies.
Upgrading /Users/akash_askoolum/code/cdk/integration-test/package.json
[====================] 1/1 100%

 aws-cdk  1.97.0  →  1.98.0

Run npm install to install new versions.

> @guardian/cdk@8.3.0 prepare /Users/akash_askoolum/code/cdk
> tsc

npm WARN @guardian/cdk@8.3.0 No license field.

updated 24 packages and audited 1807 packages in 17.102s

96 packages are looking for funding
  run `npm fund` for details

found 51 moderate severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
```

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run `./script/update-aws-cdk`.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Actually keeping things updated 😅 .

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a