### PR TITLE
fix: Remove the `GuStackParameter` construct

### DIFF
--- a/src/constructs/core/parameters/identity.ts
+++ b/src/constructs/core/parameters/identity.ts
@@ -11,12 +11,3 @@ export class GuStageParameter extends GuStringParameter {
     });
   }
 }
-
-export class GuStackParameter extends GuStringParameter {
-  constructor(scope: GuStack) {
-    super(scope, "Stack", {
-      description: "Name of this stack",
-      default: "deploy",
-    });
-  }
-}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A CFN parameter for the stack name is not necessary when defining a stack with GuCDK.

Indeed since #243, `GuStack` takes a mandatory string for `stack` in it's constructor. Due to the changes in #243, it follows that `GuStackParameter` is never used and is dead code. That is, making this a patch release should follow semver... I think!

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Removal of dead code.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a