### PR TITLE
feat: Add Wazuh security group to ASG by default

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -187,6 +187,9 @@ describe("The GuAutoScalingGroup", () => {
           "Fn::GetAtt": [`GuHttpsEgressSecurityGroup${app}89CDDA4B`, "GroupId"],
         },
         {
+          "Fn::GetAtt": ["WazuhSecurityGroup", "GroupId"],
+        },
+        {
           "Fn::GetAtt": ["SecurityGroupTestingA32D34F9", "GroupId"], // auto-generated logicalId
         },
         {

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -9,7 +9,7 @@ import type { GuStack } from "../core";
 import { GuAmiParameter, GuInstanceTypeParameter } from "../core";
 import { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
-import { GuHttpsEgressSecurityGroup } from "../ec2";
+import { GuHttpsEgressSecurityGroup, GuWazuhAccess } from "../ec2";
 import { GuInstanceRole } from "../iam";
 
 // Since we want to override the types of what gets passed in for the below props,
@@ -116,6 +116,7 @@ export class GuAutoScalingGroup extends GuStatefulMigratableConstruct(AutoScalin
 
     mergedProps.targetGroup && this.attachToApplicationTargetGroup(mergedProps.targetGroup);
 
+    this.addSecurityGroup(GuWazuhAccess.getInstance(scope, props.vpc));
     mergedProps.additionalSecurityGroups?.forEach((sg) => this.addSecurityGroup(sg));
 
     const cfnAsg = this.node.defaultChild as CfnAutoScalingGroup;

--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -155,6 +155,12 @@ Object {
               "GroupId",
             ],
           },
+          Object {
+            "Fn::GetAtt": Array [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
         ],
         "UserData": Object {
           "Fn::Base64": "#!/bin/dev foobarbaz",
@@ -671,6 +677,51 @@ Object {
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "WazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "testguec2appVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
   },
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Wazuh is required to be installed on an EC2 instance as part of our InfoSec program.

This security group allows the Wazuh agent to connect to the server.

See:
  - https://github.com/guardian/security-hq/blob/5e453f456b08763cabdfe5a0717346be8a24d556/hq/markdown/wazuh.md

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

It shouldn't do. Teams should have Wazuh running. This plus the fact that the Wazuh security group is a singleton should mean this change is a no-op for stacks.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

See updated tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More stuff comes for free 🎉 .

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a