### PR TITLE
feat(ec2-app-pattern): allow threading of ASG block device configuration

### DIFF
--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -156,9 +156,7 @@ export interface GuEc2AppProps extends AppIdentity {
     [Stage.PROD]?: GuAsgCapacityProps;
   };
   accessLogging?: AccessLoggingProps;
-  autoScalingGroup?: {
-    blockDevices?: BlockDevice[];
-  };
+  blockDevices?: BlockDevice[];
 }
 
 interface GuMaybePortProps extends Omit<GuEc2AppProps, "applicationPort"> {
@@ -354,7 +352,7 @@ export class GuEc2App {
           ? new GuUserData(scope, { app, ...props.userData }).userData
           : props.userData,
       vpcSubnets: { subnets: privateSubnets },
-      ...(props.autoScalingGroup?.blockDevices && { ...props.autoScalingGroup.blockDevices }),
+      ...(props.blockDevices && { blockDevices: props.blockDevices }),
     });
 
     // We are selectively tagging the ASG so that we can expose the number of stacks using this pattern

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -1,23 +1,24 @@
+import type { BlockDevice } from "@aws-cdk/aws-autoscaling";
 import { HealthCheck } from "@aws-cdk/aws-autoscaling";
-import { Port } from "@aws-cdk/aws-ec2";
 import type { IPeer } from "@aws-cdk/aws-ec2";
+import { Port } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration, Tags } from "@aws-cdk/core";
 import type { Stage } from "../constants";
 import { TagKeys } from "../constants/tag-keys";
-import { GuCertificate } from "../constructs/acm";
 import type { GuCertificateProps } from "../constructs/acm";
-import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
+import { GuCertificate } from "../constructs/acm";
 import type { GuAsgCapacityProps, GuUserDataProps } from "../constructs/autoscaling";
-import { Gu5xxPercentageAlarm, GuUnhealthyInstancesAlarm } from "../constructs/cloudwatch";
+import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
 import type { Http5xxAlarmProps, NoMonitoring } from "../constructs/cloudwatch";
-import { GuStringParameter } from "../constructs/core";
+import { Gu5xxPercentageAlarm, GuUnhealthyInstancesAlarm } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
+import { GuStringParameter } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
 import { GuSecurityGroup, GuVpc, SubnetType } from "../constructs/ec2";
-import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../constructs/iam";
 import type { GuInstanceRoleProps } from "../constructs/iam";
+import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../constructs/iam";
 import {
   GuApplicationLoadBalancer,
   GuApplicationTargetGroup,
@@ -155,6 +156,9 @@ export interface GuEc2AppProps extends AppIdentity {
     [Stage.PROD]?: GuAsgCapacityProps;
   };
   accessLogging?: AccessLoggingProps;
+  autoScalingGroup?: {
+    blockDevices?: BlockDevice[];
+  };
 }
 
 interface GuMaybePortProps extends Omit<GuEc2AppProps, "applicationPort"> {
@@ -350,6 +354,7 @@ export class GuEc2App {
           ? new GuUserData(scope, { app, ...props.userData }).userData
           : props.userData,
       vpcSubnets: { subnets: privateSubnets },
+      ...(props.autoScalingGroup?.blockDevices && { ...props.autoScalingGroup.blockDevices }),
     });
 
     // We are selectively tagging the ASG so that we can expose the number of stacks using this pattern


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

At the moment, some stacks like [Prism](https://github.com/guardian/prism/blob/3ca28b2329dd837cee07fb7152b74e7dd55b8185/cdk/lib/prism.ts#L93-L100) require specifying block device configurations. This isn't easily or obviously achievable by accessing the ASG sub-construct (eg `pattern.autoScalingGroup`) nor by escape hatches (eg `const cfnAsg = app.autoScalingGroup.node.defaultChild as unknown as CfnAutoScalingGroup`), and so the best method might be to thread it through the pattern props.

This PR adds a prop (nested under an `autoScalingGroup` key) that allows users to optionally configure block devices.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
