### PR TITLE
chore: Fix import order linting error

### DIFF
--- a/integration-test/src/integration-test-stack.ts
+++ b/integration-test/src/integration-test-stack.ts
@@ -1,6 +1,6 @@
+import { GuDistributionBucketParameter, GuStack } from "@guardian/cdk/lib/constructs/core";
 import type { App } from "@aws-cdk/core";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuDistributionBucketParameter, GuStack } from "@guardian/cdk/lib/constructs/core";
 
 export class IntegrationTestStack extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

I think this is failing because we do not observe a lockfile in the [integration-test project](https://github.com/guardian/cdk/blob/9b9a91bc03f507ba4d688024b4fc8059a617f9d0/integration-test/script/ci#L5-L8). As `eslint-plugin-import`'s version includes `^`, we cannot guarantee what version gets used in CI.

We hadn't seen it locally as we don't do a fresh install. If you delete `integration-test/node_modules` and lint the `integration-test` project, the error can be seen.

Options:
  - Use pinned versions in the integration-test project (I'm not sure if dependabot works with pinned dependency versions)
  - Do not lint the integration-test project
  - Use a lockfile and install @guardian/cdk into the integration-test project with `--no-package-lock` (not sure if this is possible as @guardian/cdk will remain in `package.json`)

See:
  - https://github.com/benmosher/eslint-plugin-import/pull/2021
  - https://docs.npmjs.com/cli/v6/commands/npm-install#:~:text=--no-package-lock

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See CI.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

CI passes on all branches; Dependabot branches are currently failing.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a