### PR TITLE
feat: Simplify props for `GuLambdaFunction`

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -13,6 +13,11 @@ Object {
     },
   },
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -31,7 +36,9 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": "bucket1",
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
           "S3Key": "folder/to/key",
         },
         "Handler": "handler.ts",
@@ -138,7 +145,10 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::bucket1",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
                     ],
                   ],
                 },
@@ -150,7 +160,11 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::bucket1/*",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
                     ],
                   ],
                 },

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -11,7 +11,7 @@ describe("The GuAlarm class", () => {
   it("should create a CloudWatch alarm", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -31,7 +31,7 @@ describe("The GuAlarm class", () => {
   it("should send alerts to the provided SNS Topic", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -70,7 +70,7 @@ describe("The GuAlarm class", () => {
   it("should enable alarm actions in PROD and disable them in CODE, by default", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -100,7 +100,7 @@ describe("The GuAlarm class", () => {
   it("should allow users to manually enable alarm notifications in CODE", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",

--- a/src/constructs/cloudwatch/lambda-alarms.test.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.test.ts
@@ -9,7 +9,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
   it("should create the correct alarm resource with minimal config", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -26,7 +26,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
   it("should adjust the number of evaluation periods if a custom value is provided", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -46,7 +46,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
   it("should use a custom description if one is provided", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -67,7 +67,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
   it("should use a custom alarm name if one is provided", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",

--- a/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
+++ b/src/constructs/lambda/__snapshots__/lambda.test.ts.snap
@@ -57,6 +57,11 @@ Object {
     },
   },
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -75,7 +80,9 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": "bucket1",
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
           "S3Key": "folder/to/key",
         },
         "Handler": "handler.ts",
@@ -182,7 +189,10 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::bucket1",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
                     ],
                   ],
                 },
@@ -194,7 +204,11 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::bucket1/*",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
                     ],
                   ],
                 },

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -11,7 +11,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -19,7 +19,9 @@ describe("The GuLambdaFunction class", () => {
 
     expect(stack).toHaveResource("AWS::Lambda::Function", {
       Code: {
-        S3Bucket: "bucket1",
+        S3Bucket: {
+          Ref: "DistributionBucketName",
+        },
         S3Key: "folder/to/key",
       },
     });
@@ -29,7 +31,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -42,7 +44,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       rules: [
@@ -72,7 +74,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       apis: [
@@ -104,7 +106,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       errorPercentageMonitoring: {
@@ -121,7 +123,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
@@ -142,7 +144,10 @@ describe("The GuLambdaFunction class", () => {
                     {
                       Ref: "AWS::Partition",
                     },
-                    ":s3:::bucket1",
+                    ":s3:::",
+                    {
+                      Ref: "DistributionBucketName",
+                    },
                   ],
                 ],
               },
@@ -154,7 +159,11 @@ describe("The GuLambdaFunction class", () => {
                     {
                       Ref: "AWS::Partition",
                     },
-                    ":s3:::bucket1/*",
+                    ":s3:::",
+                    {
+                      Ref: "DistributionBucketName",
+                    },
+                    "/*",
                   ],
                 ],
               },
@@ -170,7 +179,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
       memorySize: 2048,
@@ -186,7 +195,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
       app: "testing",
@@ -201,7 +210,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
       timeout: Duration.seconds(60),
@@ -217,7 +226,7 @@ describe("The GuLambdaFunction class", () => {
     const stack = simpleGuStackForTesting();
 
     new GuLambdaFunction(stack, "lambda", {
-      code: { bucket: "bucket1", key: "folder/to/key" },
+      code: { key: "folder/to/key" },
       handler: "handler.ts",
       runtime: Runtime.JAVA_8,
       app: "testing",

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -10,6 +10,7 @@ import { Duration } from "@aws-cdk/core";
 import type { GuLambdaErrorPercentageMonitoringProps } from "../cloudwatch";
 import { GuLambdaErrorPercentageAlarm } from "../cloudwatch";
 import type { GuStack } from "../core";
+import { GuDistributionBucketParameter } from "../core";
 import { AppIdentity } from "../core/identity";
 
 interface ApiProps extends Omit<LambdaRestApiProps, "handler"> {
@@ -17,7 +18,12 @@ interface ApiProps extends Omit<LambdaRestApiProps, "handler"> {
 }
 
 export interface GuFunctionProps extends Omit<FunctionProps, "code">, AppIdentity {
-  code: { bucket: string; key: string };
+  code: {
+    /**
+     * The path to the lambda's distributable from the root of the [[`GuDistributionBucketParameter`]] bucket.
+     */
+    key: string;
+  };
   rules?: Array<{
     schedule: Schedule;
     description?: string;
@@ -41,7 +47,11 @@ function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
 
 export class GuLambdaFunction extends Function {
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
-    const bucket = Bucket.fromBucketName(scope, `${id}-bucket`, props.code.bucket);
+    const bucket = Bucket.fromBucketName(
+      scope,
+      `${id}-bucket`,
+      GuDistributionBucketParameter.getInstance(scope).valueAsString
+    );
     const code = Code.fromBucket(bucket, props.code.key);
     super(scope, id, {
       ...props,

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -18,6 +18,7 @@ interface ApiProps extends Omit<LambdaRestApiProps, "handler"> {
 }
 
 export interface GuFunctionProps extends Omit<FunctionProps, "code">, AppIdentity {
+  // TODO can we reuse `GuUserDataS3DistributableProps` here?
   code: {
     /**
      * The path to the lambda's distributable from the root of the [[`GuDistributionBucketParameter`]] bucket.

--- a/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`The GuKinesisLambda pattern should create the correct resources for a new stack with minimal config 1`] = `
 Object {
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -52,7 +57,9 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": "test-dist",
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
           "S3Key": "lambda.zip",
         },
         "FunctionName": "my-lambda-function",
@@ -127,7 +134,10 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::test-dist",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
                     ],
                   ],
                 },
@@ -139,7 +149,11 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::test-dist/*",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
                     ],
                   ],
                 },

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`The GuScheduledLambda pattern should create the correct resources with minimal config 1`] = `
 Object {
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -21,7 +26,9 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": "test-dist",
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
           "S3Key": "lambda.zip",
         },
         "FunctionName": "my-lambda-function",
@@ -78,7 +85,10 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::test-dist",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
                     ],
                   ],
                 },
@@ -90,7 +100,11 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::test-dist/*",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
                     ],
                   ],
                 },

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -13,6 +13,11 @@ Object {
     },
   },
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",
@@ -56,7 +61,9 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": "test-dist",
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
           "S3Key": "lambda.zip",
         },
         "FunctionName": "my-lambda-function",
@@ -129,7 +136,10 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::test-dist",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
                     ],
                   ],
                 },
@@ -141,7 +151,11 @@ Object {
                       Object {
                         "Ref": "AWS::Partition",
                       },
-                      ":s3:::test-dist/*",
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
                     ],
                   ],
                 },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Simplifies the props needed to create a `GuLambdaFunction` by removing the bucket key in favour of using the `GuDistributionBucketParameter` singleton.

This brings `GuLambdaFunction` in line with our EC2 constructs and patterns.

`GuDistributionBucketParameter` adds an SSM parameter to a stack with a default path of `/account/services/artifact.bucket`.

BREAKING CHANGE: Shape change to the props for `GuLambdaFunction`

The `code.bucket` field has been removed.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. They'll need to update, the diff shouldn't be too difficult though as it's just the removal of a property.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should continue to pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Providing a simpler API that is consistent between EC2 and Lambda constructs.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a