### PR TITLE
fix(ec2-app): allow users to specify scaling for only one stage

### DIFF
--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -141,8 +141,8 @@ export interface GuEc2AppProps extends AppIdentity {
   roleConfiguration?: GuInstanceRoleProps;
   monitoringConfiguration: NoMonitoring | Gu5xxPercentageMonitoringProps;
   scaling?: {
-    [Stage.CODE]: GuAsgCapacityProps;
-    [Stage.PROD]: GuAsgCapacityProps;
+    [Stage.CODE]?: GuAsgCapacityProps;
+    [Stage.PROD]?: GuAsgCapacityProps;
   };
   accessLogging?: AccessLoggingProps;
 }
@@ -319,12 +319,12 @@ export class GuEc2App {
       vpc,
       stageDependentProps: {
         CODE: {
-          minimumInstances: props.scaling?.CODE.minimumInstances ?? 1,
-          maximumInstances: props.scaling?.CODE.maximumInstances,
+          minimumInstances: props.scaling?.CODE?.minimumInstances ?? 1,
+          maximumInstances: props.scaling?.CODE?.maximumInstances,
         },
         PROD: {
-          minimumInstances: props.scaling?.PROD.minimumInstances ?? 3,
-          maximumInstances: props.scaling?.PROD.maximumInstances,
+          minimumInstances: props.scaling?.PROD?.minimumInstances ?? 3,
+          maximumInstances: props.scaling?.PROD?.maximumInstances,
         },
       },
       role: new GuInstanceRole(scope, { app: props.app, ...mergedRoleConfiguration }),


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

When testing the pattern out, it struck me that part of the value of the `scaling` prop is to specify your `PROD` scaling exclusively, as you would often be happy with the default `CODE` scaling of 1 min & 2 max. At the moment, our pattern forces you to specify both CODE and PROD if you use the `scaling` prop, when you may often only want to control one environment. 

This PR makes both stages optional, so you can only specify one stage and benefit from the defaults for the other.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Nope.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Nope, as I think it's still fairly clear with the current docs.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

`./script/test`.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Users can optionally specify just one stage for scaling policies.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

![](https://media.giphy.com/media/JRhS6WoswF8FxE0g2R/giphy.gif)
