### PR TITLE
chore: Address TypeDoc warnings

### DIFF
--- a/docs/001-general-usage.md
+++ b/docs/001-general-usage.md
@@ -64,7 +64,7 @@ This does, however require the use of `ts-node` to compile on the fly. This can 
 For apps with a single stack, the generated YAML will also be printed in the console.
 You can pipe this to disk:
 
-```console
+```bash
 cdk synth --app="ts-node ./bin/my-app.ts" > cloudformation.yaml
 ```
 
@@ -107,7 +107,7 @@ module.exports = {
 
 Finally, update your snapshots. The `gu:cdk:version` tag should now be:
 
-```json5
+```jsonc
 {
   "Key": "gu:cdk:version",
   "PropagateAtLaunch": true,

--- a/typedoc.js
+++ b/typedoc.js
@@ -4,7 +4,9 @@ const constructsDir = "src/constructs";
 const utilsDir = "src/utils";
 
 function getEntryPointsFromSubdirectories(directory) {
-  return readdirSync(directory).map((dir) => `${directory}/${dir}/index.ts`);
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((dir) => dir.isDirectory())
+    .map(({ name }) => `${directory}/${name}/index.ts`);
 }
 
 module.exports = {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We use TypeDoc to create the documentation site. The file [`docs/001-general-usage.md`](https://github.com/guardian/cdk/blob/main/docs/001-general-usage.md) is used for the index page.

There are a couple of warnings in the build log:

```
Unsupported highlight language "console" will not be highlighted. Run typedoc --help for a list of supported languages.
target code block :
	cdk synth --app="ts-node ./bin/my-app.ts" > cloudformation.yaml
source files :undefined
output file :
	/home/runner/work/cdk/cdk/target/index.html
Warning:
Unsupported highlight language "json5" will not be highlighted. Run typedoc --help for a list of supported languages.
target code block :
	{
	  "Key": "gu:cdk:version",
	  "PropagateAtLaunch": true,
	  "Value": "TEST", // <-- would otherwise be the version number of @guardian/cdk in use
	}
source files :undefined
output file :
	/home/runner/work/cdk/cdk/target/index.html
```

It looks like TypeDoc uses Shiki for code highlighting. This change uses [supported language hints](https://github.com/shikijs/shiki/blob/master/docs/languages.md).

It looks like Shiki treats `jsonc` as [Microsoft's JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments).

We also crawl some directories to include in the TypeDoc documentation site.

This fixes this warning in the build log:

```
Warning: Provided entry point src/utils/logger.ts/index.ts does not exist and will not be included in the docs.
```

It looks like we need to [explicitly check](https://stackoverflow.com/a/24594123/3868241) if an item returned from `readdirSync` is a directory.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Run `./script/docs` on main and witness the above warnings
- Run `./script/docs` on this branch and witness no warnings

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A quieter build log making it easier to spot issues.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a