### PR TITLE
fix: Set the package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@guardian/cdk",
+  "description": "Generic Guardian flavoured AWS CDK components",
   "version": "22.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

If not explicitly set, it looks like NPM will use the first line of the README.md as the description.

Using `npm view  @guardian/cdk --json | jq .description`, we can see the current description of `@guardian/cdk` in NPM is `"![npm][badge-npm] [![CD][badge-cd]][internal-cd-file]"`.

This change explicitly sets the description field.