### PR TITLE
fix(ec2-app): use a traditional GuStringParameter for access logging

### DIFF
--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -441,28 +441,14 @@ describe("the GuEC2App pattern", function () {
       accessLogging: { enabled: true, prefix: "access-logging-prefix" },
     });
 
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    const lbKey = Object.keys(json.Resources).find(
-      (resource) => json.Resources[resource].Type === "AWS::ElasticLoadBalancingV2::LoadBalancer"
-    );
-    expect(lbKey).toBeTruthy();
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- We assert above that this is truthy
-    const loadBalancer = json.Resources[lbKey!];
-
-    expect(loadBalancer.Properties.LoadBalancerAttributes).toEqual(
-      expect.arrayContaining([
+    expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      LoadBalancerAttributes: [
         { Key: "deletion_protection.enabled", Value: "true" },
         { Key: "access_logs.s3.enabled", Value: "true" },
-        {
-          Key: "access_logs.s3.bucket",
-          Value: {
-            "Fn::GetAtt": [expect.stringContaining("GuSSMParameter"), "Parameter.Value"],
-          },
-        },
+        { Key: "access_logs.s3.bucket", Value: { Ref: "AccessLoggingBucket" } },
         { Key: "access_logs.s3.prefix", Value: "access-logging-prefix" },
-      ])
-    );
+      ],
+    });
   });
 
   it("can disable access logging if desired", function () {

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -6,7 +6,7 @@ import { Duration } from "@aws-cdk/core";
 import { GuCertificate } from "../constructs/acm";
 import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
 import { Gu5xxPercentageAlarm } from "../constructs/cloudwatch";
-import { GuSSMParameter } from "../constructs/core";
+import { GuStringParameter } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
 import { GuSecurityGroup, GuVpc, SubnetType } from "../constructs/ec2";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../constructs/iam";
@@ -346,13 +346,17 @@ export class GuEc2App {
     });
 
     if (props.accessLogging?.enabled) {
-      const accessLoggingBucket = new GuSSMParameter(scope, { parameter: "/account/services/access-logging/bucket" });
+      const accessLoggingBucket = new GuStringParameter(scope, "AccessLoggingBucket", {
+        description: "S3 bucket to store your access logs",
+        default: "/account/services/access-logging/bucket",
+        fromSSM: true,
+      });
 
       loadBalancer.logAccessLogs(
         Bucket.fromBucketName(
           scope,
           AppIdentity.suffixText(props, "AccessLoggingBucket"),
-          accessLoggingBucket.getValue()
+          accessLoggingBucket.valueAsString
         ),
         props.accessLogging.prefix
       );


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As discussed in chat, we are currently experiencing issues with `GuSSMParameter`'s implementation not playing nicely with snapshot tests, primarily due to `GuSSMParameter` forcing a new ID for its resources at every synth which then makes snapshot tests fail due to a mismatch in IDs.

As a temporary stop-gap while we fix this problem, this PR resorts to a "traditional" CFN string parameter with the default value being the same as the value fetched by `GuSSMParameter`. 

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Nope.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Nope, don't think so.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

`./script/test`.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Snapshot tests still pass while users configure access logging. 

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

![](https://media.giphy.com/media/8PyT9LA2cKQX4OIos8/giphy.gif)