### PR TITLE
feat: Add check-package-json CLI command

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,2 @@
 jest.mock("./src/constants/tracking-tag");
+jest.mock("./src/constants/library-info");

--- a/src/bin/commands/check-package-json.test.ts
+++ b/src/bin/commands/check-package-json.test.ts
@@ -1,0 +1,72 @@
+import { promises } from "fs";
+import { checkPackageJson } from "./check-package-json";
+
+describe("checkPackageJson", () => {
+  const mockPackageJson = (content: unknown) => {
+    jest.spyOn(promises, "access").mockReturnValue(Promise.resolve());
+    jest.spyOn(promises, "readFile").mockReturnValue(Promise.resolve(JSON.stringify(content)));
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should succeed when the versions match exactly", async () => {
+    mockPackageJson({
+      dependencies: {
+        "aws-cdk": "0.0.1",
+        "@aws-cdk/aws-ec2": "0.0.1",
+      },
+    });
+
+    const actual = await checkPackageJson("/tmp");
+
+    const expected = {
+      file: "/tmp/package.json",
+      incorrectDependencies: {},
+      incorrectDevDependencies: {},
+      versionExpected: "0.0.1",
+    };
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should fail when the versions do not match exactly", async () => {
+    mockPackageJson({
+      dependencies: {
+        "aws-cdk": "^0.0.1",
+        "@aws-cdk/aws-ec2": "0.0.1",
+      },
+      devDependencies: {
+        "@aws-cdk/aws-iam": "0.0.2",
+      },
+    });
+
+    try {
+      await checkPackageJson("/tmp");
+    } catch (actual) {
+      const expected = {
+        file: "/tmp/package.json",
+        incorrectDependencies: {
+          "aws-cdk": "^0.0.1",
+        },
+        incorrectDevDependencies: {
+          "@aws-cdk/aws-iam": "0.0.2",
+        },
+        versionExpected: "0.0.1",
+      };
+      expect(actual).toStrictEqual(expected);
+    }
+  });
+
+  it("should fail when the package.json file does not exist", async () => {
+    jest.spyOn(promises, "access").mockReturnValue(Promise.reject());
+
+    try {
+      await checkPackageJson("/tmp");
+    } catch (actual) {
+      const expected = "File not found: /tmp/package.json";
+      expect(actual).toBe(expected);
+    }
+  });
+});

--- a/src/bin/commands/check-package-json.ts
+++ b/src/bin/commands/check-package-json.ts
@@ -1,0 +1,39 @@
+import { access, readFile } from "fs/promises";
+import path from "path";
+import type { PackageJson } from "read-pkg-up";
+import { LibraryInfo } from "../../constants/library-info";
+import type { CliCommandResponse } from "../../types/command";
+import { getAwsCdkDependencies } from "../../utils/package-json";
+
+const filterVersionMismatch = (deps: Record<string, string>) =>
+  Object.fromEntries(Object.entries(deps).filter(([, version]) => version !== LibraryInfo.AWS_CDK_VERSION));
+
+export const checkPackageJson = async (directory: string): CliCommandResponse => {
+  const packageJsonPath = path.join(directory, "package.json");
+
+  try {
+    await access(packageJsonPath);
+  } catch (error) {
+    return Promise.reject(`File not found: ${packageJsonPath}`);
+  }
+
+  const fileContent = await readFile(packageJsonPath, { encoding: "utf8" });
+  const packageJson = JSON.parse(fileContent) as PackageJson;
+
+  const { dependencies, devDependencies } = getAwsCdkDependencies(packageJson);
+
+  const depsMismatch = filterVersionMismatch(dependencies);
+  const devDepsMismatch = filterVersionMismatch(devDependencies);
+  const totalMismatch = Object.keys(depsMismatch).length + Object.keys(devDepsMismatch).length;
+
+  const isOk = totalMismatch === 0;
+
+  const response = {
+    file: packageJsonPath,
+    versionExpected: LibraryInfo.AWS_CDK_VERSION,
+    incorrectDependencies: depsMismatch,
+    incorrectDevDependencies: devDepsMismatch,
+  };
+
+  return isOk ? Promise.resolve(response) : Promise.reject(response);
+};

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -6,10 +6,12 @@ import type { CliCommandResponse } from "../types/command";
 import { awsCredentialProviderChain } from "./aws-credential-provider";
 import { accountReadinessCommand } from "./commands/account-readiness";
 import { awsCdkVersionCommand } from "./commands/aws-cdk-version";
