### PR TITLE
fix: Remove circular dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1633,9 +1633,9 @@
       }
     },
     "@guardian/eslint-config": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-0.6.1.tgz",
-      "integrity": "sha512-+smvJZl0vNldw9Q1cJNK2FZToMCOrQXxh+jfHd1kNq8oeBu4/fUjyWsrpA46pvu4r4BBTF0itSSbD2A1yZsryw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-0.7.0.tgz",
+      "integrity": "sha512-d6HgVLBvLn/XFZOW+X5ukHiCbnuNb5rZHd2XtP/UT7a0f8806YhnFOYqxQXsdQadppHNDvc1wF3/ebjH2O+eHg==",
       "dev": true,
       "requires": {
         "eslint-config-prettier": "8.3.0",
@@ -1645,12 +1645,12 @@
       }
     },
     "@guardian/eslint-config-typescript": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.6.1.tgz",
-      "integrity": "sha512-0xJGIq7LzHL/iPL+gG6KoWhm2Wbpn96q3TTmpkguxVCRnMFsAliLKsGSP3qBAPk94TSiIXaCjCFqGyNpFGGmDQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-0.7.0.tgz",
+      "integrity": "sha512-Fi7cMQuD+oR3IiGfN1ubvgTMYpQRpytRSdwLt/9c1Eqjl1Lf0xzDLd0AORBQb4PIDHQtF3t7g25WUQTqF7sWtQ==",
       "dev": true,
       "requires": {
-        "@guardian/eslint-config": "^0.6.1",
+        "@guardian/eslint-config": "^0.7.0",
         "@typescript-eslint/eslint-plugin": "4.29.2",
         "@typescript-eslint/parser": "4.29.2"
       }
