### PR TITLE
fix: Use AWS CDK Annotations to log messages

### DIFF
--- a/src/constructs/core/migrating.test.ts
+++ b/src/constructs/core/migrating.test.ts
@@ -2,7 +2,7 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import type { BucketProps } from "@aws-cdk/aws-s3";
 import { Bucket } from "@aws-cdk/aws-s3";
-import { Logger } from "../../utils/logger";
+import { Annotations } from "@aws-cdk/core";
 import type { GuStatefulConstruct } from "../../utils/mixin";
 import type { SynthedStack } from "../../utils/test";
 import { simpleGuStackForTesting } from "../../utils/test";
@@ -24,8 +24,8 @@ We're calling it here to test the function in isolation.
  */
 
 describe("GuMigratingResource", () => {
-  const info = jest.spyOn(Logger, "info");
-  const warn = jest.spyOn(Logger, "warn");
+  const info = jest.spyOn(Annotations.prototype, "addInfo");
+  const warn = jest.spyOn(Annotations.prototype, "addWarning");
 
   afterEach(() => {
     warn.mockReset();

--- a/src/constructs/core/migrating.ts
+++ b/src/constructs/core/migrating.ts
@@ -1,5 +1,5 @@
 import type { CfnElement, IConstruct } from "@aws-cdk/core";
-import { Logger } from "../../utils/logger";
+import { Annotations } from "@aws-cdk/core";
 import { isGuStatefulConstruct } from "../../utils/mixin";
 
 export interface GuMigratingStack {
@@ -55,19 +55,19 @@ export const GuMigratingResource = {
       }
 
       if (isStateful) {
-        Logger.warn(
+        Annotations.of(construct).addWarning(
           `GuStack has 'migratedFromCloudFormation' set to true. ${id} is a stateful construct and 'existingLogicalId' has not been set. ${id}'s logicalId will be auto-generated and consequently AWS will create a new resource rather than inheriting an existing one. This is not advised as downstream services, such as DNS, will likely need updating.`
         );
       }
     } else {
       if (existingLogicalId) {
-        Logger.warn(
+        Annotations.of(construct).addWarning(
           `GuStack has 'migratedFromCloudFormation' set to false. ${id} has an 'existingLogicalId' set to ${existingLogicalId}. This will have no effect - the logicalId will be auto-generated. Set 'migratedFromCloudFormation' to true for 'existingLogicalId' to be observed.`
         );
       }
 
       if (isStateful) {
-        Logger.info(
+        Annotations.of(construct).addInfo(
           `GuStack has 'migratedFromCloudFormation' set to false. ${id} is a stateful construct, it's logicalId will be auto-generated and AWS will create a new resource.`
         );
       }

--- a/src/utils/mixin/migratable-construct-stateful.test.ts
+++ b/src/utils/mixin/migratable-construct-stateful.test.ts
@@ -1,9 +1,9 @@
 import type { BucketProps } from "@aws-cdk/aws-s3";
 import "../test/jest";
 import { Bucket } from "@aws-cdk/aws-s3";
+import { Annotations } from "@aws-cdk/core";
 import type { GuStack } from "../../constructs/core";
 import type { GuMigratingResource } from "../../constructs/core/migrating";
-import { Logger } from "../logger";
 import { simpleGuStackForTesting } from "../test";
 import { GuStatefulMigratableConstruct } from "./migratable-construct-stateful";
 
@@ -16,7 +16,7 @@ class StatefulTestGuMigratableConstruct extends GuStatefulMigratableConstruct(Bu
 }
 
 describe("The GuStatefulMigratableConstruct mixin", () => {
-  const info = jest.spyOn(Logger, "info");
+  const info = jest.spyOn(Annotations.prototype, "addInfo");
 
   beforeEach(() => {
     info.mockReset();


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Use AWS CDK Annotations to log messages instead of our custom Logger.

Annotations have coloured output (info = white, warning = yellow, error = red).

They also work with the `--trace`, `--strict` and `--ignore-errors` flags of the CDK CLI.

Note, we don't need to employ the trick in #434 as Annotations (somehow) do not get piped to disk if one redirects output to disk.

Before:

```console
➜ npx cdk synth --strict --path-metadata false --version-reporting false
# GuStack has 'migratedFromCloudFormation' set to false. MySnsTopic is a stateful construct, it's logicalId will be auto-generated and AWS will create a new resource.
Parameters:
  Stage:
    Type: String
    Default: CODE
    AllowedValues:
      - CODE
      - PROD
    Description: Stage name
```

After:

```console
➜ npx cdk synth --strict --path-metadata false --version-reporting false
[Info at /CdkPlayground/MySnsTopic] GuStack has 'migratedFromCloudFormation' set to false. MySnsTopic is a stateful construct, it's logicalId will be auto-generated and AWS will create a new resource.
Parameters:
  Stage:
    Type: String
    Default: CODE
    AllowedValues:
      - CODE
      - PROD
    Description: Stage name
```

See:
  - https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.Annotations.html


## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should continue to pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Less code!

Using CDK native concepts also means we get the benefit of the CLI flags.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a