### PR TITLE
fix: improve default healthcheck and deregistration settings

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -403,11 +403,11 @@ Object {
     },
     "ApplicationTargetGroupTesting080C2FF2": Object {
       "Properties": Object {
-        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
         "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 10,
-        "HealthyThresholdCount": 2,
+        "HealthyThresholdCount": 5,
         "Port": 80,
         "Protocol": "HTTP",
         "Tags": Array [
@@ -434,7 +434,13 @@ Object {
             },
           },
         ],
-        "UnhealthyThresholdCount": 5,
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+        ],
+        "UnhealthyThresholdCount": 2,
         "VpcId": "test",
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/src/constructs/loadbalancing/alb/application-target-group.test.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.test.ts
@@ -66,12 +66,12 @@ describe("The GuApplicationTargetGroup class", () => {
     });
 
     expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
-      HealthCheckIntervalSeconds: 30,
+      HealthCheckIntervalSeconds: 10,
       HealthCheckPath: "/healthcheck",
       HealthCheckProtocol: "HTTP",
       HealthCheckTimeoutSeconds: 10,
-      HealthyThresholdCount: 2,
-      UnhealthyThresholdCount: 5,
+      HealthyThresholdCount: 5,
+      UnhealthyThresholdCount: 2,
     });
   });
 
@@ -87,13 +87,13 @@ describe("The GuApplicationTargetGroup class", () => {
     });
 
     expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
-      HealthCheckIntervalSeconds: 30,
+      HealthCheckIntervalSeconds: 10,
       HealthCheckPath: "/test",
       HealthCheckPort: "9000",
       HealthCheckProtocol: "HTTP",
       HealthCheckTimeoutSeconds: 10,
-      HealthyThresholdCount: 2,
-      UnhealthyThresholdCount: 5,
+      HealthyThresholdCount: 5,
+      UnhealthyThresholdCount: 2,
     });
   });
 

--- a/src/constructs/loadbalancing/alb/application-target-group.ts
+++ b/src/constructs/loadbalancing/alb/application-target-group.ts
@@ -37,9 +37,9 @@ export class GuApplicationTargetGroup extends GuStatefulMigratableConstruct(Appl
   static DefaultHealthCheck = {
     path: "/healthcheck",
     protocol: Protocol.HTTP,
-    healthyThresholdCount: 2,
-    unhealthyThresholdCount: 5,
-    interval: Duration.seconds(30),
+    healthyThresholdCount: 5,
+    unhealthyThresholdCount: 2,
+    interval: Duration.seconds(10),
     timeout: Duration.seconds(10),
   };
 
@@ -48,6 +48,7 @@ export class GuApplicationTargetGroup extends GuStatefulMigratableConstruct(Appl
 
     const mergedProps = {
       protocol: ApplicationProtocol.HTTP, // We terminate HTTPS at the load balancer level, so load balancer to ASG/EC2 traffic can be over HTTP
+      deregistrationDelay: Duration.seconds(30),
       ...props,
       healthCheck: { ...GuApplicationTargetGroup.DefaultHealthCheck, ...props.healthCheck },
     };

--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -771,11 +771,11 @@ Object {
     },
     "TargetGroupTestguec2app9F67D503": Object {
       "Properties": Object {
-        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
         "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 10,
-        "HealthyThresholdCount": 2,
+        "HealthyThresholdCount": 5,
         "Port": 3000,
         "Protocol": "HTTP",
         "Tags": Array [
@@ -802,8 +802,14 @@ Object {
             },
           },
         ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+        ],
         "TargetType": "instance",
-        "UnhealthyThresholdCount": 5,
+        "UnhealthyThresholdCount": 2,
         "VpcId": Object {
           "Ref": "VpcId",
         },
@@ -1553,11 +1559,11 @@ Object {
     },
     "TargetGroupTestguec2app9F67D503": Object {
       "Properties": Object {
-        "HealthCheckIntervalSeconds": 30,
+        "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
         "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 10,
-        "HealthyThresholdCount": 2,
+        "HealthyThresholdCount": 5,
         "Port": 3000,
         "Protocol": "HTTP",
         "Tags": Array [
@@ -1584,8 +1590,14 @@ Object {
             },
           },
         ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+        ],
         "TargetType": "instance",
-        "UnhealthyThresholdCount": 5,
+        "UnhealthyThresholdCount": 2,
         "VpcId": Object {
           "Ref": "VpcId",
         },


### PR DESCRIPTION
## What does this change?
On ALBs the deregistration delay determines how quickly an instance can be removed from a target grouo. The default is five minutes which makes deploys take a lot longer than is needed.

This delay should be tuned to be longer than your longest ever expected request. As such 30s seems reasonable for most use cases but I could be convinced to push this up to 60s.

In addition we also flip the healthy/unhealthy default values which look wrong (an instance should go out of service no slower than come in) and increase the polling interval so that the load balancer is more responsive.

## Does this change require changes to existing projects or CDK CLI?
Existing projects will inherit these more sensible defaults when they upgrade.

## Does this change require changes to the library documentation?
These specific settings are not documented.

## How can we measure success?
Deploys of apps like Prism are substantially faster.

## Have we considered potential risks?
It's possible that some apps rely on this. It's worth reviewing settings in use across the department to verify these make sense.