### PR TITLE
chore: Remove @guardian/eslint-config-typescript

### DIFF
--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -15,7 +15,6 @@
     "generate": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/eslint-config-typescript": "^0.5.0",
     "@types/jest": "^26.0.22",
     "@types/node": "15.0.2",
     "aws-cdk": "1.103.0",


### PR DESCRIPTION
This was missed in https://github.com/guardian/cdk/pull/569.

See https://github.com/guardian/cdk/pull/569 for full details.