+import { checkPackageJson } from "./commands/check-package-json";
 
 const Commands = {
   AwsCdkVersion: "aws-cdk-version",
   AccountReadiness: "account-readiness",
+  CheckPackageJson: "check-package-json",
 };
 
 const parseCommandLineArguments = () => {
@@ -26,6 +28,14 @@ const parseCommandLineArguments = () => {
       .option("region", { type: "string", description: "AWS region", default: "eu-west-1" })
       .command(Commands.AwsCdkVersion, "Print the version of @aws-cdk libraries being used")
       .command(Commands.AccountReadiness, "Perform checks on an AWS account to see if it is GuCDK ready")
+      .command(Commands.CheckPackageJson, "Check a package.json file for compatibility with GuCDK", (yargs) =>
+        yargs.option("directory", {
+          type: "string",
+          description: "The location of the package.json file to check",
+          default: process.cwd(),
+          defaultDescription: "The current working directory",
+        })
+      )
       .version(`${LibraryInfo.VERSION} (using @aws-cdk ${LibraryInfo.AWS_CDK_VERSION})`)
       .demandCommand(1, "") // just print help
       .help()
@@ -42,6 +52,10 @@ parseCommandLineArguments()
         return awsCdkVersionCommand();
       case Commands.AccountReadiness:
         return accountReadinessCommand({ credentialProvider: awsCredentialProviderChain(profile), region });
+      case Commands.CheckPackageJson: {
+        const { directory } = argv;
+        return checkPackageJson(directory);
+      }
       default:
         throw new Error(`Unknown command: ${command}`);
     }

--- a/src/constants/__mocks__/library-info.ts
+++ b/src/constants/__mocks__/library-info.ts
@@ -1,0 +1,10 @@
+const mockAwsCdkVersion = "0.0.1";
+
+export const LibraryInfo = {
+  VERSION: "1.0.0",
+  AWS_CDK_VERSION: mockAwsCdkVersion,
+  AWS_CDK_VERSIONS: {
+    "aws-cdk": mockAwsCdkVersion,
+    "@aws-cdk/core": mockAwsCdkVersion,
+  },
+};

--- a/src/constants/library-info.ts
+++ b/src/constants/library-info.ts
@@ -1,16 +1,11 @@
 import readPkgUp from "read-pkg-up";
+import { getAwsCdkCoreVersion, getAwsCdkDependencies } from "../utils/package-json";
+
+const valueOrUnknown = (value: string | undefined) => value ?? "unknown";
 
 const packageJson = readPkgUp.sync({ cwd: __dirname })?.packageJson;
 
-const version = packageJson?.version ?? "unknown";
-
-const dependencies = packageJson?.dependencies ?? {};
-
-const awsCdkDependencies: Record<string, string> = Object.fromEntries(
-  Object.entries(dependencies).filter(([dependency]) => dependency.startsWith("@aws-cdk"))
-);
-
-const awsCdkCoreVersion = awsCdkDependencies["@aws-cdk/core"];
+const version = valueOrUnknown(packageJson?.version);
 
 export const LibraryInfo = {
   /**
@@ -22,10 +17,10 @@ export const LibraryInfo = {
    * The version of the `@aws-cdk` libraries used by `@guardian/cdk`.
    * You need to match this version exactly.
    */
-  AWS_CDK_VERSION: awsCdkCoreVersion,
+  AWS_CDK_VERSION: valueOrUnknown(getAwsCdkCoreVersion(packageJson ?? {})),
 
   /**
    * A complete list of the `@aws-cdk` libraries used by `@guardian/cdk`.
    */
-  AWS_CDK_VERSIONS: awsCdkDependencies,
+  AWS_CDK_VERSIONS: getAwsCdkDependencies(packageJson ?? {}),
 };

--- a/src/utils/package-json.test.ts
+++ b/src/utils/package-json.test.ts
@@ -1,0 +1,76 @@
+import type { PackageJson } from "read-pkg-up";
+import { getAwsCdkCoreVersion, getAwsCdkDependencies } from "./package-json";
+
+describe("getAwsCdkDependencies", () => {
+  it("should return aws-cdk dependencies when they exist", () => {
+    const packageJson = {
+      dependencies: { "@aws-cdk/aws-s3": "1.100.0", "@aws-cdk/core": "1.100.0", execa: "^5.1.1" },
+      devDependencies: { "@types/node": "16.3.2", typescript: "~4.3.4", "aws-cdk": "100.0.0" },
+    } as PackageJson;
+
+    const actual = getAwsCdkDependencies(packageJson);
+
+    const expected = {
+      dependencies: {
+        "@aws-cdk/aws-s3": "1.100.0",
+        "@aws-cdk/core": "1.100.0",
+      },
+      devDependencies: {
+        "aws-cdk": "100.0.0",
+      },
+    };
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it("should return empty objects when no aws-cdk dependencies are present", () => {
+    const packageJson = {
+      dependencies: { execa: "^5.1.1" },
+      devDependencies: { "@types/node": "16.3.2", typescript: "~4.3.4" },
+    } as PackageJson;
+
+    const actual = getAwsCdkDependencies(packageJson);
+
+    const expected = {
+      dependencies: {},
+      devDependencies: {},
+    };
+
+    expect(actual).toStrictEqual(expected);
+  });
+});
+
+describe("getAwsCdkCoreVersion", () => {
+  it("should return the value from dependencies", () => {
+    const packageJson = {
+      dependencies: { "@aws-cdk/core": "1.100.0", execa: "^5.1.1" },
+      devDependencies: { "@types/node": "16.3.2", typescript: "~4.3.4" },
+    } as PackageJson;
+
+    const actual = getAwsCdkCoreVersion(packageJson);
+
+    expect(actual).toBe("1.100.0");
+  });
+
+  it("should return the value from devDependencies", () => {
+    const packageJson = {
+      dependencies: { execa: "^5.1.1" },
+      devDependencies: { "@aws-cdk/core": "1.100.0", "@types/node": "16.3.2", typescript: "~4.3.4" },
+    } as PackageJson;
+
+    const actual = getAwsCdkCoreVersion(packageJson);
+
+    expect(actual).toBe("1.100.0");
+  });
+
+  it("should return undefined when the @aws-cdk/core package isn't present", () => {
+    const packageJson = {
+      dependencies: { execa: "^5.1.1" },
+      devDependencies: { "@types/node": "16.3.2", typescript: "~4.3.4" },
+    } as PackageJson;
+
+    const actual = getAwsCdkCoreVersion(packageJson);
+
+    expect(actual).toBeUndefined();
+  });
+});

--- a/src/utils/package-json.ts
+++ b/src/utils/package-json.ts
@@ -1,0 +1,26 @@
+import type { NormalizedPackageJson, PackageJson } from "read-pkg-up";
+
+const filterForAwsCdkDeps = (deps: Record<string, string>) =>
+  Object.fromEntries(
+    Object.entries(deps).filter(([dependency]) => dependency === "aws-cdk" || dependency.startsWith("@aws-cdk/"))
+  );
+
+export const getAwsCdkDependencies: (packageJson: PackageJson | NormalizedPackageJson) => {
+  devDependencies: Record<string, string>;
+  dependencies: Record<string, string>;
+} = (packageJson: PackageJson | NormalizedPackageJson) => {
+  const { dependencies, devDependencies } = packageJson;
+
+  return {
+    dependencies: filterForAwsCdkDeps(dependencies ?? {}),
+    devDependencies: filterForAwsCdkDeps(devDependencies ?? {}),
+  };
+};
+
+export const getAwsCdkCoreVersion: (packageJson: PackageJson | NormalizedPackageJson) => string | undefined = (
+  packageJson: PackageJson | NormalizedPackageJson
+) => {
+  const packageName = "@aws-cdk/core";
+  const { dependencies, devDependencies } = getAwsCdkDependencies(packageJson);
+  return dependencies[packageName] || devDependencies[packageName];
+};


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

When using `@guardian/cdk` the version of `aws-cdk` libraries in your `package.json` must exactly match the version `@guardian/cdk` uses. Else you get a rather cryptic message:

```console
Type 'import("/Users/philip_mcmahon/code/editions/projects/aws/node_modules/@aws-cdk/aws-ec2/lib/vpc").ISubnet[]' is not assignable to type 'import("/Users/philip_mcmahon/code/editions/projects/aws/node_modules/@aws-cdk/aws-lambda/node_modules/@aws-cdk/aws-ec2/lib/vpc").ISubnet[]'.
```

This command allows you to provide a `package.json` file to check if the versions of `aws-cdk` libraries match what `@guardian/cdk` uses.

### Example usage
```
npx @guardian/cdk check-package-json
```

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

Assuming the changes in #675 haven't broken the published version of the package:

- Checkout this branch
- Run `./script/setup`
- Run `./script/build`
- Create the file `/tmp/package.json` with the following content
    ```
    {
      "dependencies": {
        "@aws-cdk/core": "1.2.3"
      },
      "devDependencies": {
        "aws-cdk": "1.110.1"
      }
    }
    ```
- Run `./script/cli check-package-json --directory /tmp --verbose`
- Observe the output
    ```
    {
      file: '/tmp/package.json',
      versionExpected: '1.110.1',
      incorrectDependencies: { '@aws-cdk/core': '1.2.3' },
      incorrectDevDependencies: {}
    }
    ```

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is a little easier to debug issues.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a