### PR TITLE
chore(deps): bump @types/node from 15.0.2 to 15.3.0 in /integration-test

### DIFF
--- a/integration-test/package-lock.json
+++ b/integration-test/package-lock.json
@@ -485,7 +485,7 @@
         "@aws-cdk/aws-rds": "1.103.0",
         "@aws-cdk/aws-s3": "1.103.0",
         "@aws-cdk/core": "1.103.0",
-        "aws-sdk": "^2.905.0",
+        "aws-sdk": "^2.909.0",
         "execa": "^5.0.0",
         "git-url-parse": "^11.4.4",
         "read-pkg-up": "7.0.1"
@@ -15696,9 +15696,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.5.0",
     "@types/jest": "^26.0.22",
-    "@types/node": "15.0.2",
+    "@types/node": "15.3.0",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "aws-cdk": "1.103.0",


### PR DESCRIPTION
This is a replacement for #563 which Dependabot is having trouble with.

I think this is because the version of aws-sdk (a transitive dep from @guardian/cdk) in the lockfile changes. It looks like this is caused by #566.