### PR TITLE
feat: Add policy to allow writing to Anghammarad

### DIFF
--- a/docs/005-default-parameter-store-locations.md
+++ b/docs/005-default-parameter-store-locations.md
@@ -3,13 +3,14 @@
 A number of constructs from the library define parameters to get configuration from Parameter Store. Each of these parameters configures a default path.
 The below table lists those paths, the parameter that sets them, the expected value type and which construct the parameter is defined within.
 
-| Path                                  | Parameter              | Type                         | Construct                  |
-| ------------------------------------- | ---------------------- | ---------------------------- | -------------------------- |
-| /account/vpc/primary/id               | VpcId                  | AWS::EC2::VPC::Id            | GuVpc.fromIdParameter      |
-| /account/vpc/primary/subnets/public   | PublicSubnets          | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
-| /account/vpc/primary/subnets/private  | PrivateSubnets         | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
-| /account/services/artifact.bucket     | DistributionBucketName | String                       | GuGetDistributablePolicy   |
-| /account/services/logging.stream.name | LoggingStreamName      | String                       | GuLogShippingPolicy        |
+| Path                                    | Parameter              | Type                         | Construct                  |
+| --------------------------------------- | ---------------------- | ---------------------------- | -------------------------- |
+| /account/vpc/primary/id                 | VpcId                  | AWS::EC2::VPC::Id            | GuVpc.fromIdParameter      |
+| /account/vpc/primary/subnets/public     | PublicSubnets          | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
+| /account/vpc/primary/subnets/private    | PrivateSubnets         | List\<AWS::EC2::Subnet::Id\> | GuVpc.subnetsFromParameter |
+| /account/services/artifact.bucket       | DistributionBucketName | String                       | GuGetDistributablePolicy   |
+| /account/services/logging.stream.name   | LoggingStreamName      | String                       | GuLogShippingPolicy        |
+| /account/services/anghammarad.topic.arn | AnghammaradSnsArn      | String                       | AnghammaradSenderPolicy    |
 
 
 ## Pattern-specific default Parameter Store locations

--- a/src/constructs/core/parameters/anghammarad.ts
+++ b/src/constructs/core/parameters/anghammarad.ts
@@ -1,0 +1,35 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
+import type { GuStack } from "../stack";
+import { GuStringParameter } from "./base";
+
+/**
+ * Creates a CloudFormation parameter to a SSM Parameter Store item that holds the ARN of the Anghammarad SNS topic.
+ * This parameter is implemented as a singleton, meaning only one can ever be added to a stack and will be reused if necessary.
+ *
+ * @see https://github.com/guardian/anghammarad
+ */
+export class AnghammaradTopicParameter extends GuStringParameter {
+  private static instance: AnghammaradTopicParameter | undefined;
+
+  private constructor(scope: GuStack) {
+    super(scope, "AnghammaradSnsArn", {
+      fromSSM: true,
+      default: "/account/services/anghammarad.topic.arn",
+      description: "SSM parameter containing the ARN of the Anghammarad SNS topic",
+    });
+  }
+
+  /**
+   * Returns a pre-existing parameter in the stack.
+   * If no parameter exists, creates a new parameter.
+   *
+   * @param stack the stack to operate on
+   */
+  public static getInstance(stack: GuStack): AnghammaradTopicParameter {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
+      this.instance = new AnghammaradTopicParameter(stack);
+    }
+
+    return this.instance;
+  }
+}

--- a/src/constructs/iam/policies/anghammarad.test.ts
+++ b/src/constructs/iam/policies/anghammarad.test.ts
@@ -1,0 +1,60 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
+import type { SynthedStack } from "../../../utils/test";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../utils/test";
+import type { GuStack } from "../../core";
+import { AnghammaradTopicParameter } from "../../core/parameters/anghammarad";
+import { AnghammaradSenderPolicy } from "./anghammarad";
+
+describe("AnghammaradSenderPolicy", () => {
+  const getParams = (stack: GuStack) => {
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    return Object.keys(json.Parameters);
+  };
+
+  it("should add a parameter to the stack if it is not already defined", () => {
+    const stack = simpleGuStackForTesting();
+
+    // an empty stack should only have `Stage` which GuStack adds
+    expect(getParams(stack)).toEqual(["Stage"]);
+
+    // add the policy
+    attachPolicyToTestRole(stack, AnghammaradSenderPolicy.getInstance(stack));
+    expect(getParams(stack)).toEqual(["Stage", "AnghammaradSnsArn"]);
+  });
+
+  it("should not add a parameter to the stack if it already exists", () => {
+    const stack = simpleGuStackForTesting();
+
+    // an empty stack should only have `Stage` which GuStack adds
+    expect(getParams(stack)).toEqual(["Stage"]);
+
+    // explicitly add an AnghammaradTopicParameter
+    AnghammaradTopicParameter.getInstance(stack);
+    expect(getParams(stack)).toEqual(["Stage", "AnghammaradSnsArn"]);
+
+    // add the policy
+    attachPolicyToTestRole(stack, AnghammaradSenderPolicy.getInstance(stack));
+    expect(getParams(stack)).toEqual(["Stage", "AnghammaradSnsArn"]);
+  });
+
+  it("should define a policy that would allow writing to SNS", () => {
+    const stack = simpleGuStackForTesting();
+    attachPolicyToTestRole(stack, AnghammaradSenderPolicy.getInstance(stack));
+
+    expect(stack).toHaveResource("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "sns:Publish",
+            Effect: "Allow",
+            Resource: {
+              Ref: "AnghammaradSnsArn",
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/anghammarad.ts
+++ b/src/constructs/iam/policies/anghammarad.ts
@@ -1,0 +1,32 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
+import type { GuStack } from "../../core";
+import { AnghammaradTopicParameter } from "../../core/parameters/anghammarad";
+import { GuAllowPolicy } from "./base-policy";
+
+/**
+ * Creates an `AWS::IAM::Policy` to grant `sns:Publish` permission to the Anghammarad topic.
+ * An `AnghammaradSnsArn` parameter will be automatically added to the stack when needed.
+ *
+ * @see AnghammaradTopicParameter
+ * @see https://github.com/guardian/anghammarad
+ */
+export class AnghammaradSenderPolicy extends GuAllowPolicy {
+  private static instance: AnghammaradSenderPolicy | undefined;
+
+  private constructor(scope: GuStack) {
+    const anghammaradTopicParameter = AnghammaradTopicParameter.getInstance(scope);
+
+    super(scope, "GuSESSenderPolicy", {
+      actions: ["sns:Publish"],
+      resources: [anghammaradTopicParameter.valueAsString],
+    });
+  }
+
+  public static getInstance(stack: GuStack): AnghammaradSenderPolicy {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
+      this.instance = new AnghammaradSenderPolicy(stack);
+    }
+
+    return this.instance;
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Create a policy that allows `sns:Publish` to the Anghammarad SNS topic.

The Anghammarad SNS topic is used across multiple stacks, so we can promote it to an account wide ("account/services") parameter store location.

We then wrap this account wide parameter into the `AnghammaradTopicParameter` singleton, which the policy will add when necessary.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Yes, they become a little DRYer as they no longer need to define this policy themselves.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes and documentation is included.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

Tests have been added that cover:
  - Automatic parameter addition (well, the implementation of the singleton)
  - The IAM policy

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Creating a first class construct for Anghammarad permissions means downstream stacks become DRYer.

(I can also correctly spell Anghammarad!)

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a