### PR TITLE
feat: Allow users to remove Scheme property to avoid LB replacement

### DIFF
--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -222,4 +222,16 @@ describe("The GuHttpsClassicLoadBalancer class", () => {
       ],
     });
   });
+
+  test("Removes Scheme if user asks us to", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
+      ...app,
+      vpc,
+      removeScheme: true,
+      existingLogicalId: "ClassicLoadBalancer",
+    });
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(Object.keys(json.Resources.ClassicLoadBalancer.Properties)).not.toContain("Scheme");
+  });
 });

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -15,6 +15,12 @@ import type { GuMigratingResource } from "../core/migrating";
 interface GuClassicLoadBalancerProps extends Omit<LoadBalancerProps, "healthCheck">, GuMigratingResource, AppIdentity {
   propertiesToOverride?: Record<string, unknown>;
   healthCheck?: Partial<HealthCheck>;
+  /**
+   * If your CloudFormation does not define the Scheme of your Load Balancer, you must set this boolean to true to avoid
+   * resource [replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-scheme).
+   * If a Load Balancer is replaced it is likely to lead to downtime.
+   */
+  removeScheme?: boolean;
 }
 
 /**
@@ -61,6 +67,10 @@ export class GuClassicLoadBalancer extends GuStatefulMigratableConstruct(LoadBal
     AppIdentity.taggedConstruct({ app: props.app }, this);
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
+
+    if (props.removeScheme) {
+      cfnLb.addPropertyDeletionOverride("Scheme");
+    }
 
     mergedProps.propertiesToOverride &&
       Object.entries(mergedProps.propertiesToOverride).forEach(([key, value]) => cfnLb.addPropertyOverride(key, value));


### PR DESCRIPTION
## What does this change?

Reinstates some functionality that was removed in https://github.com/guardian/cdk/pull/362, as we've [realised that adding a `Scheme` property where it was previously undefined will lead to a resource replacement](https://docs.google.com/document/d/1MAwidPjyc2Ozl-J2VCnhhHGaVURGuzPAxow6BCLwDkg/edit). 

## Does this change require changes to existing projects or CDK CLI?

Projects using old versions of the library which specify `Scheme` via `propertiesToRemove` should set `removeScheme` to `true` when upgrading to the latest version.

## Does this change require changes to the library documentation?

Yes, we've updated the docs.

## How to test

We've added a unit test for this.

## How can we measure success?

It should be harder to accidentally replace your load balancer.

## Have we considered potential risks?

There's a risk that people still won't realise the significance of adding the scheme property to their LBs, but we have other actions which intend to address this.
