### PR TITLE
fix(guparameter): add a sensible default to GuParameters when using SSM

### DIFF
--- a/src/constructs/core/parameters/base.test.ts
+++ b/src/constructs/core/parameters/base.test.ts
@@ -25,6 +25,7 @@ describe("The GuParameter class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Parameters.Parameter).toEqual({
+      Default: "/$STAGE/$STACK/$APP/parameter",
       Type: "AWS::SSM::Parameter::Value<Boolean>",
     });
   });
@@ -37,6 +38,7 @@ describe("The GuParameter class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Parameters.Parameter).toEqual({
+      Default: "/$STAGE/$STACK/$APP/parameter",
       Type: "AWS::SSM::Parameter::Value<String>",
     });
   });
@@ -49,9 +51,41 @@ describe("The GuParameter class", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Parameters.Parameter).toEqual({
+      Default: "/$STAGE/$STACK/$APP/parameter",
       Type: "AWS::SSM::Parameter::Value<Boolean>",
       Description: "This is a test",
     });
+  });
+
+  it("when from SSM, has a default SSM path to remind users that it's an SSM parameter", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { fromSSM: true });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toHaveProperty("Default");
+    expect(json.Parameters.Parameter.Default).toEqual("/$STAGE/$STACK/$APP/parameter");
+  });
+
+  it("default SSM path gets overridden by prop", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { fromSSM: true, default: "/FOO/BAR" });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter.Default).toEqual("/FOO/BAR");
+  });
+
+  it("when not from SSM, has no default", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuParameter(stack, "Parameter", { fromSSM: false });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).not.toHaveProperty("Default");
   });
 });
 

--- a/src/constructs/core/parameters/base.ts
+++ b/src/constructs/core/parameters/base.ts
@@ -16,6 +16,7 @@ export class GuParameter extends CfnParameter {
 
   constructor(scope: GuStack, id: string, props: GuParameterProps) {
     super(scope, id, {
+      ...(props.fromSSM && { default: "/$STAGE/$STACK/$APP/parameter" }),
       ...props,
       type: props.fromSSM ? `AWS::SSM::Parameter::Value<${props.type ?? "String"}>` : props.type,
     });


### PR DESCRIPTION
## What does this change?

At the moment, there is no indication in the UI that the parameter you are filling in is an SSM parameter. Users may remember to add a sensible default or a hint in the description, but they also may not. 

This change ensures that, when not provided explicitly, users are hinted that the parameter is from SSM as well as what the ideal SSM path should be.

## Does this change require changes to existing projects or CDK CLI?

Nope.

## How to test

`./script/test`.

## How can we measure success?

Users spend less time confused about how to handle CFN parameters in the UI.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

I don't think there are any, as the default gets overridden if desired. 
