### PR TITLE
chore: Fix linting warning

### DIFF
--- a/src/bin/commands/account-readiness.ts
+++ b/src/bin/commands/account-readiness.ts
@@ -1,6 +1,7 @@
 import type { CredentialProviderChain } from "aws-sdk";
 import AWS from "aws-sdk";
 import { SSM_PARAMETER_PATHS } from "../../constants/ssm-parameter-paths";
+import type { CliCommandResponse } from "../../types/command";
 
 export const accountReadinessCommand = async ({
   credentialProvider,
@@ -10,7 +11,7 @@ export const accountReadinessCommand = async ({
   credentialProvider: CredentialProviderChain;
   region: string;
   verbose: boolean;
-}) => {
+}): CliCommandResponse => {
   const ssm = new AWS.SSM({
     credentialProvider,
     region,

--- a/src/bin/commands/aws-cdk-version.ts
+++ b/src/bin/commands/aws-cdk-version.ts
@@ -1,5 +1,6 @@
 import { LibraryInfo } from "../../constants/library-info";
+import type { CliCommandResponse } from "../../types/command";
 
-export const awsCdkVersionCommand = (verbose: boolean): Promise<string | Record<string, string>> => {
+export const awsCdkVersionCommand = (verbose: boolean): CliCommandResponse => {
   return Promise.resolve(verbose ? LibraryInfo.AWS_CDK_VERSIONS : LibraryInfo.AWS_CDK_VERSION);
 };

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -2,6 +2,7 @@
 
 import yargs from "yargs";
 import { LibraryInfo } from "../constants/library-info";
+import type { CliCommandResponse } from "../types/command";
 import { awsCredentialProviderChain } from "./aws-credential-provider";
 import { accountReadinessCommand } from "./commands/account-readiness";
 import { awsCdkVersionCommand } from "./commands/aws-cdk-version";
@@ -32,16 +33,6 @@ const parseCommandLineArguments = () => {
       .alias("h", "help").argv
   );
 };
-
-// A CLI command can return...
-type CliCommandResponse = Promise<
-  // ...a simple message to be printed
-  | string
-  // ...or a blob of JSON to be printed via `JSON.stringify`
-  | Record<string, unknown>
-  // ...or an exit code
-  | number
->;
 
 parseCommandLineArguments()
   .then((argv): CliCommandResponse => {

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -1,0 +1,9 @@
+// A CLI command can return...
+export type CliCommandResponse = Promise<
+  // ...a simple message to be printed
+  | string
+  // ...or a blob of JSON to be printed via `JSON.stringify`
+  | Record<string, unknown>
+  // ...or an exit code
+  | number
+>;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Our linting rules are set to warn when an exported function doesn't explicitly define it's return type.

Set the type to `CliCommandResponse`.

Note: `CliCommandResponse`'s use of `Record<string, unknown>` is pretty generic, we might want to be more strongly typed in future.

This is a no-op.