### PR TITLE
chore: Fix "duplicate manual mock found" message

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,13 @@ module.exports = {
 
   // ignore this file as it's used to demonstrate custom lint rule and Jest flags unused declarations
   testPathIgnorePatterns: ["<rootDir>/eslint/rules/valid-constructors.test.ts"],
+
+  /*
+  Ignore `lib` to prevent a 'duplicate manual mock found" warning
+  See:
+    - https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring
+    - https://github.com/facebook/jest/issues/6801#issuecomment-712951064
+    - #448
+   */
+  modulePathIgnorePatterns: ["<rootDir>/lib"],
 };


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #448 we started including the mocks in the published package.

Since then the following message is appearing when running tests, both locally and in CI:

```log
jest-haste-map: duplicate manual mock found: library-info
  The following files share their name; please delete one of them:
    * <rootDir>/lib/constants/__mocks__/library-info.js
    * <rootDir>/src/constants/__mocks__/library-info.ts
```

This change configures Jest to ignore the `lib` directory, which should quieten this message.

This should not affect the published package.

See:
  - https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring
  - https://github.com/facebook/jest/issues/6801#issuecomment-712951064
  - #448

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Compare build logs?

![image](https://user-images.githubusercontent.com/836140/114925226-bce4f700-9e26-11eb-8d23-9dfb5370575d.png)

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fewer warnings in the build log.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a