### PR TITLE
chore: Bring package-lock up to date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6670,8 +6670,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",


### PR DESCRIPTION
## What does this change?

I'm getting this small change when installing dependencies (from a clean state) on `main`, so thought it was worth bringing `package-lock.json` up to date.
