### PR TITLE
feat: Add a construct to ease S3 bucket creation

### DIFF
--- a/src/constructs/s3/__snapshots__/index.test.ts.snap
+++ b/src/constructs/s3/__snapshots__/index.test.ts.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuS3Bucket construct should set the bucket's policy to 'retain' 1`] = `
+Object {
+  "Parameters": Object {
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "MyBucketF68F3FF0": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "BucketName": "super-important-stuff",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;

--- a/src/constructs/s3/index.test.ts
+++ b/src/constructs/s3/index.test.ts
@@ -1,0 +1,17 @@
+import { SynthUtils } from "@aws-cdk/assert";
+import { simpleGuStackForTesting } from "../../utils/test";
+import { GuS3Bucket } from "./index";
+
+describe("The GuS3Bucket construct", () => {
+  it("should set the bucket's policy to 'retain'", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuS3Bucket(stack, "MyBucket", {
+      bucketName: "super-important-stuff",
+    });
+
+    // The policies are siblings of Properties.
+    // The `.toHaveResource` matcher cannot be used as it only looks at Properties.
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+});

--- a/src/constructs/s3/index.ts
+++ b/src/constructs/s3/index.ts
@@ -1,0 +1,17 @@
+import type { BucketProps } from "@aws-cdk/aws-s3";
+import { Bucket } from "@aws-cdk/aws-s3";
+import { RemovalPolicy } from "@aws-cdk/core";
+import { GuMigratableConstruct } from "../../utils/mixin";
+import type { GuStack } from "../core";
+import type { GuMigratingResource } from "../core/migrating";
+
+export interface GuS3BucketProps extends GuMigratingResource, Omit<BucketProps, "removalPolicy"> {}
+
+/**
+ * A construct to create a bucket with a "retain" policy to prevent it from being deleted. It will be orphaned instead.
+ */
+export class GuS3Bucket extends GuMigratableConstruct(Bucket) {
+  constructor(scope: GuStack, id: string, props: GuS3BucketProps) {
+    super(scope, id, { ...props, removalPolicy: RemovalPolicy.RETAIN });
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Guardian best practice is to retain S3 buckets as buckets share a global namespace. `GuS3Bucket` will set the correct policy on the bucket to simplify this.

See:
  - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes and it has been added.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See the added tests?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is easier to create Guardian flavoured buckets.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a