### PR TITLE
feat: Add a CLI to the repository

### DIFF
--- a/bin/gu-cdk
+++ b/bin/gu-cdk
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+// The file `index.js` is created at build time.
+// To use the CLI locally run `./script/cli`.
+require('../lib/bin/index.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,6 +2481,30 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+      "dev": true
+    },
     "@types/aws-lambda": {
       "version": "8.10.78",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.78.tgz",
@@ -4248,6 +4272,12 @@
           "dev": true
         }
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -14278,6 +14308,38 @@
         }
       }
     },
+    "ts-node": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
+      "dev": true,
+      "requires": {
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.0.tgz",
@@ -14975,6 +15037,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1960,6 +1960,15 @@
         "chalk": "^4.0.0"
       },
       "dependencies": {
+        "@types/yargs": {
+          "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "chalk": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -2616,9 +2625,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "15.0.14",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
-      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.2.tgz",
+      "integrity": "sha512-JhZ+pNdKMfB0rXauaDlrIvm+U7V4m03PPOSVoPS66z8gf+G4Z/UW8UlrVIj2MRQOBzuoEvYtjS0bqYwnpZaS9Q==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
@@ -3918,14 +3927,13 @@
       }
     },
     "cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^7.0.0"
       }
     },
     "clone-response": {
@@ -4770,8 +4778,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -5835,8 +5842,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -7076,6 +7082,17 @@
             "supports-color": "^7.1.0"
           }
         },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7101,6 +7118,27 @@
             "jest-validate": "^26.6.2",
             "prompts": "^2.0.1",
             "yargs": "^15.4.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "15.4.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+              "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+              "dev": true,
+              "requires": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+              }
+            }
           }
         },
         "supports-color": {
@@ -7110,6 +7148,33 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -7669,6 +7734,15 @@
         "yargs": "^15.4.1"
       },
       "dependencies": {
+        "@types/yargs": {
+          "version": "15.0.14",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+          "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
         "chalk": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -7677,6 +7751,17 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
         "has-flag": {
@@ -7698,6 +7783,52 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -12388,8 +12519,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -14739,10 +14869,9 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -14812,10 +14941,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -14830,33 +14958,23 @@
       "dev": true
     },
     "yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
+      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
       "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       }
     },
     "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "release": "semantic-release",
     "release:docs": "rm -rf target && typedoc && gh-pages -d target -u \"github-actions-bot <support+actions@github.com>\"",
     "serve:docs": "rm -rf target && typedoc && serve target",
-    "update-aws-cdk": "ncu \"/^@?aws-cdk(/.*)?$/\" --upgrade --deep"
+    "update-aws-cdk": "ncu \"/^@?aws-cdk(/.*)?$/\" --upgrade --deep",
+    "cli:dev": "ts-node src/bin/index.ts"
   },
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^0.6.0",
@@ -42,6 +43,7 @@
     "semantic-release": "^17.4.4",
     "serve": "^12.0.0",
     "ts-jest": "^26.5.6",
+    "ts-node": "^10.0.0",
     "typedoc": "^0.21.4",
     "typescript": "~4.3.4"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "files": [
     "lib"
   ],
