### PR TITLE
feat!: Make `GuVpcParameter` a singleton

### DIFF
--- a/src/constructs/core/parameters/vpc.test.ts
+++ b/src/constructs/core/parameters/vpc.test.ts
@@ -2,7 +2,7 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import { simpleGuStackForTesting } from "../../../utils/test";
 import type { SynthedStack } from "../../../utils/test";
-import { GuSubnetListParameter, GuVpcParameter } from "./vpc";
+import { GuSubnetListParameter } from "./vpc";
 
 describe("The GuSubnetListParameter class", () => {
   it("should combine override and prop values", () => {
@@ -14,21 +14,6 @@ describe("The GuSubnetListParameter class", () => {
 
     expect(json.Parameters.Parameter).toEqual({
       Type: "List<AWS::EC2::Subnet::Id>",
-      Description: "This is a test",
-    });
-  });
-});
-
-describe("The GuVpcParameter class", () => {
-  it("should combine override and prop values", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuVpcParameter(stack, "Parameter", { description: "This is a test" });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-
-    expect(json.Parameters.Parameter).toEqual({
-      Type: "AWS::EC2::VPC::Id",
       Description: "This is a test",
     });
   });

--- a/src/constructs/core/parameters/vpc.ts
+++ b/src/constructs/core/parameters/vpc.ts
@@ -1,3 +1,4 @@
+import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuParameter } from "./base";
 import type { GuNoTypeParameterProps } from "./base";
@@ -8,11 +9,28 @@ export class GuSubnetListParameter extends GuParameter {
   }
 }
 
+/**
+ * Adds a "VpcId" parameter to a stack.
+ * This parameter will read from Parameter Store.
+ * By default it will read from `/account/vpc/primary/id`, this can be changed at runtime if needed.
+ */
 export class GuVpcParameter extends GuParameter {
-  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
-    super(scope, id, {
-      ...props,
+  private static instance: GuVpcParameter | undefined;
+
+  private constructor(scope: GuStack) {
+    super(scope, "VpcId", {
+      description: "Virtual Private Cloud to run EC2 instances within",
+      default: "/account/vpc/primary/id",
       type: "AWS::EC2::VPC::Id",
+      fromSSM: true,
     });
+  }
+
+  public static getInstance(stack: GuStack): GuVpcParameter {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
+      this.instance = new GuVpcParameter(stack);
+    }
+
+    return this.instance;
   }
 }

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -7,10 +7,7 @@ interface VpcFromIdProps extends Omit<VpcAttributes, "availabilityZones"> {
   availabilityZones?: string[];
 }
 
-// TODO: Migrate this to use `AppIdentity`
-interface VpcFromIdParameterProps extends Omit<VpcFromIdProps, "vpcId"> {
-  app?: string;
-}
+type VpcFromIdParameterProps = Omit<VpcFromIdProps, "vpcId">;
 
 export enum SubnetType {
   PUBLIC = "Public",
@@ -68,12 +65,7 @@ export class GuVpc {
   }
 
   static fromIdParameter(scope: GuStack, id: string, props?: VpcFromIdParameterProps): IVpc {
-    const vpc = new GuVpcParameter(scope, `${maybeApp(props)}VpcId`, {
-      description: "Virtual Private Cloud to run EC2 instances within",
-      default: "/account/vpc/primary/id",
-      fromSSM: true,
-    });
-
+    const vpc = GuVpcParameter.getInstance(scope);
     return GuVpc.fromId(scope, id, { ...props, vpcId: vpc.valueAsString });
   }
 }

--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -58,6 +58,11 @@ Object {
       "Description": "Stage name",
       "Type": "String",
     },
+    "VpcId": Object {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
     "testguec2appPrivateSubnets": Object {
       "Default": "/account/vpc/primary/subnets/private",
       "Description": "A list of private subnets",
@@ -67,11 +72,6 @@ Object {
       "Default": "/account/vpc/primary/subnets/public",
       "Description": "A list of public subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
-    "testguec2appVpcId": Object {
-      "Default": "/account/vpc/primary/id",
-      "Description": "Virtual Private Cloud to run EC2 instances within",
-      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
   },
   "Resources": Object {
@@ -356,7 +356,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -604,7 +604,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -707,7 +707,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -805,7 +805,7 @@ Object {
         "TargetType": "instance",
         "UnhealthyThresholdCount": 5,
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
@@ -854,7 +854,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -921,6 +921,11 @@ Object {
       "Description": "Stage name",
       "Type": "String",
     },
+    "VpcId": Object {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
     "testguec2appPrivateSubnets": Object {
       "Default": "/account/vpc/primary/subnets/private",
       "Description": "A list of private subnets",
@@ -930,11 +935,6 @@ Object {
       "Default": "/account/vpc/primary/subnets/public",
       "Description": "A list of public subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
-    "testguec2appVpcId": Object {
-      "Default": "/account/vpc/primary/id",
-      "Description": "Virtual Private Cloud to run EC2 instances within",
-      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
   },
   "Resources": Object {
@@ -1219,7 +1219,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -1449,7 +1449,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -1587,7 +1587,7 @@ Object {
         "TargetType": "instance",
         "UnhealthyThresholdCount": 5,
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
@@ -1636,7 +1636,7 @@ Object {
           },
         ],
         "VpcId": Object {
-          "Ref": "testguec2appVpcId",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -343,7 +343,7 @@ export class GuEc2App {
     AppIdentity.taggedConstruct(props, scope);
 
     const { app } = props;
-    const vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText(props, "VPC"), { app });
+    const vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText(props, "VPC"));
     const privateSubnets = GuVpc.subnetsfromParameter(scope, { type: SubnetType.PRIVATE, app });
 
     if (props.access.scope === AccessScope.RESTRICTED) validateRestrictedCidrRanges(props.access);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As we do not run multiple apps in the same stack across multiple VPCs, we can make `GuVpcParameter` a singleton.

`GuVpcParameter` always reads from Parameter Store now. By default it reads from `/account/vpc/primary/id`, where `/account/vpc/primary/id` is the primary VPC used in an account. If teams use multiple VPCs, they are able to change this path at runtime.

BREAKING CHANGE: The `GuVpcParameter` construct is now a singleton.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

It shouldn't. Most stacks are using the `GuVpc.fromIdParameter` function which adds the parameter, rather than using the parameter directly. As the signature of `GuVpc.fromIdParameter` hasn't changed, existing stacks should be able to blindly update the version of the library being used.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Yes, added.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler API.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a