### PR TITLE
fix: Support singletons across multiple stacks

### DIFF
--- a/integration-test/bin/cdk.ts
+++ b/integration-test/bin/cdk.ts
@@ -3,4 +3,5 @@ import { App } from "@aws-cdk/core";
 import { IntegrationTestStack } from "../src/integration-test-stack";
 
 const app = new App();
-new IntegrationTestStack(app, "Cdk", { stack: "integration-test" });
+new IntegrationTestStack(app, "IntegrationTestStackCODE", { stack: "integration-test-CODE" });
+new IntegrationTestStack(app, "IntegrationTestStackPROD", { stack: "integration-test-PROD" });

--- a/integration-test/src/__snapshots__/integration-test-stack.test.ts.snap
+++ b/integration-test/src/__snapshots__/integration-test-stack.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`The Cdk stack matches the snapshot 1`] = `
 Object {
   "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "Stage": Object {
       "AllowedValues": Array [
         "CODE",

--- a/integration-test/src/integration-test-stack.ts
+++ b/integration-test/src/integration-test-stack.ts
@@ -1,9 +1,10 @@
 import type { App } from "@aws-cdk/core";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { GuDistributionBucketParameter, GuStack } from "@guardian/cdk/lib/constructs/core";
 
 export class IntegrationTestStack extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
+    GuDistributionBucketParameter.getInstance(this);
   }
 }

--- a/src/constructs/core/parameters/log-shipping.ts
+++ b/src/constructs/core/parameters/log-shipping.ts
@@ -1,3 +1,4 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 
@@ -13,11 +14,7 @@ export class GuLoggingStreamNameParameter extends GuStringParameter {
   }
 
   public static getInstance(stack: GuStack): GuLoggingStreamNameParameter {
-    // Resources can only live in the same App so return a new `GuSSMRunCommandPolicy` where necessary.
-    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
-    const isSameStack = this.instance?.node.root === stack.node.root;
-
-    if (!this.instance || !isSameStack) {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
       this.instance = new GuLoggingStreamNameParameter(stack);
     }
 

--- a/src/constructs/core/parameters/s3.test.ts
+++ b/src/constructs/core/parameters/s3.test.ts
@@ -1,0 +1,22 @@
+import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
+import { App } from "@aws-cdk/core";
+import { GuStack } from "../stack";
+import { GuDistributionBucketParameter } from "./s3";
+
+describe("GuDistributionBucketParameter", () => {
+  it("can exist in multiple GuStacks within the same App", () => {
+    const app = new App();
+
+    const stack1 = new GuStack(app, "MyAppCODE", { stack: "MyAppCODE" });
+    const stack1Param = GuDistributionBucketParameter.getInstance(stack1);
+
+    const stack2 = new GuStack(app, "MyAppPROD", { stack: "MyAppPROD" });
+    const stack2Param = GuDistributionBucketParameter.getInstance(stack2);
+
+    expect(stack1Param).not.toEqual(stack2Param);
+
+    // make doubly sure the two stacks can be synthesised
+    SynthUtils.toCloudFormation(stack1);
+    SynthUtils.toCloudFormation(stack2);
+  });
+});

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -1,3 +1,4 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 
@@ -17,11 +18,7 @@ export class GuDistributionBucketParameter extends GuStringParameter {
   }
 
   public static getInstance(stack: GuStack): GuDistributionBucketParameter {
-    // Resources can only live in the same App so return a new instance where necessary.
-    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
-    const isSameStack = this.instance?.node.root === stack.node.root;
-
-    if (!this.instance || !isSameStack) {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
       this.instance = new GuDistributionBucketParameter(stack);
     }
 

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -1,5 +1,6 @@
 import type { IVpc } from "@aws-cdk/aws-ec2";
 import { Peer } from "@aws-cdk/aws-ec2";
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../../core";
 import { GuMigratingResource } from "../../core/migrating";
 import { GuBaseSecurityGroup } from "./base";
@@ -104,11 +105,7 @@ export class GuWazuhAccess extends GuBaseSecurityGroup {
    * @param vpc the vpc to add this security group to
    */
   public static getInstance(stack: GuStack, vpc: IVpc): GuWazuhAccess {
-    // Resources can only live in the same App so return a new instance where necessary.
-    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
-    const isSameStack = this.instance?.node.root === stack.node.root;
-
-    if (!this.instance || !isSameStack) {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
       this.instance = new GuWazuhAccess(stack, vpc);
     }
 

--- a/src/constructs/iam/policies/describe-ec2.ts
+++ b/src/constructs/iam/policies/describe-ec2.ts
@@ -1,4 +1,5 @@
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../../core";
 import { GuPolicy } from "./base-policy";
 
@@ -24,11 +25,7 @@ export class GuDescribeEC2Policy extends GuPolicy {
   }
 
   public static getInstance(stack: GuStack): GuDescribeEC2Policy {
-    // Resources can only live in the same App so return a new instance where necessary.
-    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
-    const isSameStack = this.instance?.node.root === stack.node.root;
-
-    if (!this.instance || !isSameStack) {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
       this.instance = new GuDescribeEC2Policy(stack);
     }
 

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -1,3 +1,4 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../../core";
 import { GuLoggingStreamNameParameter } from "../../core/parameters/log-shipping";
 import { GuAllowPolicy } from "./base-policy";
@@ -17,11 +18,7 @@ export class GuLogShippingPolicy extends GuAllowPolicy {
   }
 
   public static getInstance(stack: GuStack): GuLogShippingPolicy {
-    // Resources can only live in the same App so return a new instance where necessary.
-    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
-    const isSameStack = this.instance?.node.root === stack.node.root;
-
-    if (!this.instance || !isSameStack) {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
       this.instance = new GuLogShippingPolicy(stack);
     }
 

--- a/src/constructs/iam/policies/ssm.ts
+++ b/src/constructs/iam/policies/ssm.ts
@@ -1,3 +1,4 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../../core";
 import { GuAllowPolicy } from "./base-policy";
 
@@ -28,11 +29,7 @@ export class GuSSMRunCommandPolicy extends GuAllowPolicy {
   }
 
   public static getInstance(stack: GuStack): GuSSMRunCommandPolicy {
-    // Resources can only live in the same App so return a new `GuSSMRunCommandPolicy` where necessary.
-    // See https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
-    const isSameStack = this.instance?.node.root === stack.node.root;
-
-    if (!this.instance || !isSameStack) {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
       this.instance = new GuSSMRunCommandPolicy(stack);
     }
 

--- a/src/utils/test/index.ts
+++ b/src/utils/test/index.ts
@@ -2,3 +2,4 @@ export * from "./simple-gu-stack";
 export * from "./synthed-stack";
 export * from "./attach-policy-to-test-role";
 export * from "./alphabetical-tags";
+export * from "./singleton";

--- a/src/utils/test/singleton.ts
+++ b/src/utils/test/singleton.ts
@@ -1,0 +1,41 @@
+import type { Stack } from "@aws-cdk/core/lib/stack";
+import type { GuStack } from "../../constructs/core";
+
+/**
+ * Check if an element exists in a [[`GuStack`]].
+ *
+ * Note: this explicitly tests presence in the Stack, not the App.
+ * This makes it is possible to create multiple Stacks in the same App;
+ * the singleton will new unique across the Stacks.
+ *
+ * ```typescript
+ * import { App } from "@aws-cdk/core";
+ *
+ * class SomeSingletonConstruct { }
+ *
+ * class MyStack extends GuStack {
+ *   constructor() {
+ *     // add SomeSingletonConstruct to stack
+ *   }
+ * }
+ *
+ * class MyOtherStack extends GuStack {
+ *   constructor() {
+ *     // add SomeSingletonConstruct to stack
+ *   }
+ * }
+ *
+ * const app = new App();
+ * const myStack = new MyStack(app, "MyStack", { stack: "deploy" });
+ * const myOtherStack = new MyOtherStack(app, "MyOtherStack", { stack: "deploy" });
+ * ```
+ *
+ * @param stack an instance of [[``GuStack``]]
+ * @param maybeSingletonInstance the singleton instance
+ *
+ * @see https://github.com/aws/aws-cdk/blob/0ea4b19afd639541e5f1d7c1783032ee480c307e/packages/%40aws-cdk/core/lib/private/refs.ts#L47-L50
+ */
+export const isSingletonPresentInStack = (stack: GuStack, maybeSingletonInstance?: { stack: Stack }): boolean => {
+  // destructured `maybeSingletonInstance` to support `CfnElement`s (aka parameters) and `Resource`s, which do not share a type
+  return maybeSingletonInstance ? maybeSingletonInstance.stack.node === stack.node : false;
+};


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A singleton is something that will be instantiated once and once only.

Or rather, a singleton construct is one which will be instantiated once and once only in a `Stack`.

This change fixes a bug where a singleton could not be used within two `Stack`s that get instantiated using the same `App` instance.

Something like this was not possible as there would be a cyclic reference:

```typescript
class MyStack extends GuStack {
  constructor() {
    GuDistributionBucketParameter.getInstance(this);
  }
}

