### PR TITLE
refactor: Simplify the SSM custom resource

### DIFF
--- a/src/constructs/core/custom-resources/runtime/lambda.js
+++ b/src/constructs/core/custom-resources/runtime/lambda.js
@@ -1,4 +1,0 @@
-/*
-* The reason for this file is to appease the tests in `core/ssm.test.ts`.
-* We don't need this to contain anything useful because we're not testing the contents of it within that testing suite.
-* */

--- a/src/constructs/core/custom-resources/runtime/lambda.symlink.ts
+++ b/src/constructs/core/custom-resources/runtime/lambda.symlink.ts
@@ -1,1 +1,0 @@
-../runtime/lambda.ts

--- a/src/constructs/core/custom-resources/runtime/lambda.test.ts
+++ b/src/constructs/core/custom-resources/runtime/lambda.test.ts
@@ -1,10 +1,4 @@
-/*
- * You can't specify the file extension (eg .ts) of the file to import,
- * and lambda.js exists as a dummy file, so we'd always import that over lambda.ts (the actual code to be tested) if
- * we imported `lambda`
- * lambda.symlink is a symlink to lambda.ts, so we can test it without importing lambda.js
- * */
-import { flatten } from "./lambda.symlink";
+import { flatten } from "./lambda";
 
 describe("The flatten function", function () {
   it("should flatten nested objects into one", function () {

--- a/src/constructs/core/ssm.test.ts
+++ b/src/constructs/core/ssm.test.ts
@@ -3,6 +3,16 @@ import { simpleGuStackForTesting } from "../../utils/test";
 import { GuSSMIdentityParameter, GuSSMParameter } from "./ssm";
 
 describe("SSM:", () => {
+  /*
+  `GuSSMParameter.lambdaRuntime` reads from the compiled JS file.
+  As we're not testing the execution of the runtime here, we can safely mock the result.
+   */
+  const lambdaRuntime = jest.spyOn(GuSSMParameter, "lambdaRuntime", "get").mockImplementation(() => "mocked");
+
+  afterAll(() => {
+    lambdaRuntime.mockReset();
+  });
+
   describe("The GuSSMIdentityParameter construct", () => {
     it("requires the scope and parameter name", function () {
       const stack = simpleGuStackForTesting({ stack: "some-stack" });

--- a/src/constructs/core/ssm.ts
+++ b/src/constructs/core/ssm.ts
@@ -31,12 +31,16 @@ export class GuSSMParameter extends Construct implements IGrantable {
       : `${prefix}-${stripped(parameter)}-${randomNumberBetweenOneAndTenThousand}`;
   };
 
+  static get lambdaRuntime(): string {
+    return readFileSync(join(__dirname, "/custom-resources/runtime/lambda.js")).toString();
+  }
+
   constructor(scope: GuStack, props: GuSSMParameterProps) {
     super(scope, GuSSMParameter.id("GuSSMParameter", props.parameter));
     const { parameter } = props;
 
     const provider = new SingletonFunction(scope, GuSSMParameter.id("Provider", parameter), {
-      code: Code.fromInline(readFileSync(join(__dirname, "/custom-resources/runtime/lambda.js")).toString()),
+      code: Code.fromInline(GuSSMParameter.lambdaRuntime),
       runtime: Runtime.NODEJS_12_X,
       handler: "index.handler",
       uuid: "eda001a3-b7c8-469d-bc13-787c4e13cfd9",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We currently have quite a complicated setup in place to make a few tests work, namely we've checked in an empty `lambda.js` file and a symlink.

This change takes a different approach by using a mock in the tests.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should continue to pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

This change is part of a wider set of changes to introduce a CLI to GuCDK that checks if your AWS account is setup properly by checking [SSM parameters'](https://github.com/guardian/cdk/blob/4b007724c637bdf7db3a18574c8db18691fe4d5c/docs/005-default-parameter-store-locations.md) existence. Part of this process is to change the [tsconfig file](https://github.com/guardian/cdk/blob/4b007724c637bdf7db3a18574c8db18691fe4d5c/tsconfig.json#L19), outputting inline rather than in a separate `lib` directory. Once we do that `tsc` will overwrite `lambda.js` with actual JS code and we have to start dancing around with `.gitignore`/`.gitkeep` files in order to keep the empty `lambda.js` in VCS. It's simpler to remove it from VCS.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a