### PR TITLE
fix: Don't tag the entire stack with pattern app tag in GuScheduledEcsTask

### DIFF
--- a/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
@@ -31,6 +31,10 @@ Object {
         "ClusterName": "ecs-test-cluster-TEST",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -146,6 +150,10 @@ Object {
         "StateMachineName": "ecs-test-TEST",
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -182,6 +190,10 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -253,6 +265,10 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -505,6 +521,10 @@ Object {
         ],
         "Tags": Array [
           Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -547,6 +567,10 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -621,6 +645,10 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
@@ -31,10 +31,6 @@ Object {
         "ClusterName": "ecs-test-cluster-TEST",
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -150,10 +146,6 @@ Object {
         "StateMachineName": "ecs-test-TEST",
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -190,10 +182,6 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -265,10 +253,6 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -521,10 +505,6 @@ Object {
         ],
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -567,10 +547,6 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -645,10 +621,6 @@ Object {
           "Version": "2012-10-17",
         },
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -147,7 +147,6 @@ const getContainer = (config: ContainerConfiguration) => {
  */
 export class GuScheduledEcsTask {
   constructor(scope: GuStack, props: GuScheduledEcsTaskProps) {
-    AppIdentity.taggedConstruct({ app: props.app }, scope);
 
     const timeout = props.taskTimeoutInMinutes ?? 15;
 

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -147,7 +147,6 @@ const getContainer = (config: ContainerConfiguration) => {
  */
 export class GuScheduledEcsTask {
   constructor(scope: GuStack, props: GuScheduledEcsTaskProps) {
-
     const timeout = props.taskTimeoutInMinutes ?? 15;
 
     // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu for details

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -202,7 +202,7 @@ export class GuScheduledEcsTask {
       stateMachineName: `${props.app}-${props.stage}`,
     });
 
-    new Rule(scope, AppIdentity.suffixText(props, "ScheduleRule"), {
+    const rule = new Rule(scope, AppIdentity.suffixText(props, "ScheduleRule"), {
       schedule: props.schedule,
       targets: [new SfnStateMachine(stateMachine)],
     });
@@ -243,8 +243,14 @@ export class GuScheduledEcsTask {
           treatMissingData: TreatMissingData.NOT_BREACHING,
         });
         alarm.addAlarmAction(new SnsAction(alarmTopic));
+        AppIdentity.taggedConstruct({ app: props.app }, alarm);
       });
     }
+
+    // Tag all constructs with correct app tag
+    [cluster, task, taskDefinition, stateMachine, rule].forEach((c) =>
+      AppIdentity.taggedConstruct({ app: props.app }, c)
+    );
 
     new CfnOutput(scope, AppIdentity.suffixText(props, "StateMachineArnOutput"), {
       value: stateMachine.stateMachineArn,


### PR DESCRIPTION
## What does this change?
This removes the AppIdentity.taggedConstruct call from `GuScheduledEcsTask`. On Lurch this caused some problems as we have multiple apps in one stack, and `AppIdentity.taggedConstruct` replaced all of those tags with the app tag of our `GuScheduledEcsTask`. We're doing this https://github.com/guardian/lurch/blob/main/packages/infra/LurchCDK.ts#L359 to work around it at the moment but that's not very good!

## Does this change require changes to existing projects or CDK CLI?
Just Lurch

## How can we measure success?
Gu Patterns should not interfere with other resources within the same stack

## Have we considered potential risks?
Tagging will be less thorough :(