### PR TITLE
fix: Consistently name the `AnghammaradSenderPolicy`

### DIFF
--- a/src/constructs/core/parameters/anghammarad.ts
+++ b/src/constructs/core/parameters/anghammarad.ts
@@ -8,8 +8,8 @@ import { GuStringParameter } from "./base";
  *
  * @see https://github.com/guardian/anghammarad
  */
-export class AnghammaradTopicParameter extends GuStringParameter {
-  private static instance: AnghammaradTopicParameter | undefined;
+export class GuAnghammaradTopicParameter extends GuStringParameter {
+  private static instance: GuAnghammaradTopicParameter | undefined;
 
   private constructor(scope: GuStack) {
     super(scope, "AnghammaradSnsArn", {
@@ -25,9 +25,9 @@ export class AnghammaradTopicParameter extends GuStringParameter {
    *
    * @param stack the stack to operate on
    */
-  public static getInstance(stack: GuStack): AnghammaradTopicParameter {
+  public static getInstance(stack: GuStack): GuAnghammaradTopicParameter {
     if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
-      this.instance = new AnghammaradTopicParameter(stack);
+      this.instance = new GuAnghammaradTopicParameter(stack);
     }
 
     return this.instance;

--- a/src/constructs/core/parameters/index.ts
+++ b/src/constructs/core/parameters/index.ts
@@ -1,4 +1,5 @@
 export * from "./acm";
+export * from "./anghammarad";
 export * from "./base";
 export * from "./ec2";
 export * from "./identity";

--- a/src/constructs/iam/policies/anghammarad.test.ts
+++ b/src/constructs/iam/policies/anghammarad.test.ts
@@ -3,10 +3,10 @@ import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import type { SynthedStack } from "../../../utils/test";
 import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../utils/test";
 import type { GuStack } from "../../core";
-import { AnghammaradTopicParameter } from "../../core/parameters/anghammarad";
-import { AnghammaradSenderPolicy } from "./anghammarad";
+import { GuAnghammaradTopicParameter } from "../../core";
+import { GuAnghammaradSenderPolicy } from "./anghammarad";
 
-describe("AnghammaradSenderPolicy", () => {
+describe("GuAnghammaradSenderPolicy", () => {
   const getParams = (stack: GuStack) => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     return Object.keys(json.Parameters);
@@ -19,7 +19,7 @@ describe("AnghammaradSenderPolicy", () => {
     expect(getParams(stack)).toEqual(["Stage"]);
 
     // add the policy
-    attachPolicyToTestRole(stack, AnghammaradSenderPolicy.getInstance(stack));
+    attachPolicyToTestRole(stack, GuAnghammaradSenderPolicy.getInstance(stack));
     expect(getParams(stack)).toEqual(["Stage", "AnghammaradSnsArn"]);
   });
 
@@ -30,17 +30,17 @@ describe("AnghammaradSenderPolicy", () => {
     expect(getParams(stack)).toEqual(["Stage"]);
 
     // explicitly add an AnghammaradTopicParameter
-    AnghammaradTopicParameter.getInstance(stack);
+    GuAnghammaradTopicParameter.getInstance(stack);
     expect(getParams(stack)).toEqual(["Stage", "AnghammaradSnsArn"]);
 
     // add the policy
-    attachPolicyToTestRole(stack, AnghammaradSenderPolicy.getInstance(stack));
+    attachPolicyToTestRole(stack, GuAnghammaradSenderPolicy.getInstance(stack));
     expect(getParams(stack)).toEqual(["Stage", "AnghammaradSnsArn"]);
   });
 
   it("should define a policy that would allow writing to SNS", () => {
     const stack = simpleGuStackForTesting();
-    attachPolicyToTestRole(stack, AnghammaradSenderPolicy.getInstance(stack));
+    attachPolicyToTestRole(stack, GuAnghammaradSenderPolicy.getInstance(stack));
 
     expect(stack).toHaveResource("AWS::IAM::Policy", {
       PolicyDocument: {

--- a/src/constructs/iam/policies/anghammarad.ts
+++ b/src/constructs/iam/policies/anghammarad.ts
@@ -1,30 +1,30 @@
 import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../../core";
-import { AnghammaradTopicParameter } from "../../core/parameters/anghammarad";
+import { GuAnghammaradTopicParameter } from "../../core";
 import { GuAllowPolicy } from "./base-policy";
 
 /**
  * Creates an `AWS::IAM::Policy` to grant `sns:Publish` permission to the Anghammarad topic.
  * An `AnghammaradSnsArn` parameter will be automatically added to the stack when needed.
  *
- * @see AnghammaradTopicParameter
+ * @see GuAnghammaradTopicParameter
  * @see https://github.com/guardian/anghammarad
  */
-export class AnghammaradSenderPolicy extends GuAllowPolicy {
-  private static instance: AnghammaradSenderPolicy | undefined;
+export class GuAnghammaradSenderPolicy extends GuAllowPolicy {
+  private static instance: GuAnghammaradSenderPolicy | undefined;
 
   private constructor(scope: GuStack) {
-    const anghammaradTopicParameter = AnghammaradTopicParameter.getInstance(scope);
+    const anghammaradTopicParameter = GuAnghammaradTopicParameter.getInstance(scope);
 
-    super(scope, "GuSESSenderPolicy", {
+    super(scope, "GuAnghammaradSenderPolicy", {
       actions: ["sns:Publish"],
       resources: [anghammaradTopicParameter.valueAsString],
     });
   }
 
-  public static getInstance(stack: GuStack): AnghammaradSenderPolicy {
+  public static getInstance(stack: GuStack): GuAnghammaradSenderPolicy {
     if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
-      this.instance = new AnghammaradSenderPolicy(stack);
+      this.instance = new GuAnghammaradSenderPolicy(stack);
     }
 
     return this.instance;

--- a/src/constructs/iam/policies/index.ts
+++ b/src/constructs/iam/policies/index.ts
@@ -1,4 +1,5 @@
 export * from "./assume-role";
+export * from "./anghammarad";
 export * from "./base-policy";
 export * from "./cloudwatch";
 export * from "./describe-ec2";


### PR DESCRIPTION
Follows #626.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Update the name of `AnghammaradSenderPolicy` to `GuAnghammaradSenderPolicy` to be consistent with the library.

Also add exports to the index files to simplify how the construct gets imported.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No. Nothing is currently using this construct.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Consistent naming and importing to yield a simpler interface to the library.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a