+  "bin": {
+    "gu-cdk": "bin/gu-cdk"
+  },
   "repository": "github:guardian/cdk",
   "scripts": {
     "build": "tsc",
@@ -28,6 +31,7 @@
     "@types/git-url-parse": "^9.0.1",
     "@types/jest": "^26.0.24",
     "@types/node": "16.3.2",
+    "@types/yargs": "^17.0.2",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.29.0",
     "eslint-plugin-custom-rules": "file:tools/eslint",
@@ -60,7 +64,8 @@
     "aws-sdk": "^2.945.0",
     "execa": "^5.1.1",
     "git-url-parse": "^11.5.0",
-    "read-pkg-up": "7.0.1"
+    "read-pkg-up": "7.0.1",
+    "yargs": "^17.0.1"
   },
   "config": {
     "commitizen": {

--- a/script/cli
+++ b/script/cli
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+EXTRA_ARGS=""
+if [[ $# -gt 0 ]] ; then
+  # npm requires `--` for argument passing
+  # see https://docs.npmjs.com/cli/v6/commands/npm-run-script
+  EXTRA_ARGS="-- $*"
+fi
+
+# shellcheck disable=SC2086
+npm run cli:dev $EXTRA_ARGS

--- a/src/bin/commands/aws-cdk-version.ts
+++ b/src/bin/commands/aws-cdk-version.ts
@@ -1,0 +1,6 @@
+import { LibraryInfo } from "../../constants/library-info";
+
+export const awsCdkVersionCommand = (verbose: boolean): void => {
+  const response = verbose ? JSON.stringify(LibraryInfo.AWS_CDK_VERSIONS) : LibraryInfo.AWS_CDK_VERSION;
+  console.log(response);
+};

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import yargs from "yargs";
+import { LibraryInfo } from "../constants/library-info";
+import { awsCdkVersionCommand } from "./commands/aws-cdk-version";
+
+const Commands = {
+  AwsCdkVersion: "aws-cdk-version",
+};
+
+const parseCommandLineArguments = () => {
+  /*
+  The type of `yargs.argv` is `T | Promise<T>`.
+  To avoid creating custom type guards, use `Promise.resolve` which takes `T | PromiseLike<T>` and returns `Promise<T>`.
+  That is, use `Promise.resolve` to provide a single type.
+  See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7b2f0d45985538a40df96244481bfc6cd309c250/types/yargs/index.d.ts#L74
+   */
+  return Promise.resolve(
+    yargs
+      .usage("$0 COMMAND [args]")
+      .option("verbose", { type: "boolean", default: false, description: "Show verbose output" })
+      .command(Commands.AwsCdkVersion, "Print the version of @aws-cdk libraries being used")
+      .version(`${LibraryInfo.VERSION} (using @aws-cdk ${LibraryInfo.AWS_CDK_VERSION})`)
+      .demandCommand(1, "") // just print help
+      .help()
+      .alias("h", "help").argv
+  );
+};
+
+parseCommandLineArguments()
+  .then((argv) => {
+    const command = argv._[0];
+    const { verbose } = argv;
+    switch (command) {
+      case Commands.AwsCdkVersion:
+        return awsCdkVersionCommand(verbose);
+      default:
+        throw new Error(`Unknown command: ${command}`);
+    }
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  });

--- a/src/constants/__mocks__/tracking-tag.ts
+++ b/src/constants/__mocks__/tracking-tag.ts
@@ -1,10 +1,6 @@
 import { TagKeys } from "../tag-keys";
 
-export const LibraryInfo = {
-  VERSION: "TEST",
-};
-
 export const TrackingTag = {
   Key: TagKeys.TRACKING_TAG,
-  Value: LibraryInfo.VERSION,
+  Value: "TEST",
 };

--- a/src/constants/library-info.ts
+++ b/src/constants/library-info.ts
@@ -1,0 +1,10 @@
+import readPkgUp from "read-pkg-up";
+
+const version = readPkgUp.sync({ cwd: __dirname })?.packageJson.version ?? "unknown";
+
+export const LibraryInfo = {
+  /**
+   * The current version of `@guardian/cdk`.
+   */
+  VERSION: version,
+};

--- a/src/constants/library-info.ts
+++ b/src/constants/library-info.ts
@@ -1,10 +1,31 @@
 import readPkgUp from "read-pkg-up";
 
-const version = readPkgUp.sync({ cwd: __dirname })?.packageJson.version ?? "unknown";
+const packageJson = readPkgUp.sync({ cwd: __dirname })?.packageJson;
+
+const version = packageJson?.version ?? "unknown";
+
+const dependencies = packageJson?.dependencies ?? {};
+
+const awsCdkDependencies: Record<string, string> = Object.fromEntries(
+  Object.entries(dependencies).filter(([dependency]) => dependency.startsWith("@aws-cdk"))
+);
+
+const awsCdkCoreVersion = awsCdkDependencies["@aws-cdk/core"];
 
 export const LibraryInfo = {
   /**
    * The current version of `@guardian/cdk`.
    */
   VERSION: version,
+
+  /**
+   * The version of the `@aws-cdk` libraries used by `@guardian/cdk`.
+   * You need to match this version exactly.
+   */
+  AWS_CDK_VERSION: awsCdkCoreVersion,
+
+  /**
+   * A complete list of the `@aws-cdk` libraries used by `@guardian/cdk`.
+   */
+  AWS_CDK_VERSIONS: awsCdkDependencies,
 };

--- a/src/constants/tracking-tag.ts
+++ b/src/constants/tracking-tag.ts
@@ -1,11 +1,5 @@
-import readPkgUp from "read-pkg-up";
+import { LibraryInfo } from "./library-info";
 import { TagKeys } from "./tag-keys";
-
-const version = readPkgUp.sync({ cwd: __dirname })?.packageJson.version ?? "unknown";
-
-export const LibraryInfo = {
-  VERSION: version,
-};
 
 export const TrackingTag = {
   Key: TagKeys.TRACKING_TAG,


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Add a CLI to the repository 🎉 .

This is the start of a process to bring [`@guardian/cdk-cli`](https://github.com/guardian/cdk-cli) into this repository as it makes it easier to keep the CLI up to date (we should be able to use the compiler to tell us if we've changed a type but forgot to update the CLI). Yay mono-repos!

This change adds one command `aws-cdk-version` to print the version of `aws-cdk` libraries being used. We should be able to invoke it by doing `npx @guardian/cdk aws-cdk-version` 🤞🏽 .

There's also a helpful script to invoke the CLI in DEV - `./script/cli`.

This is heavily inspired by the [AWS CDK CLI](https://github.com/aws/aws-cdk/blob/71c0a4c413e77452f47c797d4e861aa542174ce9/packages/aws-cdk/bin/cdk.ts).

### Example output

```console
➜ npx @guardian/cdk --help
@guardian/cdk aws-cdk-version

Print the version of @aws-cdk libraries being used

Options:
      --verbose  Show verbose output                  [boolean] [default: false]
      --version  Show version number                                   [boolean]
  -h, --help     Show help                                             [boolean]
```

```console
➜ npx @guardian/cdk --version
22.0.1 (using @aws-cdk 1.110.1)
```

```console
➜ npx @guardian/cdk aws-cdk-version
1.110.1
```

```console
➜ npx @guardian/cdk aws-cdk-version --verbose | jq .
{
  "@aws-cdk/assert": "1.110.1",
  "@aws-cdk/aws-apigateway": "1.110.1",
  "@aws-cdk/aws-autoscaling": "1.110.1",
  "@aws-cdk/aws-cloudwatch-actions": "1.110.1",
  "@aws-cdk/aws-ec2": "1.110.1",
  "@aws-cdk/aws-elasticloadbalancing": "1.110.1",
  "@aws-cdk/aws-elasticloadbalancingv2": "1.110.1",
  "@aws-cdk/aws-events-targets": "1.110.1",
  "@aws-cdk/aws-iam": "1.110.1",
  "@aws-cdk/aws-kinesis": "1.110.1",
  "@aws-cdk/aws-lambda": "1.110.1",
  "@aws-cdk/aws-lambda-event-sources": "1.110.1",
  "@aws-cdk/aws-rds": "1.110.1",
  "@aws-cdk/aws-s3": "1.110.1",
  "@aws-cdk/core": "1.110.1"
}
```

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Nope.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

Eventually, yes we should document the CLI, however I propose leaving it until its more mature and we know exactly what commands we'll have.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

- Checkout this branch
- Install deps: `./script/setup`
- Build: `./script/build`
- Run [`npm link`](https://docs.npmjs.com/cli/v6/commands/npm-link)
- Move to a different directory (e.g. `/tmp`)
- Make sure you're on the same node version as the library, 14.15.1
- Run `npm link @guardian/cdk` to install the library from the local filesystem
- ~Run `npx @guardian/cdk aws-cdk-version` and observe some output~ I think this will only work properly once published (#686 should help confirm this)
- Run `npx gu-cdk aws-cdk-version` and observe some output 🎉 

<details>
<summary>Alternatively, we can use Docker:</summary>

```console
docker run -it --rm -u node node:14.15.1 /bin/bash -c "npm config set prefix /home/node; mkdir -p /tmp/code; cd /tmp/code; wget https://github.com/guardian/cdk/archive/refs/heads/aa-cli.zip --quiet; unzip -q aa-cli.zip; cd cdk-aa-cli; npm install; npm run build; npm link; mkdir -p /tmp/cli-test; cd /tmp/cli-test; npm link @guardian/cdk; npx gu-cdk"
```

It looks like a lot, but we can break it down (left to right):
  1. Launch a Docker container using the image `node:14.15.1` and run some bash
  2. Set the `npm prefix`. This, combined with the `-u` flag helps combat an [issue with `aws-sdk`](https://github.com/aws/aws-sdk-js/issues/3763).
  4. Download this branch from GitHub and extract it into `/tmp/code`
  5. Build the package
  6. `npm link` the package
  7. Move to a new folder (`/tmp/cli-test`)
  8. Link the recently built package
  9. Execute the CLI with `npx`

</details>

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The CLI and library live in the same repo!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As we're publishing the CLI in the same package as the constructs and patterns, they would be importable into application code. The alternative to this would be to publish the CLI as a different package and using something like Lerna or workspaces to keep a mono-repo. That requires quite a bit of setup though...