### PR TITLE
feat: Make cli verbose by default

### DIFF
--- a/src/bin/commands/account-readiness.ts
+++ b/src/bin/commands/account-readiness.ts
@@ -6,11 +6,9 @@ import type { CliCommandResponse } from "../../types/command";
 export const accountReadinessCommand = async ({
   credentialProvider,
   region,
-  verbose,
 }: {
   credentialProvider: CredentialProviderChain;
   region: string;
-  verbose: boolean;
 }): CliCommandResponse => {
   const ssm = new AWS.SSM({
     credentialProvider,
@@ -22,18 +20,9 @@ export const accountReadinessCommand = async ({
 
   const awsResponse = await ssm.getParameters({ Names: paths }).promise();
 
-  const foundParameters = awsResponse.Parameters ?? [];
   const notFoundParameters = awsResponse.InvalidParameters ?? [];
 
-  if (!verbose) {
-    const messagePrefix = notFoundParameters.length === 0 ? "OK" : "ACTION NEEDED";
-
-    return Promise.resolve(
-      `[${messagePrefix}] ${foundParameters.length}/${ssmParams.length} SSM parameters found. ${notFoundParameters.length}/${ssmParams.length} SSM parameters not found.`
-    );
-  } else {
-    const notFoundInDetail = ssmParams.filter((_) => notFoundParameters.includes(_.path));
-    const foundInDetail = ssmParams.filter((_) => !notFoundParameters.includes(_.path));
-    return Promise.resolve({ found: foundInDetail, notFound: notFoundInDetail });
-  }
+  const notFoundInDetail = ssmParams.filter((_) => notFoundParameters.includes(_.path));
+  const foundInDetail = ssmParams.filter((_) => !notFoundParameters.includes(_.path));
+  return Promise.resolve({ found: foundInDetail, notFound: notFoundInDetail });
 };

--- a/src/bin/commands/aws-cdk-version.ts
+++ b/src/bin/commands/aws-cdk-version.ts
@@ -1,6 +1,6 @@
 import { LibraryInfo } from "../../constants/library-info";
 import type { CliCommandResponse } from "../../types/command";
 
-export const awsCdkVersionCommand = (verbose: boolean): CliCommandResponse => {
-  return Promise.resolve(verbose ? LibraryInfo.AWS_CDK_VERSIONS : LibraryInfo.AWS_CDK_VERSION);
+export const awsCdkVersionCommand = (): CliCommandResponse => {
+  return Promise.resolve(LibraryInfo.AWS_CDK_VERSIONS);
 };

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -22,7 +22,6 @@ const parseCommandLineArguments = () => {
   return Promise.resolve(
     yargs
       .usage("$0 COMMAND [args]")
-      .option("verbose", { type: "boolean", default: false, description: "Show verbose output" })
       .option("profile", { type: "string", description: "AWS profile" })
       .option("region", { type: "string", description: "AWS region", default: "eu-west-1" })
       .command(Commands.AwsCdkVersion, "Print the version of @aws-cdk libraries being used")
@@ -37,12 +36,12 @@ const parseCommandLineArguments = () => {
 parseCommandLineArguments()
   .then((argv): CliCommandResponse => {
     const command = argv._[0];
-    const { verbose, profile, region } = argv;
+    const { profile, region } = argv;
     switch (command) {
       case Commands.AwsCdkVersion:
-        return awsCdkVersionCommand(verbose);
+        return awsCdkVersionCommand();
       case Commands.AccountReadiness:
-        return accountReadinessCommand({ credentialProvider: awsCredentialProviderChain(profile), region, verbose });
+        return accountReadinessCommand({ credentialProvider: awsCredentialProviderChain(profile), region });
       default:
         throw new Error(`Unknown command: ${command}`);
     }


### PR DESCRIPTION
## What does this change?
This PR makes cli verbose by default

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Does this change require changes to existing projects or CDK CLI?
No

<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

## Does this change require changes to the library documentation?
No

<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

## How to test
N/A

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

## How can we measure success?
N/A

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
N/A

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
