### PR TITLE
docs: Add docs for CloudWatch constructs

### DIFF
--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -11,6 +11,15 @@ export interface GuAlarmProps extends AlarmProps {
   actionsEnabledInCode?: boolean;
 }
 
+/**
+ * Creates a CloudWatch alarm which sends notifications to the specified SNS topic.
+ *
+ * By default, alarm notifications will be silenced in the `CODE` environment. In order to override this behaviour
+ * (e.g. for testing purposes whilst configuring a new alarm), set the `actionsEnabledInCode` prop to `true`.
+ *
+ * This library provides an implementation of some commonly used alarms, which require less boilerplate than this construct,
+ * for example [[`Gu5xxPercentageAlarm`]]. Prefer using these more specific implementations where possible.
+ */
 export class GuAlarm extends Alarm {
   constructor(scope: GuStack, id: string, props: GuAlarmProps) {
     const actionsEnabled: GuStageDependentValue<boolean> = {

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -7,10 +7,6 @@ import type { GuApplicationLoadBalancer } from "../loadbalancing";
 import type { GuAlarmProps } from "./alarm";
 import { GuAlarm } from "./alarm";
 
-/**
- * Creates an alarm which is triggered whenever the percentage of requests with a 5xx response code exceeds
- * the specified threshold.
- */
 export interface Gu5xxPercentageMonitoringProps
   extends Omit<GuAlarmProps, "evaluationPeriods" | "metric" | "period" | "threshold" | "treatMissingData"> {
   tolerated5xxPercentage: number;
@@ -22,6 +18,10 @@ interface GuLoadBalancerAlarmProps extends Gu5xxPercentageMonitoringProps, AppId
   loadBalancer: GuApplicationLoadBalancer;
 }
 
+/**
+ * Creates an alarm which is triggered whenever the percentage of requests with a 5xx response code exceeds
+ * the specified threshold.
+ */
 export class Gu5xxPercentageAlarm extends GuAlarm {
   constructor(scope: GuStack, id: string, props: GuLoadBalancerAlarmProps) {
     const mathExpression = new MathExpression({

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -5,9 +5,6 @@ import type { GuLambdaFunction } from "../lambda";
 import type { GuAlarmProps } from "./alarm";
 import { GuAlarm } from "./alarm";
 
-/**
- * Creates an alarm which is triggered whenever the error percentage specified is exceeded.
- */
 export interface GuLambdaErrorPercentageMonitoringProps
   extends Omit<GuAlarmProps, "metric" | "threshold" | "comparisonOperator" | "evaluationPeriods" | "treatMissingData"> {
   toleratedErrorPercentage: number;
@@ -19,6 +16,9 @@ interface GuLambdaAlarmProps extends GuLambdaErrorPercentageMonitoringProps {
   lambda: GuLambdaFunction;
 }
 
+/**
+ * Creates an alarm which is triggered whenever the error percentage specified is exceeded.
+ */
 export class GuLambdaErrorPercentageAlarm extends GuAlarm {
   constructor(scope: GuStack, id: string, props: GuLambdaAlarmProps) {
     const mathExpression = new MathExpression({


### PR DESCRIPTION
## What does this change?

This PR adds some docs (and moves some docs to the correct place!) for our CloudWatch constructs.

## Does this change require changes to existing projects or CDK CLI?
No.

## Does this change require changes to the library documentation?
This _is_ a documentation change.

## How to test
Run `./script/docs` and have a look at the changes?

## How can we measure success?
It should be easier to use and understand these constructs.

## Have we considered potential risks?
N/A
