### PR TITLE
chore: Script the steps to update aws-cdk libs

### DIFF
--- a/script/update-aws-cdk
+++ b/script/update-aws-cdk
@@ -3,7 +3,70 @@
 set -e
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR=$DIR/..
 
-"${DIR}"/check-yarn-lock
+checkYarnLock() {
+  "${DIR}"/check-yarn-lock
+}
 
-npm run update-aws-cdk
+ensureAtHeadOfOrigin() {
+  DEFAULT_BRANCH=main
+
+  CURRENT_BRANCH=$(git branch --show-current)
+  if [ $CURRENT_BRANCH != $DEFAULT_BRANCH ] ; then
+    echo "ERROR: Please switch to the branch $DEFAULT_BRANCH"
+    exit 1
+  fi
+
+  DIFF_WITH_ORIGIN=$(git rev-list --count origin/$DEFAULT_BRANCH...$DEFAULT_BRANCH)
+  if [ $DIFF_WITH_ORIGIN -ne 0 ] ; then
+    echo "ERROR: You are $DIFF_WITH_ORIGIN commits out of sync with origin/$DEFAULT_BRANCH. Please update first."
+    exit 1
+  fi
+
+  if ! git diff --quiet; then
+    echo "ERROR: There are local changes. Please stash them."
+    exit 1
+  fi
+}
+
+updateAwsCdk() {
+  npm run update-aws-cdk
+}
+
+checkForLocalChanges() {
+  if git diff --quiet; then
+    echo "No changes. No further action needed."
+    exit 0
+  fi
+}
+
+raisePR() {
+  LIBRARY_TO_CHECK="@aws-cdk/core"
+  INSTALLED_VERSION_NUMBER=$(jq -r ".dependencies.\"${LIBRARY_TO_CHECK}\"" < "$DIR/../package.json")
+
+  BRANCH_NAME="update-aws-cdk-$INSTALLED_VERSION_NUMBER"
+  COMMIT_SUBJECT="chore(deps)!: Update aws-cdk libraries to $INSTALLED_VERSION_NUMBER"
+  COMMIT_BODY="BREAKING CHANGE: Update aws-cdk libraries to $INSTALLED_VERSION_NUMBER"
+
+  git checkout -b $BRANCH_NAME
+
+  for file in package.json package-lock.json integration-test/package.json; do
+    git add $file
+  done
+
+  git commit -m "$COMMIT_SUBJECT" -m "$COMMIT_BODY"
+
+  git push -u origin $BRANCH_NAME
+  gh pr create --title "$COMMIT_SUBJECT" --body "$COMMIT_BODY"
+}
+
+main() {
+  ensureAtHeadOfOrigin
+  checkYarnLock
+  updateAwsCdk
+  checkForLocalChanges
+  raisePR
+}
+
+main


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Updates the `update-aws-cdk` script to:
  1. Check one is on the head of main, with no changes
  2. Update the aws-cdk libraries
  3. Raise a PR with the correct message to issue a new major release

This is after my previous attempt to write the correct message failed.

PR #450 did not issue a new release because the commit had "BREAKING CHANGES" rather than the singular "BREAKING CHANGE" 🙄.

This change scripts the process to take the pain away.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

https://github.com/guardian/cdk/pull/465 was created with the changes in this branch. If merging that PR creates a new major release, then this script works.

Indeed, it has 🎉  https://github.com/guardian/cdk/releases/tag/v10.0.0.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

🤖 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a