### PR TITLE
fix: make it possible to define multiple lambdas per stack

### DIFF
--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -75,7 +75,7 @@ export class GuLambdaFunction extends Function {
     });
 
     if (props.errorPercentageMonitoring) {
-      new GuLambdaErrorPercentageAlarm(scope, "ErrorPercentageAlarmForLambda", {
+      new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {
         ...props.errorPercentageMonitoring,
         lambda: this,
       });


### PR DESCRIPTION
## What does this change?
Since the `ErrorPercentageAlarmForLambda` is hard coded to a value which does not contain a unique identifier per lambda in a stack, it is not currently possible to define more than one per stack. This change
prefixes the `id` so that multiple lambdas may be created per stack.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->
I don't think so, I think fresh cloudformation including this change will spin up a load of new resources with new ids anyway, but I'm not sure.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->
No

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->
We reference this code version for generating a stack with two lambdas [here](https://github.com/guardian/uk-coronavirus-data-alerts/blob/email-type-verified/package.json#L5) on a branch of the uk-coronavirus-data-alerts project where we define a stack with two lambdas:
![image](https://user-images.githubusercontent.com/9820960/132547177-3016670c-5072-4ff6-90fb-4c9ea88560f1.png)

The cloudformation generated can be successfully deployed:

![image](https://user-images.githubusercontent.com/9820960/132547095-5e3a7262-96bf-477d-ab15-7eb0f8f3ea98.png)
