### PR TITLE
refactor: Organise for more account readiness commands

### DIFF
--- a/src/bin/commands/account-readiness/index.ts
+++ b/src/bin/commands/account-readiness/index.ts
@@ -1,15 +1,8 @@
-import type { CredentialProviderChain } from "aws-sdk";
-import type { CliCommandResponse } from "../../../types/command";
+import type { AwsAccountReadiness, CliCommandResponse } from "../../../types/cli";
 import { ssmParamReadiness } from "./ssm";
 
-export const accountReadinessCommand = async ({
-  credentialProvider,
-  region,
-}: {
-  credentialProvider: CredentialProviderChain;
-  region: string;
-}): CliCommandResponse => {
-  const ssmParamReadinessResponse = await ssmParamReadiness({ credentialProvider, region });
+export const accountReadinessCommand = async (props: AwsAccountReadiness): CliCommandResponse => {
+  const ssmParamReadinessResponse = await ssmParamReadiness(props);
   const vpcReadinessResponse = 1 - 1; // TODO: Implement
 
   if (ssmParamReadinessResponse !== 0 || vpcReadinessResponse !== 0) {

--- a/src/bin/commands/account-readiness/index.ts
+++ b/src/bin/commands/account-readiness/index.ts
@@ -1,0 +1,20 @@
+import type { CredentialProviderChain } from "aws-sdk";
+import type { CliCommandResponse } from "../../../types/command";
+import { ssmParamReadiness } from "./ssm";
+
+export const accountReadinessCommand = async ({
+  credentialProvider,
+  region,
+}: {
+  credentialProvider: CredentialProviderChain;
+  region: string;
+}): CliCommandResponse => {
+  const ssmParamReadinessResponse = await ssmParamReadiness({ credentialProvider, region });
+  const vpcReadinessResponse = 1 - 1; // TODO: Implement
+
+  if (ssmParamReadinessResponse !== 0 || vpcReadinessResponse !== 0) {
+    return 1;
+  } else {
+    return 0;
+  }
+};

--- a/src/bin/commands/account-readiness/index.ts
+++ b/src/bin/commands/account-readiness/index.ts
@@ -2,12 +2,11 @@ import type { AwsAccountReadiness, CliCommandResponse } from "../../../types/cli
 import { ssmParamReadiness } from "./ssm";
 
 export const accountReadinessCommand = async (props: AwsAccountReadiness): CliCommandResponse => {
-  const ssmParamReadinessResponse = await ssmParamReadiness(props);
-  const vpcReadinessResponse = 1 - 1; // TODO: Implement
+  // Got a new AWS account readiness command? Add it to this list and ✨
+  const commandResponses: number[] = await Promise.all([ssmParamReadiness(props)]);
 
-  if (ssmParamReadinessResponse !== 0 || vpcReadinessResponse !== 0) {
-    return 1;
-  } else {
-    return 0;
-  }
+  const totalFailedCommands = commandResponses.filter((_) => _ !== 0);
+  const allCommandsSuccessful = totalFailedCommands.length === 0;
+
+  return allCommandsSuccessful ? 0 : 1;
 };

--- a/src/bin/commands/account-readiness/ssm.ts
+++ b/src/bin/commands/account-readiness/ssm.ts
@@ -1,17 +1,16 @@
 import type { CredentialProviderChain } from "aws-sdk";
 import AWS from "aws-sdk";
 import chalk from "chalk";
-import { LibraryInfo } from "../../constants/library-info";
-import { SSM_PARAMETER_PATHS } from "../../constants/ssm-parameter-paths";
-import type { CliCommandResponse } from "../../types/command";
+import { LibraryInfo } from "../../../constants/library-info";
+import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
 
-export const accountReadinessCommand = async ({
+export const ssmParamReadiness = async ({
   credentialProvider,
   region,
 }: {
   credentialProvider: CredentialProviderChain;
   region: string;
-}): CliCommandResponse => {
+}): Promise<number> => {
   const ssm = new AWS.SSM({
     credentialProvider,
     region,

--- a/src/bin/commands/account-readiness/ssm.ts
+++ b/src/bin/commands/account-readiness/ssm.ts
@@ -1,16 +1,10 @@
-import type { CredentialProviderChain } from "aws-sdk";
 import AWS from "aws-sdk";
 import chalk from "chalk";
 import { LibraryInfo } from "../../../constants/library-info";
 import { SSM_PARAMETER_PATHS } from "../../../constants/ssm-parameter-paths";
+import type { AwsAccountReadiness } from "../../../types/cli";
 
-export const ssmParamReadiness = async ({
-  credentialProvider,
-  region,
-}: {
-  credentialProvider: CredentialProviderChain;
-  region: string;
-}): Promise<number> => {
+export const ssmParamReadiness = async ({ credentialProvider, region }: AwsAccountReadiness): Promise<number> => {
   const ssm = new AWS.SSM({
     credentialProvider,
     region,

--- a/src/bin/commands/aws-cdk-version.ts
+++ b/src/bin/commands/aws-cdk-version.ts
@@ -1,5 +1,5 @@
 import { LibraryInfo } from "../../constants/library-info";
-import type { CliCommandResponse } from "../../types/command";
+import type { CliCommandResponse } from "../../types/cli";
 
 export const awsCdkVersionCommand = (): CliCommandResponse => {
   return Promise.resolve(LibraryInfo.AWS_CDK_VERSIONS);

--- a/src/bin/commands/check-package-json.ts
+++ b/src/bin/commands/check-package-json.ts
@@ -2,7 +2,7 @@ import { access, readFile } from "fs/promises";
 import path from "path";
 import type { PackageJson } from "read-pkg-up";
 import { LibraryInfo } from "../../constants/library-info";
-import type { CliCommandResponse } from "../../types/command";
+import type { CliCommandResponse } from "../../types/cli";
 import { getAwsCdkDependencies } from "../../utils/package-json";
 
 const filterVersionMismatch = (deps: Record<string, string>) =>

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -2,7 +2,7 @@
 
 import yargs from "yargs";
 import { LibraryInfo } from "../constants/library-info";
-import type { CliCommandResponse } from "../types/command";
+import type { CliCommandResponse } from "../types/cli";
 import { awsCredentialProviderChain } from "./aws-credential-provider";
 import { accountReadinessCommand } from "./commands/account-readiness";
 import { awsCdkVersionCommand } from "./commands/aws-cdk-version";

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,3 +1,10 @@
+import type { CredentialProviderChain } from "aws-sdk";
+
+export interface AwsAccountReadiness {
+  credentialProvider: CredentialProviderChain;
+  region: string;
+}
+
 // A CLI command can return...
 export type CliCommandResponse = Promise<
   // ...a simple message to be printed


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Refactors `src/bin/commands` a little to allow for future commands, such as VPC readiness.

This is a no-op, it's in it's own PR because the VPC readiness branch is getting a little big!

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Future work is easier.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a