### PR TITLE
feat: Add `account-readiness` CLI command 

### DIFF
--- a/src/bin/aws-credential-provider.ts
+++ b/src/bin/aws-credential-provider.ts
@@ -1,0 +1,12 @@
+import type { CredentialProviderChain } from "aws-sdk";
+import AWS from "aws-sdk";
+
+export const awsCredentialProviderChain: (profile: string | undefined) => CredentialProviderChain = (
+  profile: string | undefined
+) => {
+  const envCredentials = () => new AWS.EnvironmentCredentials("AWS");
+
+  return profile
+    ? new AWS.CredentialProviderChain([envCredentials, () => new AWS.SharedIniFileCredentials({ profile })])
+    : new AWS.CredentialProviderChain([envCredentials]);
+};

--- a/src/bin/commands/account-readiness.ts
+++ b/src/bin/commands/account-readiness.ts
@@ -1,0 +1,38 @@
+import type { CredentialProviderChain } from "aws-sdk";
+import AWS from "aws-sdk";
+import { SSM_PARAMETER_PATHS } from "../../constants/ssm-parameter-paths";
+
+export const accountReadinessCommand = async ({
+  credentialProvider,
+  region,
+  verbose,
+}: {
+  credentialProvider: CredentialProviderChain;
+  region: string;
+  verbose: boolean;
+}) => {
+  const ssm = new AWS.SSM({
+    credentialProvider,
+    region,
+  });
+
+  const ssmParams = Object.values(SSM_PARAMETER_PATHS);
+  const paths: string[] = ssmParams.map((param) => param.path);
+
+  const awsResponse = await ssm.getParameters({ Names: paths }).promise();
+
+  const foundParameters = awsResponse.Parameters ?? [];
+  const notFoundParameters = awsResponse.InvalidParameters ?? [];
+
+  if (!verbose) {
+    const messagePrefix = notFoundParameters.length === 0 ? "OK" : "ACTION NEEDED";
+
+    return Promise.resolve(
+      `[${messagePrefix}] ${foundParameters.length}/${ssmParams.length} SSM parameters found. ${notFoundParameters.length}/${ssmParams.length} SSM parameters not found.`
+    );
+  } else {
+    const notFoundInDetail = ssmParams.filter((_) => notFoundParameters.includes(_.path));
+    const foundInDetail = ssmParams.filter((_) => !notFoundParameters.includes(_.path));
+    return Promise.resolve({ found: foundInDetail, notFound: notFoundInDetail });
+  }
+};

--- a/src/bin/commands/aws-cdk-version.ts
+++ b/src/bin/commands/aws-cdk-version.ts
@@ -1,6 +1,5 @@
 import { LibraryInfo } from "../../constants/library-info";
 
-export const awsCdkVersionCommand = (verbose: boolean): void => {
-  const response = verbose ? JSON.stringify(LibraryInfo.AWS_CDK_VERSIONS) : LibraryInfo.AWS_CDK_VERSION;
-  console.log(response);
+export const awsCdkVersionCommand = (verbose: boolean): Promise<string | Record<string, string>> => {
+  return Promise.resolve(verbose ? LibraryInfo.AWS_CDK_VERSIONS : LibraryInfo.AWS_CDK_VERSION);
 };

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -27,8 +27,18 @@ const parseCommandLineArguments = () => {
   );
 };
 
+// A CLI command can return...
+type CliCommandResponse = Promise<
+  // ...a simple message to be printed
+  | string
+  // ...or a blob of JSON to be printed via `JSON.stringify`
+  | Record<string, unknown>
+  // ...or an exit code
+  | number
+>;
+
 parseCommandLineArguments()
