### PR TITLE
feat: Log when any stateful resource is in stack

### DIFF
--- a/src/constants/stateful-resource-types.ts
+++ b/src/constants/stateful-resource-types.ts
@@ -1,0 +1,23 @@
+/**
+ * A list of resource types that should be considered stateful
+ * and care should be taken when updating them to ensure they
+ * are not accidentally replaced as this could lead to downtime.
+ *
+ * For example, if a load balancer is accidentally replaced,
+ * any CNAME DNS entry for it would now be invalid and downtime
+ * will be incurred for the TTL of the DNS entry.
+ *
+ * Currently, this list is used to generate warnings at synth time.
+ * Ideally we'd add a stack policy to stop the resource being deleted,
+ * however this isn't currently supported in CDK.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
+ * @see https://github.com/aws/aws-cdk-rfcs/issues/72
+ */
+export const StatefulResourceTypes: string[] = [
+  "AWS::CertificateManager::Certificate",
+  "AWS::DynamoDB::Table",
+  "AWS::ElasticLoadBalancing::LoadBalancer",
+  "AWS::ElasticLoadBalancingV2::LoadBalancer",
+  "AWS::S3::Bucket",
+];

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -2,15 +2,23 @@ import "@aws-cdk/assert/jest";
 
 import { SynthUtils } from "@aws-cdk/assert";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
+import { Bucket } from "@aws-cdk/aws-s3";
 import { App } from "@aws-cdk/core";
 import { Stage, Stages } from "../../constants";
 import { TrackingTag } from "../../constants/tracking-tag";
+import { Logger } from "../../utils/logger";
 import { alphabeticalTags, simpleGuStackForTesting } from "../../utils/test";
 import type { SynthedStack } from "../../utils/test";
 import { GuParameter } from "./parameters";
 import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
+  const warn = jest.spyOn(Logger, "warn");
+
+  afterEach(() => {
+    warn.mockReset();
+  });
+
   it("requires passing the stack value as props", function () {
     const stack = simpleGuStackForTesting({ stack: "some-stack" });
     expect(stack.stack).toEqual("some-stack");
@@ -69,6 +77,21 @@ describe("The GuStack construct", () => {
 
     expect(() => stack.getParam<GuParameter>("i-do-not-exist")).toThrowError(
       "Attempting to read parameter i-do-not-exist which does not exist"
+    );
+  });
+
+  it("During the synthesise process, should advise updating with caution when it contains a stateful resource", () => {
+    const stack = simpleGuStackForTesting();
+    const bucket = new Bucket(stack, "MyBucket");
+    SynthUtils.toCloudFormation(stack);
+
+    // `defaultChild can technically be `undefined`.
+    // We know a `Bucket` has a `defaultChild` so the coalescing is just appeasing the compiler.
+    const cfnBucketResourcePath = bucket.node.defaultChild?.node.path ?? "";
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      `The resource '${cfnBucketResourcePath}' of type AWS::S3::Bucket is considered stateful by @guardian/cdk. Care should be taken when updating this resource to avoid accidental replacement as this could lead to downtime.`
     );
   });
 });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A resource is a raw [CloudFormation item](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html). A construct is CDK's L1 or L2 abstraction of a resource.

A stateful resource can be defined as something that holds state. This could be a database, a bucket, load balancer, message queue etc.

This change will, upon stack synthesis, walk the tree of resources and log a warning for all the stateful resources we have identified.

```console
The resource '<PATH IN TREE>' of type <TYPE> is considered stateful by @guardian/cdk. Care should be taken when updating this resource to avoid accidental replacement as this could lead to downtime.
```

This does mean we end up keeping a list of these resources, which is not ideal...

The [`GuStatefulMigratableConstruct` mixin](https://github.com/guardian/cdk/blob/74124e3bb0243b0e923d68f6ad24c363bd250b83/src/utils/mixin/migratable-construct-stateful.ts#L51) performs a similar role here, however that only operates against the constructs that exist in the library.

Ideally we'd be able to use [Stack Policies](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html) to protect these resources. However they are [not currently supported in CDK](https://github.com/aws/aws-cdk-rfcs/issues/72).

See:
  - https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.Construct.html#protected-prepare
  - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
  - https://github.com/aws/aws-cdk-rfcs/issues/72

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes and added.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added test.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We warn about updating _any_ stateful resource, even ones not covered by `GuStatefulMigratableConstruct`.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The risk is the `StatefulResourceTypes` is incomplete or becomes stale.