### PR TITLE
feat: add stack/stage/app environment variables to lambda

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -52,6 +52,15 @@ Object {
             ],
           },
         },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
         "Handler": "handler.ts",
         "MemorySize": 512,
         "Role": Object {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -49,6 +49,12 @@ export class GuLambdaFunction extends Function {
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const { app, fileName, runtime, memorySize, timeout } = props;
 
+    const defaultEnvironmentVariables = {
+      STACK: scope.stack,
+      STAGE: scope.stage,
+      APP: app,
+    };
+
     const bucket = Bucket.fromBucketName(
       scope,
       `${id}-bucket`,
@@ -58,6 +64,10 @@ export class GuLambdaFunction extends Function {
     const code = Code.fromBucket(bucket, objectKey);
     super(scope, id, {
       ...props,
+      environment: {
+        ...props.environment,
+        ...defaultEnvironmentVariables,
+      },
       memorySize: defaultMemorySize(runtime, memorySize),
       timeout: timeout ?? Duration.seconds(30),
       code,

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -40,7 +40,8 @@ function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
  * By default, the timeout for this lambda is 30 seconds. This can be overridden via the `timeout` prop.
  *
  * By default the Lambda is granted permission to read from the SSM parameter store subtree specific to this lambda
- * (i.e. it can read all keys under <stage>/<stack>/<app>/).
+ * (i.e. it can read all keys under <stage>/<stack>/<app>/). The lambda has STACK/STAGE/APP environment variables
+ * which can be used to determine its identity.
  *
  * Note that this construct creates a Lambda without a trigger/event source. Depending on your use-case, you may wish to
  * consider using a pattern which instantiates a Lambda with a trigger e.g. [[`GuScheduledLambda`]].

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -96,6 +96,15 @@ Object {
             ],
           },
         },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
         "Handler": "handler.ts",
         "MemorySize": 512,
         "Role": Object {

--- a/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -77,6 +77,15 @@ Object {
             ],
           },
         },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
         "FunctionName": "my-lambda-function",
         "Handler": "my-lambda/handler",
         "MemorySize": 512,

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -42,6 +42,15 @@ Object {
             ],
           },
         },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
         "FunctionName": "my-lambda-function",
         "Handler": "my-lambda/handler",
         "MemorySize": 512,

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -81,6 +81,15 @@ Object {
             ],
           },
         },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
         "FunctionName": "my-lambda-function",
         "Handler": "my-lambda/handler",
         "MemorySize": 512,


### PR DESCRIPTION
## What does this change?

This PR adds stack/stage/app environment variables to our lambda construct, which also adds it to all lambda-based patterns.

## Does this change require changes to existing projects or CDK CLI?

Existing projects which don't manually set these environment variables should get them for free. Existing projects which already set these environment variables manually should be able to remove some boilerplate.

## Does this change require changes to the library documentation?

Yes, we've added a small note about this.

## How to test

This should be covered by snapshot testing.

## How can we measure success?

Users can avoid adding this boilerplate to their `cdk` templates.

## Have we considered potential risks?

I think this is a low risk change.
