### PR TITLE
fix: Don't tag the entire stack with pattern app tag in GuEc2App

### DIFF
--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -830,10 +830,6 @@ Object {
         ],
         "Tags": Array [
           Object {
-            "Key": "App",
-            "Value": "test-gu-ec2-app",
-          },
-          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1610,10 +1606,6 @@ Object {
           },
         ],
         "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "test-gu-ec2-app",
-          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -345,8 +345,6 @@ export class GuEc2App {
   public readonly targetGroup: GuApplicationTargetGroup;
 
   constructor(scope: GuStack, props: GuEc2AppProps) {
-    AppIdentity.taggedConstruct(props, scope);
-
     const { app } = props;
     const vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText(props, "VPC"));
     const privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app });


### PR DESCRIPTION
This fixes the problem reported in https://github.com/guardian/cdk/pull/804 for the `GuEc2App` pattern (and subclasses).
