### PR TITLE
feat: add SSM read to Lambda construct for app params

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -189,6 +189,30 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -3,19 +3,21 @@ import type { GuStack } from "../../core";
 import { AppIdentity } from "../../core/identity";
 import { GuPolicy } from "./base-policy";
 
+export class GuParameterStoreReadPolicyStatement extends PolicyStatement {
+  constructor(scope: GuStack, props: AppIdentity) {
+    super({
+      effect: Effect.ALLOW,
+      actions: ["ssm:GetParametersByPath"],
+      resources: [`arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/${props.app}`],
+    });
+  }
+}
+
 export class GuParameterStoreReadPolicy extends GuPolicy {
   constructor(scope: GuStack, props: AppIdentity) {
     super(scope, AppIdentity.suffixText(props, "ParameterStoreRead"), {
       policyName: "parameter-store-read-policy",
-      statements: [
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: ["ssm:GetParametersByPath"],
-          resources: [
-            `arn:aws:ssm:${scope.region}:${scope.account}:parameter/${scope.stage}/${scope.stack}/${props.app}`,
-          ],
-        }),
-      ],
+      statements: [new GuParameterStoreReadPolicyStatement(scope, props)],
     });
 
     AppIdentity.taggedConstruct(props, this);

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -76,7 +76,7 @@ describe("The GuLambdaFunction class", () => {
       app: "testing",
     });
 
-    expect(stack).toHaveResource("AWS::IAM::Policy", {
+    expect(stack).toHaveResourceLike("AWS::IAM::Policy", {
       PolicyDocument: {
         Statement: [
           {

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -233,6 +233,30 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -179,6 +179,30 @@ Object {
               ],
             },
             Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing",
+                  ],
+                ],
+              },
+            },
+            Object {
               "Action": Array [
                 "kinesis:DescribeStreamSummary",
                 "kinesis:GetRecords",

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -125,6 +125,30 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -180,6 +180,30 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },


### PR DESCRIPTION
## What does this change?
This adds a policy statement to the Lambda construct so that permission is always granted to read SSM parameters under  $stage/$stack/$app/* for a lambda.

## Does this change require changes to existing projects or CDK CLI?
No

## Does this change require changes to the library documentation?
Have added a note on the lambda docs to reflect new permission.

## How to test
Covered by snapshot tests.

## How can we measure success?
Users don't need to concern themselves with granting permission to read configuration.

## Have we considered potential risks?
Risk is low due to test coverage.