### PR TITLE
feat: allow GuEc2App users to access VPC

### DIFF
--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -1,6 +1,6 @@
 import type { BlockDevice } from "@aws-cdk/aws-autoscaling";
 import { HealthCheck } from "@aws-cdk/aws-autoscaling";
-import type { IPeer } from "@aws-cdk/aws-ec2";
+import type { IPeer, IVpc } from "@aws-cdk/aws-ec2";
 import { Port } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Bucket } from "@aws-cdk/aws-s3";
@@ -334,6 +334,7 @@ export class GuEc2App {
    * to access in-pattern constructs, but this would allow teams to be unblocked
    * in the short term.
    * */
+  public readonly vpc: IVpc;
   public readonly certificate: GuCertificate;
   public readonly loadBalancer: GuApplicationLoadBalancer;
   public readonly autoScalingGroup: GuAutoScalingGroup;
@@ -472,6 +473,7 @@ export class GuEc2App {
       }
     }
 
+    this.vpc = vpc;
     this.certificate = certificate;
     this.loadBalancer = loadBalancer;
     this.autoScalingGroup = autoScalingGroup;


### PR DESCRIPTION
## What does this change?

This PR allows users of the `GuEc2App` (and its subclasses) to access the underlying VPC. This means that users can, amongst other things, more easily wire up additional security groups. For example:

```typescript

const playApp = new GuPlayApp(params);

const anotherSg = new GuSecurityGroup(this, "PostgresSecurityGroup", {
  app: "my-app",
  vpc: playApp.vpc,
  allowAllOutbound: false,
  egresses: [{
    range: Peer.anyIpv4(),
    port: 5432,
    description: "My Postgres SG",
  }],
});

playApp.autoScalingGroup.addSecurityGroup(anotherSg)
```

cc @jonathonherbert 

## Does this change require changes to existing projects or CDK CLI?
No.

## Does this change require changes to the library documentation?
No.

## How to test
I've tested this via [`cdk-playground`](https://github.com/guardian/cdk-playground/compare/jw-test?expand=1).

## How can we measure success?
It should be easier to teams to configure additional resources which require access to the VPC (e.g. security groups).

## Have we considered potential risks?
N/A
