### PR TITLE
feat(ec2-app): allow users to configure access logging

### DIFF
--- a/docs/005-default-parameter-store-locations.md
+++ b/docs/005-default-parameter-store-locations.md
@@ -1,6 +1,7 @@
 # Default Parameter Store Locations
 
-A number of constructs from the library define parameters to get configuration from Parameter Store. Each of these parameters configures a default path. The below table lists those paths, the parameter that sets them, the expected value type and which construct the parameter is defined within.
+A number of constructs from the library define parameters to get configuration from Parameter Store. Each of these parameters configures a default path.
+The below table lists those paths, the parameter that sets them, the expected value type and which construct the parameter is defined within.
 
 | Path                                  | Parameter              | Type                         | Construct                  |
 | ------------------------------------- | ---------------------- | ---------------------------- | -------------------------- |
@@ -9,3 +10,13 @@ A number of constructs from the library define parameters to get configuration f
 | /account/vpc/primary/subnets/private  | PrivateSubnets         | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
 | /account/services/artifact.bucket     | DistributionBucketName | String                       | GuGetDistributablePolicy   |
 | /account/services/logging.stream.name | LoggingStreamName      | String                       | GuLogShippingPolicy        |
+
+
+## Pattern-specific default Parameter Store locations
+
+Patterns embrace Guardian best practices and sensible defaults by design, and use [GuSSMParameter](../src/constructs/core/ssm.ts) to fetch values from Parameter Store.
+The below table lists those paths, the expected contents, the property/properties and pattern(s) that use them.
+
+| Path                                    | Expected Contents                      | Relevant Properties                           | Patterns                               |
+| ----------------------------------------| -------------------------------------- | --------------------------------------------- | -------------------------------------- |
+| /account/services/access-logging/bucket | The S3 bucket used to hold access logs | [`accessLogging`](../src/patterns/ec2-app.ts) | [GuEC2App](../src/patterns/ec2-app.ts) |

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -428,6 +428,46 @@ describe("the GuEC2App pattern", function () {
     });
   });
 
