### PR TITLE
refactor: control incoming traffic via the listener and tighten egress rules

### DIFF
--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -343,7 +343,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "GuHttpsEgressSecurityGroupTestguec2appfromTestSecurityGroupTestguec2app1CF2869E3000B9658665": Object {
+    "GuHttpsEgressSecurityGroupTestguec2appfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C9300051FB63C7": Object {
       "Properties": Object {
         "Description": "Load balancer to target",
         "FromPort": 3000,
@@ -356,7 +356,7 @@ Object {
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": Object {
           "Fn::GetAtt": Array [
-            "SecurityGroupTestguec2appAC0CD258",
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
             "GroupId",
           ],
         },
@@ -491,7 +491,7 @@ Object {
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
-              "SecurityGroupTestguec2appAC0CD258",
+              "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
               "GroupId",
             ],
           },
@@ -521,6 +521,65 @@ Object {
         ],
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerTestguec2appSecurityGroupCC6F85C1": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB TestLoadBalancerTestguec2app8CD12AE9",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "testguec2appVpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerTestguec2appSecurityGrouptoTestGuHttpsEgressSecurityGroupTestguec2appE5EE51F53000FE644240": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "ParameterStoreReadTestguec2app072DCDE1": Object {
       "Properties": Object {
@@ -597,51 +656,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "SecurityGroupTestguec2appAC0CD258": Object {
-      "Properties": Object {
-        "GroupDescription": "Allow all inbound traffic via HTTPS",
-        "SecurityGroupEgress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "SecurityGroupIngress": Array [
-          Object {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all inbound traffic via HTTPS",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "test-gu-ec2-app",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-        "VpcId": Object {
-          "Ref": "testguec2appVpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "TargetGroupTestguec2app9F67D503": Object {
       "Properties": Object {

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -159,7 +159,7 @@ describe("the GuEC2App pattern", function () {
       SecurityGroupIngress: [
         {
           CidrIp: "0.0.0.0/0",
-          Description: "Allow all inbound traffic via HTTPS",
+          Description: "Allow from anyone on port 443",
           FromPort: 443,
           IpProtocol: "tcp",
           ToPort: 443,
@@ -221,18 +221,6 @@ describe("the GuEC2App pattern", function () {
       },
       monitoringConfiguration: { noMonitoring: true },
       userData: "UserData from pattern declaration",
-    });
-
-    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      SecurityGroupIngress: [
-        {
-          CidrIp: "0.0.0.0/0",
-          Description: "Allow all inbound traffic via HTTPS",
-          FromPort: 443,
-          IpProtocol: "tcp",
-          ToPort: 443,
-        },
-      ],
     });
 
     const cfnLb = pattern.loadBalancer.node.defaultChild as CfnLoadBalancer;

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -168,31 +168,6 @@ describe("the GuEC2App pattern", function () {
     });
   });
 
-  it("assume public application if no access specified", function () {
-    const stack = simpleGuStackForTesting();
-    const app = "test-gu-ec2-app";
-    new GuEc2App(stack, {
-      applicationPort: GuApplicationPorts.Node,
-      app,
-      access: { scope: AccessScope.PUBLIC },
-      certificateProps: getCertificateProps(),
-      monitoringConfiguration: { noMonitoring: true },
-      userData: "",
-    });
-
-    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      SecurityGroupIngress: [
-        {
-          CidrIp: "0.0.0.0/0",
-          Description: "Allow all inbound traffic via HTTPS",
-          FromPort: 443,
-          IpProtocol: "tcp",
-          ToPort: 443,
-        },
-      ],
-    });
-  });
-
   it("errors if specifying open access as well as specific CIDR ranges", function () {
     const stack = simpleGuStackForTesting();
     const app = "test-gu-ec2-app";


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/cdk/pull/500, we made some changes to the security group configuration of the EC2 App pattern. As part of this we have inadvertently added a [very permissive egress rule](https://github.com/guardian/cdk/blob/859ef3e6c3a0be0bab45ed4ee47ff1c684bcb278/src/patterns/__snapshots__/ec2-app.test.ts.snap#L604-L610) to our load balancer. We have also overridden some of the AWS CDK's default security group behaviour, which I now believe to be unnecessary.

Here's a [diff](https://github.com/guardian/cdk-playground/compare/jw-14.4.0-upgrade?expand=1) which shows the security group changes which occur when upgrading to `14.4.0` (from `14.2.0`).

Here's a much [smaller diff](https://github.com/guardian/cdk-playground/compare/jw-cdk-upgrade?expand=1) which shows the changes which occur when upgrading to use this branch (from `14.2.0`).

## Does this change require changes to existing projects or CDK CLI?
This shouldn't require changes to existing projects, as the pattern is still under development and (to my knowledge) no test projects have upgraded to the latest version yet.

## Does this change require changes to the library documentation?
No.

## How to test
I am hoping to spin up a new stack from scratch, which will allow us to test this change properly.

## How can we measure success?
* Our security groups are less permissive
* AWS CDK takes care of more work for us
* Hopefully the pattern code is a little bit easier to reason about

## Have we considered potential risks?
Since this is predominantly a revert of some changes we recently introduced via https://github.com/guardian/cdk/pull/500, I think the risk is quite low.
