### PR TITLE
fix: Add `AppIdentity` to `GuClassicLoadBalancer`

### DIFF
--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -9,9 +9,10 @@ import { Duration } from "@aws-cdk/core";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
 import type { GuStack } from "../core";
 import { GuArnParameter } from "../core";
+import { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-interface GuClassicLoadBalancerProps extends Omit<LoadBalancerProps, "healthCheck">, GuMigratingResource {
+interface GuClassicLoadBalancerProps extends Omit<LoadBalancerProps, "healthCheck">, GuMigratingResource, AppIdentity {
   propertiesToOverride?: Record<string, unknown>;
   healthCheck?: Partial<HealthCheck>;
 }
@@ -33,7 +34,8 @@ export class GuClassicLoadBalancer extends GuStatefulMigratableConstruct(LoadBal
       healthCheck: { ...GuClassicLoadBalancer.DefaultHealthCheck, ...props.healthCheck },
     };
 
-    super(scope, id, mergedProps);
+    super(scope, AppIdentity.suffixText({ app: props.app }, id), mergedProps);
+    AppIdentity.taggedConstruct({ app: props.app }, this);
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adding `AppIdentity` to `GuClassicLoadBalancer` to support a multi-app stack.

This means the auto-generated logicalId gets suffixed with the app string and the resource also gets the App tag.

This isn't considered a breaking change because `GuClassicLoadBalancer` only gets used when migrating a stack and not for new stacks.

That is, we can expect `existingLogicalId` will always get set, which will prevent the logicalId from being auto-generated.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

The Prism stack can close [a TODO](https://github.com/guardian/prism/blob/7592e9e8c02f5267d160eeefe738536caf98ca4c/cdk/lib/prism.ts#L33) 🎉 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Consistent application of `AppIdentity` to identify a resource being tied to an app.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a