-  .then((argv) => {
+  .then((argv): CliCommandResponse => {
     const command = argv._[0];
     const { verbose } = argv;
     switch (command) {
@@ -36,6 +46,15 @@ parseCommandLineArguments()
         return awsCdkVersionCommand(verbose);
       default:
         throw new Error(`Unknown command: ${command}`);
+    }
+  })
+  .then((commandResponse) => {
+    if (typeof commandResponse === "number") {
+      process.exitCode = commandResponse;
+    } else if (typeof commandResponse === "string") {
+      console.log(commandResponse);
+    } else {
+      console.log(JSON.stringify(commandResponse));
     }
   })
   .catch((err) => {

--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -1,0 +1,39 @@
+export interface SsmParameterPath {
+  path: string;
+  description: string;
+}
+
+export const SSM_PARAMETER_PATHS: Record<string, SsmParameterPath> = {
+  Anghammarad: {
+    path: "/account/services/anghammarad.topic.arn",
+    description: "SSM parameter containing the ARN of the Anghammarad SNS topic",
+  },
+  LoggingStreamName: {
+    path: "/account/services/logging.stream.name",
+    description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
+  },
+  DistributionBucket: {
+    path: "/account/services/artifact.bucket",
+    description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
+  },
+  ConfigurationBucket: {
+    path: "/account/services/private.config.bucket",
+    description: "SSM parameter containing the S3 bucket name holding the app's private configuration",
+  },
+  PrimaryVpcId: {
+    path: "/account/vpc/primary/id",
+    description: "Virtual Private Cloud to run EC2 instances within",
+  },
+  AccessLoggingBucket: {
+    path: "/account/services/access-logging/bucket",
+    description: "S3 bucket to store your access logs",
+  },
+  PrimaryVpcPrivateSubnets: {
+    path: "/account/vpc/primary/subnets/private",
+    description: "A list of private subnets",
+  },
+  PrimaryVpcPublicSubnets: {
+    path: "/account/vpc/primary/subnets/public",
+    description: "A list of public subnets",
+  },
+};

--- a/src/constructs/core/parameters/anghammarad.ts
+++ b/src/constructs/core/parameters/anghammarad.ts
@@ -1,3 +1,4 @@
+import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
 import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -14,8 +15,8 @@ export class GuAnghammaradTopicParameter extends GuStringParameter {
   private constructor(scope: GuStack) {
     super(scope, "AnghammaradSnsArn", {
       fromSSM: true,
-      default: "/account/services/anghammarad.topic.arn",
-      description: "SSM parameter containing the ARN of the Anghammarad SNS topic",
+      default: SSM_PARAMETER_PATHS.Anghammarad.path,
+      description: SSM_PARAMETER_PATHS.Anghammarad.description,
     });
   }
 

--- a/src/constructs/core/parameters/log-shipping.ts
+++ b/src/constructs/core/parameters/log-shipping.ts
@@ -1,3 +1,4 @@
+import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
 import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -7,8 +8,8 @@ export class GuLoggingStreamNameParameter extends GuStringParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "LoggingStreamName", {
-      description: "SSM parameter containing the Name (not ARN) on the kinesis stream",
-      default: "/account/services/logging.stream.name",
+      description: SSM_PARAMETER_PATHS.LoggingStreamName.description,
+      default: SSM_PARAMETER_PATHS.LoggingStreamName.path,
       fromSSM: true,
     });
   }

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -1,3 +1,4 @@
+import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
 import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -11,8 +12,8 @@ export class GuDistributionBucketParameter extends GuStringParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "DistributionBucketName", {
-      description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
-      default: "/account/services/artifact.bucket",
+      description: SSM_PARAMETER_PATHS.DistributionBucket.description,
+      default: SSM_PARAMETER_PATHS.DistributionBucket.path,
       fromSSM: true,
     });
   }
@@ -31,8 +32,8 @@ export class GuPrivateConfigBucketParameter extends GuStringParameter {
 
   constructor(scope: GuStack) {
     super(scope, GuPrivateConfigBucketParameter.parameterName, {
-      description: "SSM parameter containing the S3 bucket name holding the app's private configuration",
-      default: "/account/services/private.config.bucket",
+      description: SSM_PARAMETER_PATHS.ConfigurationBucket.description,
+      default: SSM_PARAMETER_PATHS.ConfigurationBucket.path,
       fromSSM: true,
     });
   }

--- a/src/constructs/core/parameters/vpc.ts
+++ b/src/constructs/core/parameters/vpc.ts
@@ -1,3 +1,4 @@
+import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
 import { isSingletonPresentInStack } from "../../../utils/test";
 import type { GuStack } from "../stack";
 import { GuParameter } from "./base";
@@ -19,8 +20,8 @@ export class GuVpcParameter extends GuParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "VpcId", {
-      description: "Virtual Private Cloud to run EC2 instances within",
-      default: "/account/vpc/primary/id",
+      description: SSM_PARAMETER_PATHS.PrimaryVpcId.description,
+      default: SSM_PARAMETER_PATHS.PrimaryVpcId.path,
       type: "AWS::EC2::VPC::Id",
       fromSSM: true,
     });

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -9,6 +9,7 @@ interface VpcFromIdProps extends Omit<VpcAttributes, "availabilityZones"> {
 
 type VpcFromIdParameterProps = Omit<VpcFromIdProps, "vpcId">;
 
+// TODO convert to boolean
 export enum SubnetType {
   PUBLIC = "Public",
   PRIVATE = "Private",
@@ -50,6 +51,8 @@ export class GuVpc {
 
     const subnets = new GuSubnetListParameter(scope, `${maybeApp(props)}${type}Subnets`, {
       description: `A list of ${type.toLowerCase()} subnets`,
+
+      // TODO use `SSM_PARAMETER_PATHS.PrimaryVpcPrivateSubnets` or `SSM_PARAMETER_PATHS.PrimaryVpcPublicSubnets`
       default: `/account/vpc/primary/subnets/${type.toLowerCase()}`,
       fromSSM: true,
     });

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -6,6 +6,7 @@ import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration, Tags } from "@aws-cdk/core";
 import type { Stage } from "../constants";
+import { SSM_PARAMETER_PATHS } from "../constants/ssm-parameter-paths";
 import { TagKeys } from "../constants/tag-keys";
 import type { GuCertificateProps } from "../constructs/acm";
 import { GuCertificate } from "../constructs/acm";
@@ -408,8 +409,8 @@ export class GuEc2App {
 
     if (props.accessLogging?.enabled) {
       const accessLoggingBucket = new GuStringParameter(scope, "AccessLoggingBucket", {
-        description: "S3 bucket to store your access logs",
-        default: "/account/services/access-logging/bucket",
+        description: SSM_PARAMETER_PATHS.AccessLoggingBucket.description,
+        default: SSM_PARAMETER_PATHS.AccessLoggingBucket.path,
         fromSSM: true,
       });
 


### PR DESCRIPTION
Requires #675.

It might be easier to review commit by commit.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The `account-readiness` CLI command will check for the existence of SSM parameters in an account.

Note: It does not check if the value is correct, just that it exists. Although `LoggingStreamName` is described as "Name (not ARN)", this command will not validate the value in parameter store against this requirement.

The command supports the `--profile` and `--region` flags, similar to AWS's CLI.

### Example output

#### Happy path (non-verbose)

```console
[OK] 8/8 SSM parameters found. 0/8 SSM parameters not found.
```

#### Unhappy path (non-verbose)

```console
[ACTION NEEDED] 0/8 SSM parameters found. 8/8 SSM parameters not found.
```

#### Happy path (verbose mode)

```console
{
  "found": [
    {
      "path": "/account/services/anghammarad.topic.arn",
      "description": "SSM parameter containing the ARN of the Anghammarad SNS topic"
    },
    {
      "path": "/account/services/logging.stream.name",
      "description": "SSM parameter containing the Name (not ARN) on the kinesis stream"
    },
    {
      "path": "/account/services/artifact.bucket",
      "description": "SSM parameter containing the S3 bucket name holding distribution artifacts"
    },
    {
      "path": "/account/services/private.config.bucket",
      "description": "SSM parameter containing the S3 bucket name holding the app's private configuration"
    },
    {
      "path": "/account/vpc/primary/id",
      "description": "Virtual Private Cloud to run EC2 instances within"
    },
    {
      "path": "/account/services/access-logging/bucket",
      "description": "S3 bucket to store your access logs"
    },
    {
      "path": "/account/vpc/primary/subnets/private",
      "description": "A list of private subnets"
    },
    {
      "path": "/account/vpc/primary/subnets/public",
      "description": "A list of public subnets"
    }
  ],
  "notFound": []
}
```

#### Unhappy path (verbose mode)

```console
{
  "found": [],
  "notFound": [
    {
      "path": "/account/services/anghammarad.topic.arn",
      "description": "SSM parameter containing the ARN of the Anghammarad SNS topic"
    },
    {
      "path": "/account/services/logging.stream.name",
      "description": "SSM parameter containing the Name (not ARN) on the kinesis stream"
    },
    {
      "path": "/account/services/artifact.bucket",
      "description": "SSM parameter containing the S3 bucket name holding distribution artifacts"
    },
    {
      "path": "/account/services/private.config.bucket",
      "description": "SSM parameter containing the S3 bucket name holding the app's private configuration"
    },
    {
      "path": "/account/vpc/primary/id",
      "description": "Virtual Private Cloud to run EC2 instances within"
    },
    {
      "path": "/account/services/access-logging/bucket",
      "description": "S3 bucket to store your access logs"
    },
    {
      "path": "/account/vpc/primary/subnets/private",
      "description": "A list of private subnets"
    },
    {
      "path": "/account/vpc/primary/subnets/public",
      "description": "A list of public subnets"
    }
  ]
}
```

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

Assuming the changes in #675 haven't broken the published version of the package:
  - Checkout this branch
  - Run `./script/build`
  - Run `./script/cli account-readiness --profile deployTools` or `./script/cli account-readiness --profile deployTools --verbose` to see output

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We're able to identify if an account is ready for GuCDK with ease.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a