### PR TITLE
fix: Add a reason prop to GuMigratingResource

### DIFF
--- a/src/constructs/acm/certificate.test.ts
+++ b/src/constructs/acm/certificate.test.ts
@@ -39,7 +39,7 @@ describe("The GuCertificate class", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuCertificate(stack, {
       app: "testing",
-      existingLogicalId: "MyCloudFormedCertificate",
+      existingLogicalId: { logicalId: "MyCloudFormedCertificate", reason: "testing" },
       [Stage.CODE]: {
         domainName: "code-guardian.com",
         hostedZoneId: "id123",

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -205,7 +205,10 @@ describe("The GuAutoScalingGroup", () => {
 
   test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, existingLogicalId: "MyASG" });
+    new GuAutoScalingGroup(stack, "AutoscalingGroup", {
+      ...defaultProps,
+      existingLogicalId: { logicalId: "MyASG", reason: "testing" },
+    });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::AutoScaling::AutoScalingGroup", "MyASG");
   });

--- a/src/constructs/core/migrating.test.ts
+++ b/src/constructs/core/migrating.test.ts
@@ -52,7 +52,9 @@ describe("GuMigratingResource", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     const construct = new Bucket(stack, "MyBucket");
 
-    GuMigratingResource.setLogicalId(construct, stack, { existingLogicalId: "my-pre-existing-bucket" });
+    GuMigratingResource.setLogicalId(construct, stack, {
+      existingLogicalId: { logicalId: "my-pre-existing-bucket", reason: "testing" },
+    });
 
     expect(warn).toHaveBeenCalledTimes(0);
     expect(info).toHaveBeenCalledTimes(0);
@@ -81,7 +83,9 @@ describe("GuMigratingResource", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: false });
     const construct = new Bucket(stack, "MyBucket");
 
-    GuMigratingResource.setLogicalId(construct, stack, { existingLogicalId: "my-pre-existing-bucket" });
+    GuMigratingResource.setLogicalId(construct, stack, {
+      existingLogicalId: { logicalId: "my-pre-existing-bucket", reason: "testing" },
+    });
 
     expect(info).toHaveBeenCalledTimes(0);
     expect(warn).toHaveBeenCalledTimes(1);

--- a/src/constructs/core/migrating.ts
+++ b/src/constructs/core/migrating.ts
@@ -32,7 +32,17 @@ export interface GuMigratingResource {
    * @see GuMigratingStack
    * @see GuStack
    */
-  existingLogicalId?: string;
+  existingLogicalId?: {
+    /**
+     * The logical ID to use in the synthesised template for this resource.
+     */
+    logicalId: string;
+
+    /**
+     * A short description to help developers understand why this resource's logical ID is being set.
+     */
+    reason: string;
+  };
 }
 
 export const GuMigratingResource = {
@@ -51,7 +61,7 @@ export const GuMigratingResource = {
 
     if (migratedFromCloudFormation) {
       if (existingLogicalId) {
-        return overrideLogicalId(existingLogicalId);
+        return overrideLogicalId(existingLogicalId.logicalId);
       }
 
       if (isStateful) {
@@ -62,7 +72,7 @@ export const GuMigratingResource = {
     } else {
       if (existingLogicalId) {
         Annotations.of(construct).addWarning(
-          `GuStack has 'migratedFromCloudFormation' set to false. ${id} has an 'existingLogicalId' set to ${existingLogicalId}. This will have no effect - the logicalId will be auto-generated. Set 'migratedFromCloudFormation' to true for 'existingLogicalId' to be observed.`
+          `GuStack has 'migratedFromCloudFormation' set to false. ${id} has an 'existingLogicalId' set to ${existingLogicalId.logicalId}. This will have no effect - the logicalId will be auto-generated. Set 'migratedFromCloudFormation' to true for 'existingLogicalId' to be observed.`
         );
       }
 

--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -14,7 +14,11 @@ describe("The GuSecurityGroup class", () => {
 
   it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuSecurityGroup(stack, "TestSecurityGroup", { vpc, existingLogicalId: "TestSG", app: "testing" });
+    new GuSecurityGroup(stack, "TestSecurityGroup", {
+      vpc,
+      existingLogicalId: { logicalId: "TestSG", reason: "testing" },
+      app: "testing",
+    });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::EC2::SecurityGroup", "TestSG");
   });

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -88,7 +88,12 @@ export class GuWazuhAccess extends GuBaseSecurityGroup {
     GuMigratingResource.setLogicalId(
       this,
       { migratedFromCloudFormation: true },
-      { existingLogicalId: "WazuhSecurityGroup" }
+      {
+        existingLogicalId: {
+          logicalId: "WazuhSecurityGroup",
+          reason: "Avoid tricky security group replacement during a YAML to GuCDK migration.",
+        },
+      }
     );
   }
 

--- a/src/constructs/iam/policies/base-policy.test.ts
+++ b/src/constructs/iam/policies/base-policy.test.ts
@@ -72,7 +72,7 @@ describe("GuAllowPolicy", () => {
       new GuAllowPolicy(stack, "AllowS3GetObject", {
         actions: ["s3:GetObject"],
         resources: ["*"],
-        existingLogicalId: "MyAwesomeAllowPolicy",
+        existingLogicalId: { logicalId: "MyAwesomeAllowPolicy", reason: "testing" },
       })
     );
 
@@ -149,7 +149,7 @@ describe("GuDenyPolicy", () => {
       new GuDenyPolicy(stack, "DenyS3GetObject", {
         actions: ["s3:GetObject"],
         resources: ["*"],
-        existingLogicalId: "MyAwesomeDenyPolicy",
+        existingLogicalId: { logicalId: "MyAwesomeDenyPolicy", reason: "testing" },
       })
     );
 

--- a/src/constructs/iam/roles/roles.test.ts
+++ b/src/constructs/iam/roles/roles.test.ts
@@ -9,7 +9,7 @@ describe("The GuRole class", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
 
     new GuRole(stack, "TestRole", {
-      existingLogicalId: "MyRole",
+      existingLogicalId: { logicalId: "MyRole", reason: "testing" },
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
     });
 

--- a/src/constructs/kinesis/kinesis-stream.test.ts
+++ b/src/constructs/kinesis/kinesis-stream.test.ts
@@ -12,7 +12,7 @@ describe("The GuKinesisStream construct", () => {
 
   it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuKinesisStream(stack, "LoggingStream", { existingLogicalId: "MyStream" });
+    new GuKinesisStream(stack, "LoggingStream", { existingLogicalId: { logicalId: "MyStream", reason: "testing" } });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", "MyStream");
   });

--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -67,7 +67,7 @@ describe("The GuApplicationListener class", () => {
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
       loadBalancer: getLoadBalancer(stack),
-      existingLogicalId: "AppListener",
+      existingLogicalId: { logicalId: "AppListener", reason: "testing" },
       defaultAction: ListenerAction.forward([getAppTargetGroup(stack)]),
       certificates: [{ certificateArn: "" }],
     });

--- a/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
@@ -40,7 +40,11 @@ describe("The GuApplicationLoadBalancer class", () => {
 
   test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc, existingLogicalId: "MyALB" });
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+      existingLogicalId: { logicalId: "MyALB", reason: "testing" },
+    });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::ElasticLoadBalancingV2::LoadBalancer", "MyALB");
   });
@@ -61,7 +65,7 @@ describe("The GuApplicationLoadBalancer class", () => {
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
       ...app,
       vpc,
-      existingLogicalId: "MyALB",
+      existingLogicalId: { logicalId: "MyALB", reason: "testing" },
       removeType: true,
     });
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;

--- a/src/constructs/loadbalancing/alb/application-target-group.test.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.test.ts
@@ -39,7 +39,11 @@ describe("The GuApplicationTargetGroup class", () => {
 
   test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { ...app, vpc, existingLogicalId: "MyTargetGroup" });
+    new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", {
+      ...app,
+      vpc,
+      existingLogicalId: { logicalId: "MyTargetGroup", reason: "testing" },
+    });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::ElasticLoadBalancingV2::TargetGroup", "MyTargetGroup");
   });

--- a/src/constructs/loadbalancing/elb.test.ts
+++ b/src/constructs/loadbalancing/elb.test.ts
@@ -20,7 +20,11 @@ describe("The GuClassicLoadBalancer class", () => {
 
   test("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", { ...app, vpc, existingLogicalId: "MyCLB" });
+    new GuClassicLoadBalancer(stack, "ClassicLoadBalancer", {
+      ...app,
+      vpc,
+      existingLogicalId: { logicalId: "MyCLB", reason: "testing" },
+    });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::ElasticLoadBalancing::LoadBalancer", "MyCLB");
   });
@@ -212,7 +216,7 @@ describe("The GuHttpsClassicLoadBalancer class", () => {
       ...app,
       vpc,
       removeScheme: true,
-      existingLogicalId: "ClassicLoadBalancer",
+      existingLogicalId: { logicalId: "ClassicLoadBalancer", reason: "testing" },
     });
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(Object.keys(json.Resources.ClassicLoadBalancer.Properties)).not.toContain("Scheme");

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -95,7 +95,7 @@ describe("The GuDatabaseInstance class", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuDatabaseInstance(stack, "DatabaseInstance", {
       vpc,
-      existingLogicalId: "MyDb",
+      existingLogicalId: { logicalId: "MyDb", reason: "testing" },
       instanceType: "t3.small",
       engine: DatabaseInstanceEngine.postgres({
         version: PostgresEngineVersion.VER_11_8,

--- a/src/constructs/sns/sns-topic.test.ts
+++ b/src/constructs/sns/sns-topic.test.ts
@@ -12,7 +12,7 @@ describe("The GuSnsTopic construct", () => {
 
   it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuSnsTopic(stack, "my-sns-topic", { existingLogicalId: "TheSnsTopic" });
+    new GuSnsTopic(stack, "my-sns-topic", { existingLogicalId: { logicalId: "TheSnsTopic", reason: "testing" } });
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", "TheSnsTopic");
   });
 });

--- a/src/patterns/kinesis-lambda.test.ts
+++ b/src/patterns/kinesis-lambda.test.ts
@@ -46,7 +46,7 @@ describe("The GuKinesisLambda pattern", () => {
       runtime: Runtime.NODEJS_12_X,
       errorHandlingConfiguration: basicErrorHandling,
       monitoringConfiguration: noMonitoring,
-      existingKinesisStream: { existingLogicalId: "pre-existing-kinesis-stream" },
+      existingKinesisStream: { existingLogicalId: { logicalId: "pre-existing-kinesis-stream", reason: "testing" } },
       app: "testing",
     };
     new GuKinesisLambda(stack, "my-lambda-function", props);

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -108,7 +108,7 @@ export class GuKinesisLambda extends GuLambdaFunction {
       encryption: StreamEncryption.MANAGED,
       ...props.kinesisStreamProps,
     };
-    const streamId = props.existingKinesisStream?.existingLogicalId ?? "KinesisStream";
+    const streamId = props.existingKinesisStream?.existingLogicalId?.logicalId ?? "KinesisStream";
 
     const kinesisStream = props.existingKinesisStream?.externalKinesisStreamName
       ? Stream.fromStreamArn(

--- a/src/patterns/sns-lambda.test.ts
+++ b/src/patterns/sns-lambda.test.ts
@@ -31,7 +31,7 @@ describe("The GuSnsLambda pattern", () => {
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
       monitoringConfiguration: noMonitoring,
-      existingSnsTopic: { existingLogicalId: "in-use-sns-topic" },
+      existingSnsTopic: { existingLogicalId: { logicalId: "in-use-sns-topic", reason: "testing" } },
       app: "testing",
     };
     new GuSnsLambda(stack, "my-lambda-function", props);

--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -85,7 +85,7 @@ export class GuSnsLambda extends GuLambdaFunction {
       ...props,
       errorPercentageMonitoring: props.monitoringConfiguration.noMonitoring ? undefined : props.monitoringConfiguration,
     });
-    const topicId = props.existingSnsTopic?.existingLogicalId ?? "SnsIncomingEventsTopic";
+    const topicId = props.existingSnsTopic?.existingLogicalId?.logicalId ?? "SnsIncomingEventsTopic";
 
     const snsTopic = props.existingSnsTopic?.externalTopicName
       ? Topic.fromTopicArn(

--- a/src/utils/mixin/migratable-construct.test.ts
+++ b/src/utils/mixin/migratable-construct.test.ts
@@ -23,7 +23,7 @@ describe("The GuMigratableConstruct mixin", () => {
 
   it("should call GuMigratingResource.setLogicalId when the stack is being migrated and existingLogicalId is set", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new TestGuMigratableConstruct(stack, "MyBucket", { existingLogicalId: "Hello" });
+    new TestGuMigratableConstruct(stack, "MyBucket", { existingLogicalId: { logicalId: "Hello", reason: "testing" } });
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::S3::Bucket", "Hello");
@@ -31,7 +31,7 @@ describe("The GuMigratableConstruct mixin", () => {
 
   it("should call GuMigratingResource.setLogicalId when the stack is not being migrated and existingLogicalId is set", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: false });
-    new TestGuMigratableConstruct(stack, "MyBucket", { existingLogicalId: "Hello" });
+    new TestGuMigratableConstruct(stack, "MyBucket", { existingLogicalId: { logicalId: "Hello", reason: "testing" } });
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::S3::Bucket", /^MyBucket.+/);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Updates the shape of `GuMigratingResource` to include a reason field to explain why a resource's logical ID is being pinned.

This is on the back of https://github.com/guardian/prism/pull/212 which fixes [this mistake](https://github.com/guardian/prism/commit/dc69fbee724965a49d9db54ef356fb18867e368c#diff-14cbc0e0275d178f0a4cf31c3c0d4408758ee8daad333947c0ff38391bc7d600L19).

The `reason` field isn't used anywhere, it's more like using the compiler to force comments... now that I think about it, it's a possible misuse of the compiler 😬 !

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes - there is an interface shape change. Projects cannot rely on Dependabot bumping the version of GuCDK as the CI step will definitely fail. The change isn't too onerous, however.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes - added.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Today's developers are kind to tomorrow's?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a