### PR TITLE
fix: Fix naming of `subnetsFromParameter` static function

### DIFF
--- a/src/constructs/ec2/vpc.test.ts
+++ b/src/constructs/ec2/vpc.test.ts
@@ -22,7 +22,7 @@ describe("The GuVpc class", () => {
     test("adds the parameter with default type as private", () => {
       const stack = simpleGuStackForTesting();
 
-      GuVpc.subnetsfromParameter(stack);
+      GuVpc.subnetsFromParameter(stack);
 
       const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
@@ -36,7 +36,7 @@ describe("The GuVpc class", () => {
     test("adds a public subnets parameter if the type is public", () => {
       const stack = simpleGuStackForTesting();
 
-      GuVpc.subnetsfromParameter(stack, { type: SubnetType.PUBLIC });
+      GuVpc.subnetsFromParameter(stack, { type: SubnetType.PUBLIC });
 
       const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -45,7 +45,7 @@ export class GuVpc {
     );
   }
 
-  static subnetsfromParameter(scope: GuStack, props?: GuSubnetProps): ISubnet[] {
+  static subnetsFromParameter(scope: GuStack, props?: GuSubnetProps): ISubnet[] {
     const type = props?.type ?? SubnetType.PRIVATE;
 
     const subnets = new GuSubnetListParameter(scope, `${maybeApp(props)}${type}Subnets`, {

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -344,7 +344,7 @@ export class GuEc2App {
 
     const { app } = props;
     const vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText(props, "VPC"));
-    const privateSubnets = GuVpc.subnetsfromParameter(scope, { type: SubnetType.PRIVATE, app });
+    const privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app });
 
     if (props.access.scope === AccessScope.RESTRICTED) validateRestrictedCidrRanges(props.access);
     if (props.access.scope === AccessScope.INTERNAL) validateInternalCidrRanges(props.access);
@@ -402,7 +402,7 @@ export class GuEc2App {
         subnets:
           props.access.scope === AccessScope.INTERNAL
             ? privateSubnets
-            : GuVpc.subnetsfromParameter(scope, { type: SubnetType.PUBLIC, app }),
+            : GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       },
     });
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

`subnetsfromParameter` becomes `subnetsFromParameter` (the `f` should be capitalised).
