### PR TITLE
chore(docs): Update AWS CDK link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Welcome to the Guardian CDK library! This library contains a number of reusable 
 ## Wait, what is CDK?
 > The AWS Cloud Development Kit (AWS CDK) is an open-source software development framework to define cloud infrastructure in code and provision it through AWS CloudFormation.
 
-You can read more about it in the [here][aws-cdk].
+You can read more about it in the [AWS CDK repository][aws-cdk].
 
 ## Architecture
 ### Patterns


### PR DESCRIPTION
## What does this change?

This change updates the text of the link to the `aws cdk` repo in the README to ensure the sentence makes sense and to provide more context from the link text alone.