### PR TITLE
feat(ec2-app-pattern): add support for different access types

### DIFF
--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -63,6 +63,11 @@ Object {
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
+    "testguec2appPublicSubnets": Object {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
     "testguec2appVpcId": Object {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within",
@@ -338,7 +343,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "GuHttpsEgressSecurityGroupTestguec2appfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C9300051FB63C7": Object {
+    "GuHttpsEgressSecurityGroupTestguec2appfromTestSecurityGroupTestguec2app1CF2869E3000B9658665": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "FromPort": 3000,
@@ -351,7 +356,7 @@ Object {
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "SecurityGroupTestguec2appAC0CD258",
             "GroupId",
           ],
         },
@@ -482,17 +487,17 @@ Object {
             "Value": "true",
           },
         ],
-        "Scheme": "internal",
+        "Scheme": "internet-facing",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
-              "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+              "SecurityGroupTestguec2appAC0CD258",
               "GroupId",
             ],
           },
         ],
         "Subnets": Object {
-          "Ref": "testguec2appPrivateSubnets",
+          "Ref": "testguec2appPublicSubnets",
         },
         "Tags": Array [
           Object {
@@ -516,65 +521,6 @@ Object {
         ],
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    },
-    "LoadBalancerTestguec2appSecurityGroupCC6F85C1": Object {
-      "Properties": Object {
-        "GroupDescription": "Automatically created Security Group for ELB TestLoadBalancerTestguec2app8CD12AE9",
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 443",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "test-gu-ec2-app",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "testguec2appVpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "LoadBalancerTestguec2appSecurityGrouptoTestGuHttpsEgressSecurityGroupTestguec2appE5EE51F53000FE644240": Object {
-      "Properties": Object {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": Object {
-          "Fn::GetAtt": Array [
-            "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
-            "GroupId",
-          ],
-        },
-        "FromPort": 3000,
-        "GroupId": Object {
-          "Fn::GetAtt": Array [
-            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 3000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "ParameterStoreReadTestguec2app072DCDE1": Object {
       "Properties": Object {
@@ -651,6 +597,51 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "SecurityGroupTestguec2appAC0CD258": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all inbound traffic via HTTPS",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all inbound traffic via HTTPS",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "testguec2appVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
     "TargetGroupTestguec2app9F67D503": Object {
       "Properties": Object {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently, we have no way of passing in whitelisted CIDR ranges to our EC2 pattern. This is something we'd like to be able to do as [some stacks such as AMIable require it](https://github.com/guardian/deploy-tools-platform/blob/ee1cfd98af1de71f0d2bb6700831827c7375942b/cdk/lib/amiable/amiable.ts#L81). 

Furthermore, the current logic of the pattern only accounts for 2 of the 3 possible application/load balancer access options:

1. Load balancer is open to the world (currently covered by `publicFacing: true`)
2. Load balancer is open to the world but IP-locked (not currently covered)
3. Load balancer is internal (covered by `publicFacing: false`)

This PR changes the `GuEc2App` props by replacing `publicFacing` with `access`. This new `access` field can be used in one of the three following ways:

### Usage

```ts
new GuEc2App(stack, {
      applicationPort: GuApplicationPorts.Node,
      app: app,
      // ONLY allows access to CIDR ranges provided
      access: { scope:  AccessScope.RESTRICTED, cidrRanges: [Peer.ipv4("192.168.1.1/32"), Peer.ipv4("8.8.8.8/32")] }, 
      certificateProps: getCertificateProps(),
      monitoringConfiguration: { noMonitoring: true },
      userData: "",
    });

new GuEc2App(stack, {
      applicationPort: GuApplicationPorts.Node,
      app: app,
      // Open to the world
      access: { scope:  AccessScope.PUBLIC}, 
      certificateProps: getCertificateProps(),
      monitoringConfiguration: { noMonitoring: true },
      userData: "",
    });

new GuEc2App(stack, {
      applicationPort: GuApplicationPorts.Node,
      app: app,
     // Errors, as this wouldn't make sense due to to the open-to-the-world CIDR range making any others pointless 
      access: { scope: AccessScope.RESTRICTED, cidrRanges: [Peer.ipv4("192.168.1.1/32"), Peer.ipv4("0.0.0.0/0")] }, 
      certificateProps: getCertificateProps(),
      monitoringConfiguration: { noMonitoring: true },
      userData: "",
    });
```

With this change, we can be more specific about the load balancer access types without adding too much noise to the API.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Nope.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes. Some comments have been added to document this usage, might need more though!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

`./script/test`. New tests have been added to ensure correct behaviour.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

 - We can set correct access types for applications with ease.
 - We can restrict access on public load balancers 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

No, but there may be some that further tests could dig out? Not sure.
