### PR TITLE
feat: Simplify props for `GuLambdaFunction`

### DIFF
--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -1,6 +1,5 @@
 import { SynthUtils } from "@aws-cdk/assert";
 import "@aws-cdk/assert/jest";
-import { Schedule } from "@aws-cdk/aws-events";
 import { Runtime } from "@aws-cdk/aws-lambda";
 import { Duration } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../utils/test";
@@ -49,36 +48,6 @@ describe("The GuLambdaFunction class", () => {
     });
 
     expect(stack).not.toHaveResource("AWS::Events::Rule");
-  });
-
-  it("should add any rules passed in", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuLambdaFunction(stack, "lambda", {
-      fileName: "my-app.zip",
-      handler: "handler.ts",
-      runtime: Runtime.NODEJS_12_X,
-      rules: [
-        {
-          schedule: Schedule.rate(Duration.days(7)),
-          description: "run every week",
-        },
-        {
-          schedule: Schedule.expression("0 1 * * *"),
-          description: "run every hour (cron)",
-        },
-      ],
-      app: "testing",
-    });
-
-    expect(stack).toHaveResource("AWS::Events::Rule", {
-      Description: "run every week",
-      ScheduleExpression: "rate(7 days)",
-    });
-    expect(stack).toHaveResource("AWS::Events::Rule", {
-      Description: "run every hour (cron)",
-      ScheduleExpression: "0 1 * * *",
-    });
   });
 
   it("should add any apis passed in", () => {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -1,8 +1,5 @@
 import type { LambdaRestApiProps } from "@aws-cdk/aws-apigateway";
 import { LambdaRestApi } from "@aws-cdk/aws-apigateway";
-import type { Schedule } from "@aws-cdk/aws-events";
-import { Rule } from "@aws-cdk/aws-events";
-import { LambdaFunction } from "@aws-cdk/aws-events-targets";
 import { Code, Function, RuntimeFamily } from "@aws-cdk/aws-lambda";
 import type { FunctionProps, Runtime } from "@aws-cdk/aws-lambda";
 import { Bucket } from "@aws-cdk/aws-s3";
@@ -19,10 +16,6 @@ interface ApiProps extends Omit<LambdaRestApiProps, "handler"> {
 }
 
 export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code">, AppIdentity {
-  rules?: Array<{
-    schedule: Schedule;
-    description?: string;
-  }>;
   apis?: ApiProps[];
   errorPercentageMonitoring?: GuLambdaErrorPercentageMonitoringProps;
 }
@@ -56,16 +49,6 @@ export class GuLambdaFunction extends Function {
       memorySize: defaultMemorySize(runtime, memorySize),
       timeout: timeout ?? Duration.seconds(30),
       code,
-    });
-
-    props.rules?.forEach((rule, index) => {
-      const target = new LambdaFunction(this);
-      new Rule(this, `${id}-${rule.schedule.expressionString}-${index}`, {
-        schedule: rule.schedule,
-        targets: [target],
-        ...(rule.description && { description: rule.description }),
-        enabled: true,
-      });
     });
 
     props.apis?.forEach((api) => {

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -81,7 +81,7 @@ export interface ExistingKinesisStream extends GuMigratingResource {
  *  monitoringConfiguration: { noMonitoring: true } as NoMonitoring
  * ```
  */
-export interface GuKinesisLambdaProps extends Omit<GuFunctionProps, "rules" | "apis" | "errorPercentageMonitoring"> {
+export interface GuKinesisLambdaProps extends Omit<GuFunctionProps, "apis" | "errorPercentageMonitoring"> {
   monitoringConfiguration: NoMonitoring | GuLambdaErrorPercentageMonitoringProps;
   existingKinesisStream?: ExistingKinesisStream;
   errorHandlingConfiguration: StreamErrorHandlingProps;

--- a/src/patterns/scheduled-lambda.test.ts
+++ b/src/patterns/scheduled-lambda.test.ts
@@ -16,7 +16,7 @@ describe("The GuScheduledLambda pattern", () => {
       functionName: "my-lambda-function",
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
-      schedule: Schedule.rate(Duration.minutes(1)),
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
       monitoringConfiguration: noMonitoring,
       app: "testing",
     };
@@ -31,7 +31,7 @@ describe("The GuScheduledLambda pattern", () => {
       functionName: "my-lambda-function",
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
-      schedule: Schedule.rate(Duration.minutes(1)),
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
       monitoringConfiguration: {
         toleratedErrorPercentage: 99,
         snsTopicName: "alerts-topic",

--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -66,7 +66,7 @@ export interface ExistingSnsTopic extends GuMigratingResource {
  *  monitoringConfiguration: { noMonitoring: true } as NoMonitoring
  * ```
  */
-export interface GuSnsLambdaProps extends Omit<GuFunctionProps, "rules" | "apis" | "errorPercentageMonitoring"> {
+export interface GuSnsLambdaProps extends Omit<GuFunctionProps, "apis" | "errorPercentageMonitoring"> {
   monitoringConfiguration: NoMonitoring | GuLambdaErrorPercentageMonitoringProps;
   existingSnsTopic?: ExistingSnsTopic;
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently the props to `GuLambdaFunction` are a little confusing.

The props currently have an optional `rules` and `apis` property.

This means it is possible to create a lambda that:
  - Sits there with no event source
  - Runs on a cron
  - Runs behind API Gateway
  - Runs on a cron and behind API Gateway

We never want the first and last option to be possible.

This change moves the props for a cron lambda into the `GuScheduledLambda` pattern for a cleaner API.

BREAKING CHANGE: The shape of the `GuScheduledLambda` pattern has changed.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes. See breaking change note.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Ultimately, this is part of a stream of work to make defining an API Gateway backed lambda simpler. This will be the next PR, so success is if that PR makes sense?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a