### PR TITLE
docs: Add basic docs for Kinesis streams and SNS topics

### DIFF
--- a/src/constructs/kinesis/kinesis-stream.ts
+++ b/src/constructs/kinesis/kinesis-stream.ts
@@ -6,6 +6,23 @@ import type { GuMigratingResource } from "../core/migrating";
 
 export interface GuKinesisStreamProps extends StreamProps, GuMigratingResource {}
 
+/**
+ * Construct which creates a Kinesis stream.
+ *
+ * To inherit a Kinesis stream which has already been created via a CloudFormation stack, the `migratedFromCloudFormation`
+ * prop on your stack must be set to `true`. You should also pass in the logical id via the `existingLogicalId` prop.
+ *
+ * For example, when migrating a CloudFormation stack which includes the following resource:
+ * ```yaml
+ * MyCloudFormedKinesisStream:
+ *   Type: AWS::Kinesis::Stream
+ * ```
+ *
+ * Inherit the Kinesis stream (rather than creating a new one) using:
+ * ```typescript
+ * new GuKinesisStream(stack, "LoggingStream", { existingLogicalId: "MyCloudFormedKinesisStream" });
+ * ```
+ */
 export class GuKinesisStream extends GuStatefulMigratableConstruct(Stream) {
   constructor(scope: GuStack, id: string, props?: GuKinesisStreamProps) {
     super(scope, id, props);

--- a/src/constructs/sns/sns-topic.ts
+++ b/src/constructs/sns/sns-topic.ts
@@ -6,6 +6,22 @@ import type { GuMigratingResource } from "../core/migrating";
 
 interface GuSnsTopicProps extends TopicProps, GuMigratingResource {}
 
+/**
+ * Construct which creates an SNS Topic.
+ *
+ * To inherit an SNS topic which has already been created via a CloudFormation stack, the `migratedFromCloudFormation`
+ * prop on your stack must be set to `true`. You should also pass in the logical id via the `existingLogicalId` prop.
+ *
+ * For example, when migrating a CloudFormation stack which includes the following resource:
+ * ```yaml
+ * MyCloudFormedSnsTopic:
+ *   Type: AWS::SNS::Topic
+ * ```
+ * Inherit the SNS topic (rather than creating a new one) using:
+ * ```typescript
+ *  new GuSnsTopic(stack, "SnsTopic", { existingLogicalId: "MyCloudFormedSnsTopic" });
+ * ```
+ */
 export class GuSnsTopic extends GuStatefulMigratableConstruct(Topic) {
   constructor(scope: GuStack, id: string, props?: GuSnsTopicProps) {
     super(scope, id, props);


### PR DESCRIPTION
## What does this change?

This PR adds some docs for our Kinesis stream and SNS topic constructs.

## Does this change require changes to existing projects or CDK CLI?
No.

## Does this change require changes to the library documentation?
N/A.

## How to test
I've tested these changes by running `./script/docs`.

## How can we measure success?
It's easier to understand these constructs, especially if you are migrating a stream/topic which has already been CloudFormed.

## Have we considered potential risks?
N/A