### PR TITLE
feat: add an alarm capable of catching cycling instances and instantiate within the EC2 App pattern

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -123,7 +123,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "testAF53AC38": Object {
+    "High5xxPercentageAlarm01AF21CD": Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [
@@ -242,6 +242,312 @@ Object {
             "ReturnData": false,
           },
         ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+  },
+}
+`;
+
+exports[`The GuUnhealthyHostsAlarm construct should create the correct alarm resource with minimal config 1`] = `
+Object {
+  "Mappings": Object {
+    "stagemapping": Object {
+      "CODE": Object {
+        "alarmActionsEnabled": false,
+      },
+      "PROD": Object {
+        "alarmActionsEnabled": true,
+      },
+    },
+  },
+  "Outputs": Object {
+    "ApplicationLoadBalancerTestingDnsName": Object {
+      "Description": "DNS entry for ApplicationLoadBalancerTesting",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "ApplicationLoadBalancerTesting172A253B",
+          "DNSName",
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "ApplicationListener62E539D0": Object {
+      "Properties": Object {
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "ApplicationTargetGroupTesting080C2FF2",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "ApplicationLoadBalancerTesting172A253B",
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "ApplicationLoadBalancerTesting172A253B": Object {
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "ApplicationLoadBalancerTestingSecurityGroup883A01A4",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Array [
+          "",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "ApplicationLoadBalancerTestingSecurityGroup883A01A4": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB TestApplicationLoadBalancerTesting8F9EA5A8",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "255.255.255.255/32",
+            "Description": "Disallow all traffic",
+            "FromPort": 252,
+            "IpProtocol": "icmp",
+            "ToPort": 86,
+          },
+        ],
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": "test",
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "ApplicationTargetGroupTesting080C2FF2": Object {
+      "Properties": Object {
+        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 10,
+        "HealthyThresholdCount": 2,
+        "Port": 80,
+        "Protocol": "HTTP",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "UnhealthyThresholdCount": 5,
+        "VpcId": "test",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "UnhealthyHostsAlarmE3387D4B": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "stagemapping",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "testing has had unhealthy hosts for more than an hour",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "testing has unhealthy hosts in ",
+              Object {
+                "Ref": "Stage",
+              },
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  Object {
+                    "Fn::Select": Array [
+                      1,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ApplicationListener62E539D0",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      2,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ApplicationListener62E539D0",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "/",
+                  Object {
+                    "Fn::Select": Array [
+                      3,
+                      Object {
+                        "Fn::Split": Array [
+                          "/",
+                          Object {
+                            "Ref": "ApplicationListener62E539D0",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Name": "TargetGroup",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "ApplicationTargetGroupTesting080C2FF2",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "UnHealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "Period": 3600,
+        "Statistic": "Average",
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -123,7 +123,7 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "High5xxPercentageAlarm01AF21CD": Object {
+    "High5xxPercentageAlarmTesting9E960B0F": Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [
@@ -439,7 +439,7 @@ Object {
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "UnhealthyHostsAlarmE3387D4B": Object {
+    "UnhealthyHostsAlarmTesting8569AD5C": Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -251,7 +251,7 @@ Object {
 }
 `;
 
-exports[`The GuUnhealthyHostsAlarm construct should create the correct alarm resource with minimal config 1`] = `
+exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
   "Mappings": Object {
     "stagemapping": Object {
@@ -439,7 +439,7 @@ Object {
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "UnhealthyHostsAlarmTesting8569AD5C": Object {
+    "UnhealthyInstancesAlarmTestingD3AE50F4": Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -468,12 +468,16 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "testing has had unhealthy hosts for more than an hour",
+        "AlarmDescription": "testing's instances have failed healthchecks several times over the last hour.
+      This typically results in the AutoScaling Group cycling instances and can lead to problems with deployment,
+      scaling or handling traffic spikes.
+
+      Check testing's application logs or ssh onto an unhealthy instance in order to debug these problems.",
         "AlarmName": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "testing has unhealthy hosts in ",
+              "Unhealthy instances for testing in ",
               Object {
                 "Ref": "Stage",
               },
@@ -481,6 +485,7 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 6,
         "Dimensions": Array [
           Object {
             "Name": "LoadBalancer",
@@ -543,10 +548,10 @@ Object {
             },
           },
         ],
-        "EvaluationPeriods": 1,
+        "EvaluationPeriods": 12,
         "MetricName": "UnHealthyHostCount",
         "Namespace": "AWS/ApplicationELB",
-        "Period": 3600,
+        "Period": 300,
         "Statistic": "Average",
         "Threshold": 1,
         "TreatMissingData": "notBreaching",

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -552,7 +552,7 @@ Object {
         "MetricName": "UnHealthyHostCount",
         "Namespace": "AWS/ApplicationELB",
         "Period": 300,
-        "Statistic": "Average",
+        "Statistic": "Maximum",
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
       },

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -31,7 +31,7 @@ export class GuAlarm extends Alarm {
     };
     super(scope, id, { ...props, actionsEnabled: scope.withStageDependentValue(actionsEnabled) });
     const topicArn: string = `arn:aws:sns:${scope.region}:${scope.account}:${props.snsTopicName}`;
-    const snsTopic: ITopic = Topic.fromTopicArn(scope, "sns-topic-for-alarm-notifications", topicArn);
+    const snsTopic: ITopic = Topic.fromTopicArn(scope, `SnsTopicFor${id}`, topicArn);
     this.addAlarmAction(new SnsAction(snsTopic));
   }
 }

--- a/src/constructs/cloudwatch/ec2-alarms.test.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.test.ts
@@ -5,7 +5,7 @@ import { ApplicationListener, ApplicationProtocol } from "@aws-cdk/aws-elasticlo
 import { Stack } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuApplicationLoadBalancer, GuApplicationTargetGroup } from "../loadbalancing";
-import { Gu5xxPercentageAlarm, GuUnhealthyHostsAlarm } from "./ec2-alarms";
+import { Gu5xxPercentageAlarm, GuUnhealthyInstancesAlarm } from "./ec2-alarms";
 import type { AppIdentity } from "../core/identity";
 
 const vpc = Vpc.fromVpcAttributes(new Stack(), "VPC", {
@@ -73,7 +73,7 @@ describe("The Gu5xxPercentageAlarm construct", () => {
   });
 });
 
-describe("The GuUnhealthyHostsAlarm construct", () => {
+describe("The GuUnhealthyInstancesAlarm construct", () => {
   it("should create the correct alarm resource with minimal config", () => {
     const stack = simpleGuStackForTesting();
     const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
@@ -84,7 +84,7 @@ describe("The GuUnhealthyHostsAlarm construct", () => {
       loadBalancer: alb,
       defaultTargetGroups: [targetGroup],
     });
-    new GuUnhealthyHostsAlarm(stack, { ...app, targetGroup: targetGroup, snsTopicName: "test-topic" });
+    new GuUnhealthyInstancesAlarm(stack, { ...app, targetGroup: targetGroup, snsTopicName: "test-topic" });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 });

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -1,4 +1,4 @@
-import { ComparisonOperator, MathExpression, TreatMissingData } from "@aws-cdk/aws-cloudwatch";
+import { ComparisonOperator, MathExpression, Statistic, TreatMissingData } from "@aws-cdk/aws-cloudwatch";
 import { HttpCodeElb, HttpCodeTarget } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Duration } from "@aws-cdk/core";
 import { GuAlarm } from "./alarm";
@@ -72,6 +72,7 @@ export class GuUnhealthyHostsAlarm extends GuAlarm {
       alarmDescription: alarmDescription,
       metric: props.targetGroup.metricUnhealthyHostCount(),
       treatMissingData: TreatMissingData.NOT_BREACHING,
+      statistic: Statistic.MAXIMUM,
       threshold: 1,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       period: Duration.minutes(5),

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -56,12 +56,16 @@ export class Gu5xxPercentageAlarm extends GuAlarm {
 }
 
 /**
- * Creates an alarm which is triggered whenever there have been unhealthy hosts for a consistent period.
+ * Creates an alarm which is triggered whenever there have been several healthcheck failures within a single hour.
  */
 export class GuUnhealthyHostsAlarm extends GuAlarm {
   constructor(scope: GuStack, props: GuTargetGroupAlarmProps) {
-    const alarmName = `${props.app} has unhealthy hosts in ${scope.stage}`;
-    const alarmDescription = `${props.app} has had unhealthy hosts for more than an hour`;
+    const alarmName = `Unhealthy instances for ${props.app} in ${scope.stage}`;
+    const alarmDescription = `${props.app}'s instances have failed healthchecks several times over the last hour.
+      This typically results in the AutoScaling Group cycling instances and can lead to problems with deployment,
+      scaling or handling traffic spikes.
+
+      Check ${props.app}'s application logs or ssh onto an unhealthy instance in order to debug these problems.`;
     const alarmProps = {
       ...props,
       alarmName: alarmName,
@@ -70,8 +74,9 @@ export class GuUnhealthyHostsAlarm extends GuAlarm {
       treatMissingData: TreatMissingData.NOT_BREACHING,
       threshold: 1,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      period: Duration.hours(1),
-      evaluationPeriods: 1,
+      period: Duration.minutes(5),
+      datapointsToAlarm: 6,
+      evaluationPeriods: 12,
     };
     super(scope, "UnhealthyHostsAlarm", alarmProps);
   }

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -1,9 +1,9 @@
 import { ComparisonOperator, MathExpression, Statistic, TreatMissingData } from "@aws-cdk/aws-cloudwatch";
 import { HttpCodeElb, HttpCodeTarget } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Duration } from "@aws-cdk/core";
+import { AppIdentity } from "../core/identity";
 import { GuAlarm } from "./alarm";
 import type { GuStack } from "../core";
-import type { AppIdentity } from "../core/identity";
 import type { GuApplicationLoadBalancer, GuApplicationTargetGroup } from "../loadbalancing";
 import type { GuAlarmProps } from "./alarm";
 
@@ -51,7 +51,7 @@ export class Gu5xxPercentageAlarm extends GuAlarm {
       alarmDescription: props.alarmDescription ?? defaultDescription,
       evaluationPeriods: props.numberOfMinutesAboveThresholdBeforeAlarm ?? 1,
     };
-    super(scope, "High5xxPercentageAlarm", alarmProps);
+    super(scope, AppIdentity.suffixText(props, "High5xxPercentageAlarm"), alarmProps);
   }
 }
 
@@ -79,6 +79,6 @@ export class GuUnhealthyHostsAlarm extends GuAlarm {
       datapointsToAlarm: 6,
       evaluationPeriods: 12,
     };
-    super(scope, "UnhealthyHostsAlarm", alarmProps);
+    super(scope, AppIdentity.suffixText(props, "UnhealthyHostsAlarm"), alarmProps);
   }
 }

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -108,7 +108,7 @@ describe("the GuEC2App pattern", function () {
     });
   });
 
-  it("creates an alarm if monitoringConfiguration is provided", function () {
+  it("creates alarms if monitoringConfiguration is provided", function () {
     const stack = simpleGuStackForTesting();
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
@@ -122,7 +122,9 @@ describe("the GuEC2App pattern", function () {
       },
       userData: "",
     });
-    expect(stack).toHaveResource("AWS::CloudWatch::Alarm"); //The shape of the alarm is tested at construct level
+    //The shape of the alarms is tested at construct level
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::CloudWatch::Alarm", /^High5xxPercentageAlarm.+/);
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::CloudWatch::Alarm", /^UnhealthyHostsAlarm.+/);
   });
 
   it("creates the appropriate ingress rules for a restricted access application", function () {

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -5,7 +5,7 @@ import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration } from "@aws-cdk/core";
 import { GuCertificate } from "../constructs/acm";
 import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
-import { Gu5xxPercentageAlarm } from "../constructs/cloudwatch";
+import { Gu5xxPercentageAlarm, GuUnhealthyHostsAlarm } from "../constructs/cloudwatch";
 import { GuStringParameter } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
 import { GuSecurityGroup, GuVpc, SubnetType } from "../constructs/ec2";
@@ -393,10 +393,15 @@ export class GuEc2App {
     }
 
     if (!props.monitoringConfiguration.noMonitoring) {
-      new Gu5xxPercentageAlarm(scope, "Alarm", {
+      new Gu5xxPercentageAlarm(scope, {
         app,
         loadBalancer,
         ...props.monitoringConfiguration,
+      });
+      new GuUnhealthyHostsAlarm(scope, {
+        app,
+        targetGroup,
+        snsTopicName: props.monitoringConfiguration.snsTopicName,
       });
     }
 

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -89,13 +89,15 @@ export interface Alarms {
  * }
  * ```
  *
- * To create an alarm which is triggered whenever the percentage of requests with a 5xx response code exceeds
- * the specified threshold, use:
+ * To create alarms (recommended), use:
  * ```typescript
  * // other props
  * monitoringConfiguration: {
- *   tolerated5xxPercentage: 1,
  *   snsTopicName: "alerts-topic-for-my-team",
+ *   http5xxAlarm: {
+ *     tolerated5xxPercentage: 1,
+ *   },
+ *   unhealthyInstancesAlarm: true,
  * }
  * ```
  *
@@ -212,9 +214,12 @@ function restrictedCidrRanges(ranges: IPeer[]) {
  *     },
  *   },
  *   monitoringConfiguration: {
- *     tolerated5xxPercentage: 1,
  *     snsTopicName: "alerts-topic-for-my-team",
- *   },
+ *     http5xxAlarm: {
+ *       tolerated5xxPercentage: 1,
+ *     },
+ *     unhealthyInstancesAlarm: true,
+ *   }
  *   userData: {
  *     distributable: {
  *       fileName: "app-name.deb",
@@ -244,9 +249,12 @@ function restrictedCidrRanges(ranges: IPeer[]) {
  *     },
  *   },
  *   monitoringConfiguration: {
- *     tolerated5xxPercentage: 1,
  *     snsTopicName: "alerts-topic-for-my-team",
- *   },
+ *     http5xxAlarm: {
+ *       tolerated5xxPercentage: 1,
+ *     },
+ *     unhealthyInstancesAlarm: true,
+ *   }
  *   userData: {
  *     distributable: {
  *       fileName: "app-name.deb",


### PR DESCRIPTION
## What does this change?

* Creates a new alarm construct which helps to identify cycling instances (e.g. after a failed deploy or scaling event)
* Allows users to create this new alarm easily, via the EC2 App pattern
* Simplifies an existing alarm construct slightly (id is no longer required)

Perhaps this should have been split into separate PRs; I'm happy to do that if reviewers think it'd be helpful.

## Does this change require changes to existing projects or CDK CLI?

1. Yes, any user who currently instantiates a `Gu5xxPercentageAlarm` directly (i.e. not via the pattern) should no longer specify an id in the constructor
2. Any user who has already created a `Gu5xxPercentageAlarm` (either directly, or via the pattern) will also need to:
    1. Specify a custom name 
    2. Temporarily remove alarms
3. Any user who has configured an alarm via the pattern will need to refactor their `monitoringConfiguration` props slightly, as the API has been updated to offer better support for multiple alarms.
    
Note: 2 is required to avoid a situation where CFN attempts to create an alarm with a name which is identical to the first as part of resource replacement. Although this sounds like a real pain (it was during testing!), I don't think we actually have any users in this state!

## Does this change require changes to the library documentation?

Yes, the pattern docs/examples have been updated and (minimal) documentation has been added for the new construct.

## How to test

I've tested this change by deploying it to `cdk-playground` and breaking things in various ways!

## How can we measure success?

Users should notice problems with cycling instances more quickly, which should help to keep apps in a healthier, more stable state.

## Have we considered potential risks?

As with other alarms, there is a risk that rolling this out across many stacks will generate too much noise.