@@ -2734,6 +2734,12 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/minimist": {
@@ -14607,14 +14613,26 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
       "dev": true,
       "requires": {
-        "json5": "^2.2.0",
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cli:dev": "ts-node src/bin/index.ts"
   },
   "devDependencies": {
-    "@guardian/eslint-config-typescript": "^0.6.1",
+    "@guardian/eslint-config-typescript": "0.7.0",
     "@types/aws-lambda": "^8.10.83",
     "@types/git-url-parse": "^9.0.1",
     "@types/jest": "^27.0.1",

--- a/src/constructs/core/migrating.test.ts
+++ b/src/constructs/core/migrating.test.ts
@@ -3,7 +3,7 @@ import { SynthUtils } from "@aws-cdk/assert";
 import { Bucket } from "@aws-cdk/aws-s3";
 import type { BucketProps } from "@aws-cdk/aws-s3";
 import { Annotations } from "@aws-cdk/core";
-import type { GuStatefulConstruct } from "../../utils/mixin";
+import type { GuStatefulConstruct } from "../../types/migrating";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { SynthedStack } from "../../utils/test";
 import { GuMigratingResource } from "./migrating";

--- a/src/constructs/core/migrating.ts
+++ b/src/constructs/core/migrating.ts
@@ -1,23 +1,7 @@
 import { Annotations } from "@aws-cdk/core";
 import type { CfnElement, IConstruct } from "@aws-cdk/core";
-import { isGuStatefulConstruct } from "../../utils/mixin";
-
-export interface GuMigratingStack {
-  /**
-   * A flag to symbolise if a stack is being migrated from a previous format (eg YAML) into guardian/cdk.
-   * A value of `true` means resources in the stack can have custom logicalIds set using the property `existingLogicalId` (where available).
-   * A value of `false` or `undefined` means the stack is brand new. Any resource that gets created will have an auto-generated logicalId.
-   * Ideally, for use only by [[ `GuStack` ]].
-   * @see GuMigratingResource
-   * @see GuStack
-   */
-  migratedFromCloudFormation: boolean;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types -- user defined type guard
-export function isGuMigratingStack(construct: any): construct is GuMigratingStack {
-  return "migratedFromCloudFormation" in construct;
-}
+import type { GuMigratingStack } from "../../types/migrating";
+import { isGuStatefulConstruct } from "../../types/migrating";
 
 export interface GuMigratingResource {
   /**

--- a/src/constructs/core/parameters/anghammarad.ts
+++ b/src/constructs/core/parameters/anghammarad.ts
@@ -1,5 +1,5 @@
 import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 

--- a/src/constructs/core/parameters/identity.ts
+++ b/src/constructs/core/parameters/identity.ts
@@ -1,5 +1,5 @@
 import { Stage, Stages } from "../../../constants";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 

--- a/src/constructs/core/parameters/log-shipping.ts
+++ b/src/constructs/core/parameters/log-shipping.ts
@@ -1,5 +1,5 @@
 import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -1,5 +1,5 @@
 import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
 

--- a/src/constructs/core/parameters/vpc.ts
+++ b/src/constructs/core/parameters/vpc.ts
@@ -1,5 +1,5 @@
 import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuParameter } from "./base";
 import type { GuNoTypeParameterProps } from "./base";

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -6,11 +6,11 @@ import { Stage } from "../../constants";
 import { ContextKeys } from "../../constants/context-keys";
 import { TagKeys } from "../../constants/tag-keys";
 import { TrackingTag } from "../../constants/tracking-tag";
+import type { GuMigratingStack } from "../../types/migrating";
 import { Logger } from "../../utils/logger";
 import type { StackStageIdentity } from "./identity";
 import { GuStageMapping } from "./mappings";
 import type { GuStageDependentValue } from "./mappings";
-import type { GuMigratingStack } from "./migrating";
 import { GuStageParameter } from "./parameters";
 import type { GuParameter } from "./parameters";
 

--- a/src/constructs/ec2/security-groups/wazuh.ts
+++ b/src/constructs/ec2/security-groups/wazuh.ts
@@ -1,6 +1,6 @@
 import { Peer } from "@aws-cdk/aws-ec2";
 import type { IVpc } from "@aws-cdk/aws-ec2";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../../core";
 import { GuMigratingResource } from "../../core/migrating";
 import { GuBaseSecurityGroup } from "./base";

--- a/src/constructs/iam/policies/anghammarad.ts
+++ b/src/constructs/iam/policies/anghammarad.ts
@@ -1,4 +1,4 @@
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../../core";
 import { GuAnghammaradTopicParameter } from "../../core";
 import { GuAllowPolicy } from "./base-policy";

--- a/src/constructs/iam/policies/describe-ec2.ts
+++ b/src/constructs/iam/policies/describe-ec2.ts
@@ -1,5 +1,5 @@
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../../core";
 import { GuPolicy } from "./base-policy";
 

--- a/src/constructs/iam/policies/log-shipping.ts
+++ b/src/constructs/iam/policies/log-shipping.ts
@@ -1,4 +1,4 @@
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../../core";
 import { GuLoggingStreamNameParameter } from "../../core/parameters/log-shipping";
 import { GuAllowPolicy } from "./base-policy";

--- a/src/constructs/iam/policies/ssm.ts
+++ b/src/constructs/iam/policies/ssm.ts
@@ -1,4 +1,4 @@
-import { isSingletonPresentInStack } from "../../../utils/test";
+import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../../core";
 import { GuAllowPolicy } from "./base-policy";
 

--- a/src/types/migrating.ts
+++ b/src/types/migrating.ts
@@ -1,0 +1,29 @@
+export interface GuMigratingStack {
+  /**
+   * A flag to symbolise if a stack is being migrated from a previous format (eg YAML) into guardian/cdk.
+   * A value of `true` means resources in the stack can have custom logicalIds set using the property `existingLogicalId` (where available).
+   * A value of `false` or `undefined` means the stack is brand new. Any resource that gets created will have an auto-generated logicalId.
+   * Ideally, for use only by [[ `GuStack` ]].
+   * @see GuMigratingResource
+   * @see GuStack
+   */
+  migratedFromCloudFormation: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types -- user defined type guard
+export function isGuMigratingStack(construct: any): construct is GuMigratingStack {
+  return "migratedFromCloudFormation" in construct;
+}
+
+export interface GuStatefulConstruct {
+  /**
+   * A flag to signal to `GuMigratingResource` that a construct is stateful and care should be taken when migrating to GuCDK.
+   * If one accidentally replaces a stateful resource, downstream services such as DNS may be impacted.
+   */
+  isStatefulConstruct: true;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types -- user defined type guard
+export function isGuStatefulConstruct(construct: any): construct is GuStatefulConstruct {
+  return "isStatefulConstruct" in construct;
+}

--- a/src/utils/mixin/migratable-construct-stateful.ts
+++ b/src/utils/mixin/migratable-construct-stateful.ts
@@ -1,18 +1,6 @@
+import type { GuStatefulConstruct } from "../../types/migrating";
 import { GuMigratableConstruct } from "./migratable-construct";
 import type { AnyConstructor } from "./types";
-
-export interface GuStatefulConstruct {
-  /**
-   * A flag to signal to `GuMigratingResource` that a construct is stateful and care should be taken when migrating to GuCDK.
-   * If one accidentally replaces a stateful resource, downstream services such as DNS may be impacted.
-   */
-  isStatefulConstruct: true;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types -- user defined type guard
-export function isGuStatefulConstruct(construct: any): construct is GuStatefulConstruct {
-  return "isStatefulConstruct" in construct;
-}
 
 /**
  * A mixin to add the property `isStatefulConstruct` to a class and execute logic to conditionally override a construct's logicalId when synthesised.

--- a/src/utils/mixin/migratable-construct.ts
+++ b/src/utils/mixin/migratable-construct.ts
@@ -1,6 +1,7 @@
 import { Construct } from "@aws-cdk/core";
-import { GuMigratingResource, isGuMigratingStack } from "../../constructs/core/migrating";
-import type { GuMigratingStack } from "../../constructs/core/migrating";
+import { GuMigratingResource } from "../../constructs/core/migrating";
+import type { GuMigratingStack } from "../../types/migrating";
+import { isGuMigratingStack } from "../../types/migrating";
 import type { AnyConstructor } from "./types";
 
 /**

--- a/src/utils/singleton.ts
+++ b/src/utils/singleton.ts
@@ -1,5 +1,5 @@
 import type { Stack } from "@aws-cdk/core/lib/stack";
-import type { GuStack } from "../../constructs/core";
+import type { GuStack } from "../constructs/core";
 
 /**
  * Check if an element exists in a [[`GuStack`]].

--- a/src/utils/test/index.ts
+++ b/src/utils/test/index.ts
@@ -1,4 +1,3 @@
 export * from "./simple-gu-stack";
 export * from "./synthed-stack";
 export * from "./attach-policy-to-test-role";
-export * from "./singleton";

--- a/tools/integration-test/package.json
+++ b/tools/integration-test/package.json
@@ -16,7 +16,7 @@
     "generate": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/eslint-config-typescript": "^0.6.0",
+    "@guardian/eslint-config-typescript": "0.7.0",
     "@types/jest": "^27.0.1",
     "@types/node": "16.7.10",
     "aws-cdk": "1.120.0",


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Updates @guardian/eslint-config-typescript to v0.7.0 which brings a [new linting rule](https://github.com/guardian/configs/pull/114) to prevent [circular dependencies](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md).

It also fixes the 18 issues that this rule catches. The fixes are fairly straightforward:
  - The file `singleton.ts` moves from `utils/test/singleton.ts` to `utils/singleton.ts` (https://github.com/guardian/cdk/pull/773/commits/ed72819c1ba00fa91461eadfb2129d9f5f3ff50f)
  - Two interfaces and user defined type guards get relocated to the `types` directory (https://github.com/guardian/cdk/pull/773/commits/3c1194e8c7d70ab59486053fd078a1ddec812cc4)

<details>
<summary>List of circular dependency violations</summary>

```console
➜ ./script/lint


> @guardian/cdk@24.0.0 test:custom-lint-rule /Users/akash_askoolum/code/cdk
> eslint tools/eslint/rules/valid-constructors.test.ts


> @guardian/cdk@24.0.0 lint /Users/akash_askoolum/code/cdk
> eslint src --ext .ts


/Users/akash_askoolum/code/cdk/src/constructs/core/index.ts
  2:1  error  Dependency cycle via ./anghammarad:2=>../../../utils/test:2=>./simple-gu-stack:1                   import/no-cycle
  3:1  error  Dependency cycle via ./parameters:14=>./anghammarad:2=>../../../utils/test:2=>./simple-gu-stack:1  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/migrating.ts
  3:1  error  Dependency cycle via ./migratable-construct:1  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/parameters/anghammarad.ts
  2:1  error  Dependency cycle via ./simple-gu-stack:1=>../../constructs/core:3=>./parameters:2  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/parameters/identity.ts
  2:1  error  Dependency cycle via ./simple-gu-stack:1=>../../constructs/core:3=>./parameters:2  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/parameters/index.ts
  2:1  error  Dependency cycle via ../../../utils/test:2=>./simple-gu-stack:1=>../../constructs/core:3  import/no-cycle
  5:1  error  Dependency cycle via ../../../utils/test:2=>./simple-gu-stack:1=>../../constructs/core:3  import/no-cycle
  6:1  error  Dependency cycle via ../../../utils/test:2=>./simple-gu-stack:1=>../../constructs/core:3  import/no-cycle
  8:1  error  Dependency cycle via ../../../utils/test:2=>./simple-gu-stack:1=>../../constructs/core:3  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/parameters/s3.ts
  2:1  error  Dependency cycle via ./simple-gu-stack:1=>../../constructs/core:3=>./parameters:2  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/parameters/vpc.ts
  2:1  error  Dependency cycle via ./simple-gu-stack:1=>../../constructs/core:3=>./parameters:2  import/no-cycle

/Users/akash_askoolum/code/cdk/src/constructs/core/stack.ts
  14:1  error  Dependency cycle via ./anghammarad:2=>../../../utils/test:2=>./simple-gu-stack:1=>../../constructs/core:3  import/no-cycle

/Users/akash_askoolum/code/cdk/src/utils/mixin/index.ts
  1:1  error  Dependency cycle via ../../constructs/core/migrating:2                            import/no-cycle
  2:1  error  Dependency cycle via ./migratable-construct:1=>../../constructs/core/migrating:2  import/no-cycle

/Users/akash_askoolum/code/cdk/src/utils/mixin/migratable-construct-stateful.ts
  1:1  error  Dependency cycle via ../../constructs/core/migrating:2=>../../utils/mixin:3  import/no-cycle

/Users/akash_askoolum/code/cdk/src/utils/mixin/migratable-construct.ts
  2:1  error  Dependency cycle via ../../utils/mixin:3  import/no-cycle

/Users/akash_askoolum/code/cdk/src/utils/test/index.ts
  1:1  error  Dependency cycle via ../../constructs/core:3=>./parameters:2=>./anghammarad:2  import/no-cycle

/Users/akash_askoolum/code/cdk/src/utils/test/simple-gu-stack.ts
  3:1  error  Dependency cycle via ./parameters:2=>./anghammarad:2=>../../../utils/test:2  import/no-cycle

✖ 18 problems (18 errors, 0 warnings)
```

</details>

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The library is usable [everywhere](https://github.com/guardian/typerighter/commit/1d5995dcc6f78c0be6b1b9f7d631e8980ffaa04c) regardless of the order imports are specified.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

No.