### PR TITLE
feat: Add optional alarm configuration to EC2 App pattern

### DIFF
--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -12,14 +12,13 @@ import { GuAlarm } from "./alarm";
  * the specified threshold.
  */
 export interface Gu5xxPercentageMonitoringProps
-  extends Omit<GuAlarmProps, "evaluationPeriods" | "metric" | "period" | "threshold" | "treatMissingData">,
-    AppIdentity {
+  extends Omit<GuAlarmProps, "evaluationPeriods" | "metric" | "period" | "threshold" | "treatMissingData"> {
   tolerated5xxPercentage: number;
   numberOfMinutesAboveThresholdBeforeAlarm?: number;
   noMonitoring?: false;
 }
 
-interface GuLoadBalancerAlarmProps extends Gu5xxPercentageMonitoringProps {
+interface GuLoadBalancerAlarmProps extends Gu5xxPercentageMonitoringProps, AppIdentity {
   loadBalancer: GuApplicationLoadBalancer;
 }
 

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -12,6 +12,7 @@ describe("the GuEC2App pattern", function () {
       applicationPort: GuApplicationPorts.Node,
       app: "test-gu-ec2-app",
       publicFacing: false,
+      monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
@@ -24,6 +25,7 @@ describe("the GuEC2App pattern", function () {
       applicationPort: GuApplicationPorts.Node,
       app: app,
       publicFacing: false,
+      monitoringConfiguration: { noMonitoring: true },
       userData: {
         distributable: {
           bucket: GuDistributionBucketParameter.getInstance(stack),
@@ -75,12 +77,29 @@ describe("the GuEC2App pattern", function () {
     });
   });
 
+  it("creates an alarm if monitoringConfiguration is provided", function () {
+    const stack = simpleGuStackForTesting();
+    const app = "test-gu-ec2-app";
+    new GuEc2App(stack, {
+      applicationPort: GuApplicationPorts.Node,
+      app: app,
+      publicFacing: false,
+      monitoringConfiguration: {
+        tolerated5xxPercentage: 5,
+        snsTopicName: "test-topic",
+      },
+      userData: "",
+    });
+    expect(stack).toHaveResource("AWS::CloudWatch::Alarm"); //The shape of the alarm is tested at construct level
+  });
+
   it("can handle multiple EC2 apps in a single stack", function () {
     const stack = simpleGuStackForTesting();
     new GuEc2App(stack, {
       applicationPort: GuApplicationPorts.Node,
       app: "NodeApp",
       publicFacing: false,
+      monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
     });
 
@@ -88,6 +107,7 @@ describe("the GuEC2App pattern", function () {
       applicationPort: GuApplicationPorts.Play,
       app: "PlayApp",
       publicFacing: false,
+      monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
     });
 
@@ -118,6 +138,7 @@ describe("the GuEC2App pattern", function () {
       new GuNodeApp(stack, {
         app: "NodeApp",
         publicFacing: false,
+        monitoringConfiguration: { noMonitoring: true },
         userData: "#!/bin/dev foobarbaz",
       });
 
@@ -133,6 +154,7 @@ describe("the GuEC2App pattern", function () {
       new GuPlayApp(stack, {
         app: "PlayApp",
         publicFacing: false,
+        monitoringConfiguration: { noMonitoring: true },
         userData: "#!/bin/dev foobarbaz",
       });
 


### PR DESCRIPTION
## What does this change?

This PR wires up the new 5XX alarm construct (https://github.com/guardian/cdk/pull/439) with the EC2 app pattern. Users can opt-in/out of alarm creation with minimal effort and minimal understanding of CloudWatch concepts. 

This follows a [convention that is already in place for our lambda-based patterns](https://github.com/guardian/cdk/blob/2692d040c70486fbe5acb11075e4fc0a027d86fa/src/patterns/sns-lambda.ts#L70).

## Does this change require changes to existing projects or CDK CLI?
No, although it's a breaking change for the EC2 app pattern, the pattern is not in use yet.

## How to test
I've updated the unit tests and included a new one to test that alarm creation works when the appropriate props are provided.

## How can we measure success?
1. Teams who want to configure alarms for their EC2 apps can do so with minimal effort. 
2. Teams who have chosen to configure alarms via a different mechanism can easily opt-out. 
3. No user/team can completely forget about configuring alarms (which currently happens frequently) because they must provide _something_ for the `monitoringConfiguration` prop.

## Have we considered potential risks?
It's possible that encouraging teams to create more alarms will generate a lot of noisy alarms. This is mitigated by the fact that we give teams control over: 

* whether to configure an alarm 
* what the threshold should be
* how long the threshold should be exceeded before a notification is sent

Furthermore: 

* all alarms in `CODE` are silent by default (https://github.com/guardian/cdk/pull/404)
* all alarms become version controlled so it's easy to find and silence/relax irritating ones with a tiny PR
