### PR TITLE
feat: Add the GuCDK version to the CLI JSON response

### DIFF
--- a/script/cli
+++ b/script/cli
@@ -10,4 +10,4 @@ if [[ $# -gt 0 ]] ; then
 fi
 
 # shellcheck disable=SC2086
-npm run cli:dev $EXTRA_ARGS
+npm run --silent cli:dev $EXTRA_ARGS

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -66,7 +66,8 @@ parseCommandLineArguments()
     } else if (typeof commandResponse === "string") {
       console.log(commandResponse);
     } else {
-      console.log(JSON.stringify(commandResponse));
+      const responseWithVersionInfo = { "@guardian/cdk": { version: LibraryInfo.VERSION }, ...commandResponse };
+      console.log(JSON.stringify(responseWithVersionInfo));
     }
   })
   .catch((err) => {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

It is useful to know what version of the CLI you're using when running commands.

Let's say you're working on a CDK project using v22.3.0 of GuCDK. You'll be using AWS CDK libraries of v1.110.1.

However if you run `npx @guardian/cdk aws-cdk-version` the CLI will suggest using v1.115.0 of the AWS CDK libraries. This is because you're invoking the latest version of the CLI, rather than version for v22.3.0.

Printing the version of GuCDK in the CLI response should hopefully make this process easier.

Before:

```console
➜ ./script/cli aws-cdk-version | jq .
{
  "dependencies": {
    "@aws-cdk/assert": "1.115.0",
    "@aws-cdk/aws-apigateway": "1.115.0",
    "@aws-cdk/aws-autoscaling": "1.115.0",
    "@aws-cdk/aws-cloudwatch-actions": "1.115.0",
    "@aws-cdk/aws-ec2": "1.115.0",
    "@aws-cdk/aws-elasticloadbalancing": "1.115.0",
    "@aws-cdk/aws-elasticloadbalancingv2": "1.115.0",
    "@aws-cdk/aws-events-targets": "1.115.0",
    "@aws-cdk/aws-iam": "1.115.0",
    "@aws-cdk/aws-kinesis": "1.115.0",
    "@aws-cdk/aws-lambda": "1.115.0",
    "@aws-cdk/aws-lambda-event-sources": "1.115.0",
    "@aws-cdk/aws-rds": "1.115.0",
    "@aws-cdk/aws-s3": "1.115.0",
    "@aws-cdk/core": "1.115.0"
  },
  "devDependencies": {}
}
```

After:

```console
➜ ./script/cli aws-cdk-version | jq .
{
  "@guardian/cdk": {
    "version": "23.3.0"
  },
  "dependencies": {
    "@aws-cdk/assert": "1.115.0",
    "@aws-cdk/aws-apigateway": "1.115.0",
    "@aws-cdk/aws-autoscaling": "1.115.0",
    "@aws-cdk/aws-cloudwatch-actions": "1.115.0",
    "@aws-cdk/aws-ec2": "1.115.0",
    "@aws-cdk/aws-elasticloadbalancing": "1.115.0",
    "@aws-cdk/aws-elasticloadbalancingv2": "1.115.0",
    "@aws-cdk/aws-events-targets": "1.115.0",
    "@aws-cdk/aws-iam": "1.115.0",
    "@aws-cdk/aws-kinesis": "1.115.0",
    "@aws-cdk/aws-lambda": "1.115.0",
    "@aws-cdk/aws-lambda-event-sources": "1.115.0",
    "@aws-cdk/aws-rds": "1.115.0",
    "@aws-cdk/aws-s3": "1.115.0",
    "@aws-cdk/core": "1.115.0"
  },
  "devDependencies": {}
}
```

This change also makes invoking the CLI locally a bit easier to use; by silencing the npm logs we can pipe the CLI to `jq` and other tools.