+  it("can be configured with access logging", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "test-gu-ec2-app";
+    new GuEc2App(stack, {
+      applicationPort: GuApplicationPorts.Node,
+      access: { scope: AccessScope.PUBLIC },
+      app,
+      certificateProps: getCertificateProps(),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "",
+      accessLogging: {
+        bucketSSMPath: "/path/to/access-logging-bucket",
+        prefix: "access-logging-prefix",
+      },
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    const lbKey = Object.keys(json.Resources).find(
+      (resource) => json.Resources[resource].Type === "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    );
+    expect(lbKey).toBeTruthy();
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- We assert above that this is truthy
+    const loadBalancer = json.Resources[lbKey!];
+
+    expect(loadBalancer.Properties.LoadBalancerAttributes).toEqual(
+      expect.arrayContaining([
+        { Key: "deletion_protection.enabled", Value: "true" },
+        { Key: "access_logs.s3.enabled", Value: "true" },
+        {
+          Key: "access_logs.s3.bucket",
+          Value: {
+            "Fn::GetAtt": [expect.stringContaining("GuSSMParameter"), "Parameter.Value"],
+          },
+        },
+        { Key: "access_logs.s3.prefix", Value: "access-logging-prefix" },
+      ])
+    );
+  });
+
   describe("GuNodeApp", () => {
     it("should set the port to the default of 3000 if not specified", function () {
       const stack = simpleGuStackForTesting();

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -1,10 +1,13 @@
 import { HealthCheck } from "@aws-cdk/aws-autoscaling";
 import { Port } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
+import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration } from "@aws-cdk/core";
 import { GuCertificate } from "../constructs/acm";
 import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
 import { Gu5xxPercentageAlarm } from "../constructs/cloudwatch";
+import type { GuStack } from "../constructs/core";
+import { GuSSMParameter } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
 import { GuSecurityGroup, GuVpc, SubnetType } from "../constructs/ec2";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../constructs/iam";
@@ -62,6 +65,12 @@ export interface RestrictedAccess extends Access {
 
 export type AppAccess = PublicAccess | RestrictedAccess;
 
+export interface AccessLoggingProps {
+  // This provides a hint & incentive to users to use a recommended path
+  bucketSSMPath: string | "/account/services/access-logging/bucket";
+  prefix?: string;
+}
+
 /**
  * Configuration options for the [[`GuEc2App`]] pattern.
  *
@@ -99,6 +108,21 @@ export type AppAccess = PublicAccess | RestrictedAccess;
  *   PROD: { minimumInstances: 5, maximumInstances: 12 }
  * }
  * ```
+ *
+ * To enable access logging for your load balancer, you can specify the bucket and prefix to write the logs to.
+ * You must specify a region in your stack declaration if you are to use this prop, as specified here:
+ * https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-elasticloadbalancingv2.ApplicationLoadBalancer.html#logwbraccesswbrlogsbucket-prefix
+ * For example:
+ * ```typescript
+ * {
+ *   // other props
+ *   accessLogging: {
+ *     // Recommended path: `/account/services/access-logging/bucket`
+ *     bucket: "/SSM/PATH/TO/ACCESS_LOGGING_BUCKET",
+ *     prefix: "my-application-logs"
+ *   }
+ * }
+ * ```
  */
 export interface GuEc2AppProps extends AppIdentity {
   userData: GuUserDataProps | string;
@@ -111,6 +135,7 @@ export interface GuEc2AppProps extends AppIdentity {
     [Stage.CODE]: GuAsgCapacityProps;
     [Stage.PROD]: GuAsgCapacityProps;
   };
+  accessLogging?: AccessLoggingProps;
 }
 
 interface GuMaybePortProps extends Omit<GuEc2AppProps, "applicationPort"> {
@@ -310,6 +335,19 @@ export class GuEc2App {
       internetFacing: true,
       vpcSubnets: { subnets: GuVpc.subnetsfromParameter(scope, { type: SubnetType.PUBLIC, app }) },
     });
+
+    if (props.accessLogging) {
+      const accessLoggingBucket = new GuSSMParameter(scope, { parameter: props.accessLogging.bucketSSMPath });
+
+      loadBalancer.logAccessLogs(
+        Bucket.fromBucketName(
+          scope,
+          AppIdentity.suffixText(props, "AccessLoggingBucket"),
+          accessLoggingBucket.getValue()
+        ),
+        props.accessLogging.prefix
+      );
+    }
 
     const targetGroup = new GuApplicationTargetGroup(scope, "TargetGroup", {
       app,

--- a/src/utils/test/simple-gu-stack.ts
+++ b/src/utils/test/simple-gu-stack.ts
@@ -1,7 +1,7 @@
-import type { Environment } from "@aws-cdk/core";
 import { App } from "@aws-cdk/core";
 import { GuStack } from "../../constructs/core";
 import type { GuStackProps } from "../../constructs/core";
+import type { Environment } from "@aws-cdk/core";
 
 // Some stacks (such as ones using access logging on load balancers) require specifying a region
 interface SimpleGuStackProps extends Partial<GuStackProps> {

--- a/src/utils/test/simple-gu-stack.ts
+++ b/src/utils/test/simple-gu-stack.ts
@@ -1,6 +1,15 @@
+import type { Environment } from "@aws-cdk/core";
 import { App } from "@aws-cdk/core";
 import { GuStack } from "../../constructs/core";
 import type { GuStackProps } from "../../constructs/core";
 
-export const simpleGuStackForTesting: (props?: Partial<GuStackProps>) => GuStack = (props?: Partial<GuStackProps>) =>
-  new GuStack(new App(), "Test", { stack: props?.stack ?? "test-stack", ...props });
+// Some stacks (such as ones using access logging on load balancers) require specifying a region
+interface SimpleGuStackProps extends Partial<GuStackProps> {
+  env?: Environment;
+}
+
+export const simpleGuStackForTesting: (props?: SimpleGuStackProps) => GuStack = (props?: SimpleGuStackProps) =>
+  new GuStack(new App(), "Test", {
+    stack: props?.stack ?? "test-stack",
+    ...props,
+  });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Many stacks [like to configure an access logging policy for their load balancers](https://github.com/search?p=2&q=org%3Aguardian+%22AccessLoggingPolicy%22&type=Code). This appears to be a fairly common trend among EC2 applications, and also has significant variability in terms of how it's configured. Although it would be great to enforce a sensible default (ie always logging to the same bucket and prefix), this is currently not the case across the Guardian and so it is worth providing an interface to users to configure it themselves.

This PR allows users to optionally configure access logging by specifying the bucket and prefix of where the logs are written.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Nope.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes, a comment has been added to explain usage, with an example provided.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

`./script/test`.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Users can specify access logging configuration if desired.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

None that I can think of - the only risk is that we allow for more fragmentation across the department where different applications & teams have different preferences for using and defining access logging. However, it feels more important to have support for the feature for now, and potentially decide and enforce a best practice later down the line!

You are required to specify a region when using access logging - this has been reflected in our test, where we thread a new `env` prop through to our `simpleGuStackForTesting`. Documentation has been added to inform users of this.