class MyOtherStack extends GuStack {
  constructor() {
    GuDistributionBucketParameter.getInstance(this);
  }
}

const app = new App();

const myStack = new MyStack(app, "MyStack", { stack: "deploy" });
const myOtherStack = new MyOtherStack(app, "MyOtherStack", { stack: "deploy" });

myStack.synth();
myOtherStack.synth();
```

We'd get an error like this:

> Error: 'MyStack' depends on 'MyOtherStack'. Adding this dependency (MyOtherStack -> MyStack/DistributionBucketName.Ref) would create a cyclic reference.

This change checks if a singleton exists on the `Stack`, rather than the `App` to fix this issue.

A test is added to the `GuDistributionBucketParameter` construct to demonstrate this.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes, only a version bump.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is possible to share an `App` instance between `Stack`s. For example:

```typescript
const app = new App();

const prismStack = new PrismStack(app, "PrismPROD", { stack: "deploy" });
const amiableStack = new AmiableStack(app, "AmiablePROD", { stack: "deploy" });
```

Or more ambitiously (as more changes are needed to support this):

```typescript
const app = new App();

const prismCODE = new PrismStack(app, "PrismCODE", { stack: "deploy", stackName: "Prism-CODE" });
const prismPROD = new PrismStack(app, "PrismPROD", { stack: "deploy", stackName: "Prism-PROD" });
```

The change to the integration tests demonstrate this idea.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a