### PR TITLE
refactor: Safer retrieval of error message

### DIFF
--- a/src/constructs/core/custom-resources/runtime/lambda.ts
+++ b/src/constructs/core/custom-resources/runtime/lambda.ts
@@ -58,9 +58,18 @@ export async function handler(event: CloudFormationCustomResourceEvent, context:
     await respond("SUCCESS", "OK", physicalResourceId, data);
   } catch (e) {
     console.log(e);
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- e.message is valid, see docs above
-    await respond("FAILED", e.message || "Internal Error", context.logStreamName, {});
+
+    const errorMessage = (error: unknown) => {
+      if (typeof error === "string") {
+        return error;
+      }
+      if (error instanceof Error) {
+        return error.message;
+      }
+      return "Internal Error";
+    };
+
+    await respond("FAILED", errorMessage(e), context.logStreamName, {});
   }
 
   function respond(responseStatus: string, reason: string, physicalResourceId: string, data: Record<string, string>) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In a `catch`, the caught value is of type `unknown`. This is because `throw "something bad happened"` is valid JS. That is, you don't have to throw an `Error` type.

Refactor to handle this fact in a slightly more type-safe way.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw

This is after seeing #777 [fail](https://github.com/guardian/cdk/runs/3547568732?check_suite_focus=true) it's build.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

#777 can be merged and one less instance of disabling the linter.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a