### PR TITLE
feat: Simplify props for `GuUserData`

### DIFF
--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -3,7 +3,7 @@ import { Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
 import { Stage } from "../../constants";
 import { simpleGuStackForTesting } from "../../utils/test";
-import { GuDistributionBucketParameter, GuPrivateConfigBucketParameter } from "../core";
+import { GuPrivateConfigBucketParameter } from "../core";
 import { GuAutoScalingGroup } from "./asg";
 import type { GuUserDataPropsWithApp } from "./user-data";
 import { GuUserData } from "./user-data";
@@ -22,7 +22,6 @@ describe("GuUserData", () => {
     const props: GuUserDataPropsWithApp = {
       app,
       distributable: {
-        bucket: GuDistributionBucketParameter.getInstance(stack),
         fileName: "my-app.deb",
         executionStatement: `dpkg -i /${app}/my-app.deb`,
       },
@@ -73,7 +72,6 @@ describe("GuUserData", () => {
     const props: GuUserDataPropsWithApp = {
       app,
       distributable: {
-        bucket: GuDistributionBucketParameter.getInstance(stack),
         fileName: "my-app.deb",
         executionStatement: `dpkg -i /${app}/my-app.deb`,
       },

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -2,17 +2,21 @@ import type { S3DownloadOptions } from "@aws-cdk/aws-ec2";
 import { UserData } from "@aws-cdk/aws-ec2";
 import { Bucket } from "@aws-cdk/aws-s3";
 import type { GuPrivateS3ConfigurationProps } from "../../utils/ec2";
-import type { GuDistributionBucketParameter, GuStack } from "../core";
+import { GuDistributionBucketParameter } from "../core";
+import type { GuStack } from "../core";
 import type { AppIdentity } from "../core/identity";
 
-/**
- * Where to download a distributable from.
- * We'll look for `fileName` on the path "bucket/stack/stage/app/<fileName>".
- * `executionStatement` will be something like "dpkg -i application.deb` or `service foo start`.
- */
 export interface GuUserDataS3DistributableProps {
-  bucket: GuDistributionBucketParameter;
+  /**
+   * Where to download a distributable from.
+   * We'll look for `fileName` on the path "bucket/stack/stage/app/<fileName>".
+   */
   fileName: string;
+
+  /**
+   * The command to run `fileName`.
+   * For example `dpkg -i application.deb` or `service foo start`.
+   */
   executionStatement: string; // TODO can we detect this and auto generate it? Maybe from the file extension?
 }
 
@@ -40,7 +44,7 @@ export class GuUserData {
     const bucketKey = [scope.stack, scope.stage, app, props.fileName].join("/");
 
     const bucket = Bucket.fromBucketAttributes(scope, "DistributionBucket", {
-      bucketName: props.bucket.valueAsString,
+      bucketName: GuDistributionBucketParameter.getInstance(scope).valueAsString,
     });
 
     this.addS3DownloadCommand({

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -2,7 +2,7 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Stage } from "../constants";
 import { TrackingTag } from "../constants/tracking-tag";
-import { GuDistributionBucketParameter, GuPrivateConfigBucketParameter } from "../constructs/core";
+import { GuPrivateConfigBucketParameter } from "../constructs/core";
 import { alphabeticalTags, simpleGuStackForTesting } from "../utils/test";
 import { GuApplicationPorts, GuEc2App, GuNodeApp, GuPlayApp } from "./ec2-app";
 
@@ -49,7 +49,6 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: {
         distributable: {
-          bucket: GuDistributionBucketParameter.getInstance(stack),
           fileName: "my-app.deb",
           executionStatement: `dpkg -i /${app}/my-app.deb`,
         },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following from #455, simplify the props for `GuUserData` by removing the bucket key in favour of using the `GuDistributionBucketParameter` singleton.

BREAKING CHANGE: Shape change to the props for `GuUserData`

The `bucket` field has been removed.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - the props to `GuUserData` has changed.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Tests continue to pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler, more consistent API.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

With this change, we require an account to have the parameter store entry created. We do not have any tooling to assess an account's GuCDK readiness, so we're somewhat relying on our documentation for now.