### PR TITLE
refactor: Improve `GuHttpsApplicationListener` and use it in `GuEc2App` pattern

### DIFF
--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -9,6 +9,20 @@ import type { GuApplicationTargetGroup } from "./application-target-group";
 
 export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity, GuMigratingResource {}
 
+/**
+ * Construct which creates a Listener.
+ *
+ * This construct should be used in conjunction with [[`GuApplicationLoadBalancer`]] and [[`GuApplicationTargetGroup`]]
+ * to route traffic to your application. For more details on these three components, see the
+ * [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html#application-load-balancer-components).
+ *
+ * In order to inherit an existing Listener, the `migratedFromCloudFormation` prop on your stack must
+ * be set to `true`. You must also pass the logical id from your CloudFormation template to this construct via the
+ * `existingLogicalId` prop.
+ *
+ * If you are running an application which only accepts traffic over HTTPS, consider using [[`GuHttpsApplicationListener`]]
+ * to reduce the amount of boilerplate needed when configuring your Listener.
+ */
 export class GuApplicationListener extends GuStatefulMigratableConstruct(ApplicationListener) {
   constructor(scope: GuStack, id: string, props: GuApplicationListenerProps) {
     const { app } = props;
@@ -33,6 +47,13 @@ export interface GuHttpsApplicationListenerProps
   certificate: GuCertificate;
 }
 
+/**
+ * Construct which creates a Listener which accepts HTTPS traffic.
+ *
+ * You must pass a [[`GuCertificate`]] to this Listener via the `certificate` prop.
+ *
+ * For general details about Listeners, see [[`GuApplicationListener`]].
+ */
 export class GuHttpsApplicationListener extends ApplicationListener {
   constructor(scope: GuStack, id: string, props: GuHttpsApplicationListenerProps) {
     const { app, certificate, targetGroup } = props;

--- a/src/constructs/loadbalancing/alb/application-load-balancer.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.ts
@@ -7,6 +7,17 @@ import type { GuMigratingResource } from "../../core/migrating";
 
 interface GuApplicationLoadBalancerProps extends ApplicationLoadBalancerProps, AppIdentity, GuMigratingResource {}
 
+/**
+ * Construct which creates an Application Load Balancer.
+ *
+ * This construct should be used in conjunction with [[`GuApplicationListener`]] and [[`GuApplicationTargetGroup`]]
+ * to route traffic to your application. For more details on these three components, see the
+ * [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html#application-load-balancer-components).
+ *
+ * In order to inherit an existing Application Load Balancer, the `migratedFromCloudFormation` prop on your stack must
+ * be set to `true`. You must also pass the logical id from your CloudFormation template to this construct via the
+ * `existingLogicalId` prop.
+ */
 export class GuApplicationLoadBalancer extends GuStatefulMigratableConstruct(ApplicationLoadBalancer) {
   constructor(scope: GuStack, id: string, props: GuApplicationLoadBalancerProps) {
     const { app } = props;

--- a/src/constructs/loadbalancing/alb/application-target-group.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.ts
@@ -8,6 +8,31 @@ import type { GuMigratingResource } from "../../core/migrating";
 
 export interface GuApplicationTargetGroupProps extends ApplicationTargetGroupProps, AppIdentity, GuMigratingResource {}
 
+/**
+ * Construct which creates a Target Group.
+ *
+ * This construct should be used in conjunction with [[`GuApplicationLoadBalancer`]] and [[`GuApplicationListener`]]
+ * to route traffic to your application. For more details on these three components, see the
+ * [AWS documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html#application-load-balancer-components).
+ *
+ * In order to inherit an existing Target Group, the `migratedFromCloudFormation` prop on your stack must
+ * be set to `true`. You must also pass the logical id from your CloudFormation template to this construct via the
+ * `existingLogicalId` prop.
+ *
+ * By default, Target Groups created via this construct will perform a healthcheck against `/healthcheck` on your application's
+ * traffic port (as specified via the `port` prop). All healthcheck defaults can be overridden via the `healthcheck` prop.
+ *
+ * For example, to use `/test` for the healthcheck path use:
+ *
+ * ```typescript
+ * new GuApplicationTargetGroup(stack, "TargetGroup", {
+ *     // other props
+ *     healthCheck: {
+ *       path: "/test",
+ *     },
+ *   });
+ * ```
+ */
 export class GuApplicationTargetGroup extends GuStatefulMigratableConstruct(ApplicationTargetGroup) {
   static DefaultHealthCheck = {
     path: "/healthcheck",

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -1,5 +1,5 @@
 import { HealthCheck } from "@aws-cdk/aws-autoscaling";
-import { ApplicationProtocol, ListenerAction } from "@aws-cdk/aws-elasticloadbalancingv2";
+import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Duration } from "@aws-cdk/core";
 import type { GuCertificateProps } from "../constructs/acm";
 import { GuCertificate } from "../constructs/acm";
@@ -12,9 +12,9 @@ import { AppIdentity } from "../constructs/core/identity";
 import { GuVpc, SubnetType } from "../constructs/ec2";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../constructs/iam";
 import {
-  GuApplicationListener,
   GuApplicationLoadBalancer,
   GuApplicationTargetGroup,
+  GuHttpsApplicationListener,
 } from "../constructs/loadbalancing";
 
 interface GuEc2AppProps extends AppIdentity {
@@ -87,11 +87,11 @@ export class GuEc2App {
       port: props.applicationPort,
     });
 
-    new GuApplicationListener(scope, "Listener", {
+    new GuHttpsApplicationListener(scope, "Listener", {
       app,
       loadBalancer: loadBalancer,
-      defaultAction: ListenerAction.forward([targetGroup]),
-      certificates: [certificate],
+      certificate: certificate,
+      targetGroup: targetGroup,
     });
 
     if (!props.monitoringConfiguration.noMonitoring) {


### PR DESCRIPTION
## What does this change?

* Refactors `GuHttpsApplicationListener` so that it accepts a (mandatory) `GuCertificate`, instead of an optional ARN
* Uses the `GuHttpsApplicationListener` in our `GuEc2App` pattern
* Adds basic docs for all ALB-related constructs

## Does this change require changes to existing projects or CDK CLI?

Yes, this PR includes a [breaking change](https://github.com/guardian/cdk/commit/edb9b33672f312ec3b0aad96e41cf95321257148) to the `GuHttpsApplicationListener` construct. That said, [I don't think anyone is currently using this construct](https://github.com/search?q=org%3Aguardian+GuHttpsApplicationListener&type=code)!

## How to test

This should be covered by existing unit tests. Note that the CFN produced by the `GuEc2App` pattern does not change, the code is just simplified slightly.

## How can we measure success?

* Pattern code should be easier to understand
* Users of the library are able to understand ALB constructs more easily
* The change to the `GuHttpsApplicationListener` construct improves type safety. It should also lead to fewer parameters being created and more resources being created by `@guardian/cdk`

## Have we considered potential risks?

I can't think of any significant risks associated with this change.
