### PR TITLE
feat!: Make `GuStageParameter` a singleton

### DIFF
--- a/src/constructs/core/parameters/identity.ts
+++ b/src/constructs/core/parameters/identity.ts
@@ -1,13 +1,24 @@
 import { Stage, Stages } from "../../../constants";
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 
 export class GuStageParameter extends GuStringParameter {
-  constructor(scope: GuStack) {
+  private static instance: GuStageParameter | undefined;
+
+  private constructor(scope: GuStack) {
     super(scope, "Stage", {
       description: "Stage name",
       allowedValues: Stages,
       default: Stage.CODE,
     });
+  }
+
+  public static getInstance(stack: GuStack): GuStageParameter {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
+      this.instance = new GuStageParameter(stack);
+    }
+
+    return this.instance;
   }
 }

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -118,7 +118,7 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
     this.params = new Map<string, GuParameter>();
 
     this._stack = props.stack;
-    this._stage = new GuStageParameter(this).valueAsString;
+    this._stage = GuStageParameter.getInstance(this).valueAsString;
 
     this.addTag(TrackingTag.Key, TrackingTag.Value);
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Converts the `GuStageParameter` construct into a singleton to simplify references to it across constructs.

Before, we had to something like:

```typescript
const stage = this.getParam<GuStageParameter>("Stage");
```

With this change, this becomes:

```typescript
GuStageParameter.getInstance(this).valueAsString
```

BREAKING CHANGE: `GuStageParameter` is now a singleton

Making `GuStageParameter` a singleton simplifies access to it. Note, `this.stage` on the `GuStack` is still possible.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No? I think stacks are accessing `stage` via the property on `GuStack`, which hasn't changed.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Accessing `stage` across constructs, particularly in a YAML to CDK process, becomes simpler (see [AMIgo](https://github.com/guardian/amigo/blob/e59a763e895b58c46b3bae346bf1257faeb1fb2b/cdk/lib/amigo.ts#L145)).

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a