### PR TITLE
chore!: remove `GuPublicInternetAccessSecurityGroup`

### DIFF
--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -3,7 +3,7 @@ import "../../../utils/test/jest";
 import { Peer, Port, Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../../utils/test";
-import { GuHttpsEgressSecurityGroup, GuPublicInternetAccessSecurityGroup, GuSecurityGroup } from "./base";
+import { GuHttpsEgressSecurityGroup, GuSecurityGroup } from "./base";
 
 describe("The GuSecurityGroup class", () => {
   const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
@@ -101,36 +101,6 @@ describe("The GuSecurityGroup class", () => {
         app: "testing",
       });
     }).toThrow(new Error("An ingress rule on port 22 is not allowed. Prefer to setup SSH via SSM."));
-  });
-});
-
-describe("The GuPublicInternetAccessSecurityGroup class", () => {
-  const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
-    vpcId: "test",
-    availabilityZones: [""],
-    publicSubnetIds: [""],
-  });
-
-  it("adds global access on 443 by default", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuPublicInternetAccessSecurityGroup(stack, "InternetAccessGroup", {
-      vpc,
-      app: "testing",
-    });
-
-    expect(stack).toHaveResource("AWS::EC2::SecurityGroup", {
-      GroupDescription: "Allow all inbound traffic via HTTPS",
-      SecurityGroupIngress: [
-        {
-          CidrIp: "0.0.0.0/0",
-          Description: "Allow all inbound traffic via HTTPS",
-          FromPort: 443,
-          IpProtocol: "tcp",
-          ToPort: 443,
-        },
-      ],
-    });
   });
 });
 

--- a/src/constructs/ec2/security-groups/base.ts
+++ b/src/constructs/ec2/security-groups/base.ts
@@ -75,17 +75,6 @@ export class GuSecurityGroup extends GuBaseSecurityGroup {
   }
 }
 
-// TODO should this be a singleton?
-export class GuPublicInternetAccessSecurityGroup extends GuSecurityGroup {
-  constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
-    super(scope, id, {
-      ...props,
-      ingresses: [{ range: Peer.anyIpv4(), port: 443, description: "Allow all inbound traffic via HTTPS" }],
-      description: "Allow all inbound traffic via HTTPS",
-    });
-  }
-}
-
 /**
  * Creates a security group which allows all outbound HTTPS traffic.
  */


### PR DESCRIPTION
## What does this change?
`GuPublicInternetAccessSecurityGroup` has been removed, as AWS automatically creates a security group which
is almost identical to this by default when creating an Application Load Balancer.

## Does this change require changes to existing projects or CDK CLI?
Yes, this is a breaking change. As far as I can see it only affects [Typerighter](https://github.com/guardian/typerighter/blob/fa90ef260cd71e0f4fa1b893d7bba9b87ff828ef/cdk/lib/rule-manager/rule-manager.ts#L102-L107).

In the future, users should make use of the default security group that AWS automatically creates when creating an Application Load Balancer. However, moving from `GuPublicInternetAccessSecurityGroup`  to AWS's default requires a security group replacement, which is a disruptive change, so stacks which previously created an instance of `GuPublicInternetAccessSecurityGroup` should be able to retain the same custom security group, by passing the appropriate `id`, `ingresses` and `description` (see removed code in this PR) to `GuSecurityGroup` instead of using the `GuPublicInternetAccessSecurityGroup` helper.

## Does this change require changes to the library documentation?
No

## How to test
N/A

## How can we measure success?
The codebase is simpler. Users won't be tempted to create custom security groups when AWS is capable of doing this for them.

## Have we considered potential risks?
Yes, there is a risk that this will disrupt the team who maintain Typerighter. I have tried to suggest a couple of ways forward in the PR description.
