### PR TITLE
chore: Configure Dependabot to run on Wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,12 +12,16 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      # somewhat arbitrary, this is to spread Dependabot PRs throughout the week to avoid Monday overload
+      day: "wednesday"      
     commit-message:
       prefix: "chore(deps): "
   - package-ecosystem: 'npm'
     directory: '/integration-test'
     schedule:
       interval: 'weekly'
+      # somewhat arbitrary, this is to spread Dependabot PRs throughout the week to avoid Monday overload
+      day: "wednesday"      
     commit-message:
       prefix: "chore(deps): "
     # The version of @aws-cdk/* libraries must match those from @guardian/cdk.


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This is a somewhat arbitrary day, the aim is to spread Dependabot PRs throughout the week to avoid being overloaded by PRs across our repositories at the start of the week.

Note: the Dependabot configuration for GHA are unchanged as PRs to bump these are fairly infrequent already.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Dependabot PRs will be raised on Wednesday morning, rather than Monday morning.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a