### PR TITLE
feat: Perform VPC analysis in account-readiness

### DIFF
--- a/src/bin/commands/account-readiness/index.ts
+++ b/src/bin/commands/account-readiness/index.ts
@@ -1,9 +1,10 @@
 import type { AwsAccountReadiness, CliCommandResponse } from "../../../types/cli";
 import { ssmParamReadiness } from "./ssm";
+import { vpcReadiness } from "./vpc";
 
 export const accountReadinessCommand = async (props: AwsAccountReadiness): CliCommandResponse => {
   // Got a new AWS account readiness command? Add it to this list and ✨
-  const commandResponses: number[] = await Promise.all([ssmParamReadiness(props)]);
+  const commandResponses: number[] = await Promise.all([ssmParamReadiness(props), vpcReadiness(props)]);
 
   const totalFailedCommands = commandResponses.filter((_) => _ !== 0);
   const allCommandsSuccessful = totalFailedCommands.length === 0;

--- a/src/bin/commands/account-readiness/vpc.ts
+++ b/src/bin/commands/account-readiness/vpc.ts
@@ -1,0 +1,58 @@
+import AWS from "aws-sdk";
+import chalk from "chalk";
+import type { AwsAccountReadiness } from "../../../types/cli";
+import { doesDefaultVpcSsmParameterExist, getSsmParametersForVpc, getVpcsInDetail } from "../../../utils/cli/vpc";
+
+const UNKNOWN = "unknown";
+
+export const vpcReadiness = async ({ credentialProvider, region }: AwsAccountReadiness): Promise<number> => {
+  const ec2Client = new AWS.EC2({
+    credentialProvider,
+    region,
+  });
+  const ssmClient = new AWS.SSM({
+    credentialProvider,
+    region,
+  });
+
+  const vpcs = await getVpcsInDetail(ec2Client);
+  const inUseVpcs = vpcs.filter((vpc) => vpc.isUsed);
+  const ssmParamsFromAccount = await getSsmParametersForVpc(ssmClient);
+  const usingDeprecatedSsmParameter = doesDefaultVpcSsmParameterExist(ssmParamsFromAccount);
+
+  console.group(chalk.bold("\nVPC Summary"));
+
+  if (usingDeprecatedSsmParameter) {
+    console.log(
+      `❌ SSM parameters with path '/account/vpc/default/*' found. Please rename to '/account/vpc/primary/*'`
+    );
+  }
+
+  const totalSsmParametersExpected = inUseVpcs.length * 3;
+  const hasExpectedSsmParameters = ssmParamsFromAccount.length === totalSsmParametersExpected;
+
+  if (!hasExpectedSsmParameters) {
+    console.log(
+      `❌ Expected to find ${chalk.bold(
+        totalSsmParametersExpected
+      )} SSM Parameters (3 per in use VPC) but found ${chalk.bold(ssmParamsFromAccount.length)}`
+    );
+  }
+
+  const vpcsForLogging = vpcs.map((vpc) => ({
+    VpcId: vpc.VpcId ?? UNKNOWN,
+    Region: region,
+    IsAwsDefaultVpc: vpc.IsDefault,
+    InUse: vpc.isUsed,
+    CidrBlock: vpc.CidrBlock,
+  }));
+  console.table(vpcsForLogging);
+
+  console.groupEnd();
+
+  if (!usingDeprecatedSsmParameter && hasExpectedSsmParameters) {
+    return Promise.resolve(0);
+  } else {
+    return Promise.resolve(1);
+  }
+};

--- a/src/constants/library-info.ts
+++ b/src/constants/library-info.ts
@@ -9,6 +9,11 @@ const version = valueOrUnknown(packageJson?.version);
 
 export const LibraryInfo = {
   /**
+   * The name of this package
+   */
+  NAME: "@guardian/cdk",
+
+  /**
    * The current version of `@guardian/cdk`.
    */
   VERSION: version,

--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -3,6 +3,8 @@ export interface SsmParameterPath {
   description: string;
 }
 
+export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
+
 export const SSM_PARAMETER_PATHS: Record<string, SsmParameterPath> = {
   Anghammarad: {
     path: "/account/services/anghammarad.topic.arn",
@@ -16,24 +18,24 @@ export const SSM_PARAMETER_PATHS: Record<string, SsmParameterPath> = {
     path: "/account/services/artifact.bucket",
     description: "SSM parameter containing the S3 bucket name holding distribution artifacts",
   },
+  AccessLoggingBucket: {
+    path: "/account/services/access-logging/bucket",
+    description: "S3 bucket to store your access logs",
+  },
   ConfigurationBucket: {
     path: "/account/services/private.config.bucket",
     description: "SSM parameter containing the S3 bucket name holding the app's private configuration",
   },
   PrimaryVpcId: {
-    path: "/account/vpc/primary/id",
+    path: `${VPC_SSM_PARAMETER_PREFIX}/primary/id`,
     description: "Virtual Private Cloud to run EC2 instances within",
   },
-  AccessLoggingBucket: {
-    path: "/account/services/access-logging/bucket",
-    description: "S3 bucket to store your access logs",
-  },
   PrimaryVpcPrivateSubnets: {
-    path: "/account/vpc/primary/subnets/private",
+    path: `${VPC_SSM_PARAMETER_PREFIX}/primary/subnets/private`,
     description: "A list of private subnets",
   },
   PrimaryVpcPublicSubnets: {
-    path: "/account/vpc/primary/subnets/public",
+    path: `${VPC_SSM_PARAMETER_PREFIX}/primary/subnets/public`,
     description: "A list of public subnets",
   },
 };

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,4 +1,5 @@
 import type { CredentialProviderChain } from "aws-sdk";
+import type { SubnetList, Vpc } from "aws-sdk/clients/ec2";
 
 export interface AwsAccountReadiness {
   credentialProvider: CredentialProviderChain;
@@ -14,3 +15,8 @@ export type CliCommandResponse = Promise<
   // ...or an exit code
   | number
 >;
+
+export interface VpcInDetail extends Vpc {
+  subnets: SubnetList;
+  isUsed: boolean;
+}

--- a/src/utils/cli/vpc.test.ts
+++ b/src/utils/cli/vpc.test.ts
@@ -1,0 +1,19 @@
+import { primaryVpcSsmParameterPaths, vpcSsmParameterPaths } from "./vpc";
+
+describe("VPC utils", () => {
+  test("Identification of primary VPC SSM parameter paths", () => {
+    expect(primaryVpcSsmParameterPaths).toEqual([
+      "/account/vpc/primary/id",
+      "/account/vpc/primary/subnets/private",
+      "/account/vpc/primary/subnets/public",
+    ]);
+  });
+
+  test("VPC SSM parameter path regex patterns", () => {
+    expect(vpcSsmParameterPaths).toEqual([
+      new RegExp("^/account/vpc/([A-z0-9.-_])+/id$"),
+      new RegExp("^/account/vpc/([A-z0-9.-_])+/subnets/private$"),
+      new RegExp("^/account/vpc/([A-z0-9.-_])+/subnets/public$"),
+    ]);
+  });
+});

--- a/src/utils/cli/vpc.ts
+++ b/src/utils/cli/vpc.ts
@@ -1,0 +1,107 @@
+import type AWS from "aws-sdk";
+import type { DescribeSubnetsResult, DescribeVpcsResult, SubnetList, Vpc, VpcList } from "aws-sdk/clients/ec2";
+import type { ParameterList } from "aws-sdk/clients/ssm";
+import { SSM_PARAMETER_PATHS, VPC_SSM_PARAMETER_PREFIX } from "../../constants/ssm-parameter-paths";
+import type { VpcInDetail } from "../../types/cli";
+import { sum } from "../math";
+
+export const primaryVpcSsmParameterPaths: string[] = Object.values(SSM_PARAMETER_PATHS)
+  .map((_) => _.path)
+  .filter((_) => _.startsWith(VPC_SSM_PARAMETER_PREFIX));
+
+export const vpcSsmParameterPaths: RegExp[] = primaryVpcSsmParameterPaths.map((primaryPath) => {
+  const reBody = primaryPath.replace("primary", "([A-z0-9.-_])+");
+  return new RegExp(`^${reBody}$`);
+});
+
+const getSsmParametersWithVpcPrefix = async (ssmClient: AWS.SSM): Promise<ParameterList> => {
+  const params = await ssmClient
+    .getParametersByPath({
+      Path: VPC_SSM_PARAMETER_PREFIX,
+      Recursive: true,
+    })
+    .promise();
+  return params.Parameters ?? [];
+};
+
+export const getSsmParametersForVpc = async (ssmClient: AWS.SSM): Promise<ParameterList> => {
+  const paramsWithVpcPrefix = await getSsmParametersWithVpcPrefix(ssmClient);
+
+  return paramsWithVpcPrefix.filter((param) => {
+    const path = param.Name;
+    if (!path) {
+      return false;
+    }
+
+    return vpcSsmParameterPaths.filter((re) => re.exec(path)).length > 0;
+  });
+};
+
+export const doesDefaultVpcSsmParameterExist = (parameters: ParameterList): boolean => {
+  const vpcIdentifiers = parameters.map((_) => vpcIdentifierFromVpcSsmParameterPath(_.Name ?? ""));
+  return vpcIdentifiers.includes("default");
+};
+
+export const vpcIdentifierFromVpcSsmParameterPath = (path: string): string => {
+  const [, , identifier] = path.split("/");
+  return identifier;
+};
+
+const getSubnetsForVpc = async (vpc: Vpc, ec2Client: AWS.EC2): Promise<SubnetList> => {
+  if (!vpc.VpcId) {
+    return [];
+  }
+  const response: DescribeSubnetsResult = await ec2Client
+    .describeSubnets({ Filters: [{ Name: "vpc-id", Values: [vpc.VpcId] }] })
+    .promise();
+  return response.Subnets ?? [];
+};
+
+const getVpcs = async (ec2Client: AWS.EC2): Promise<VpcList> => {
+  const vpcs: DescribeVpcsResult = await ec2Client.describeVpcs().promise();
+  return vpcs.Vpcs ?? [];
+};
+
+const totalUnusedAddressesInSubnet = (subnets: SubnetList): number => {
+  return sum(subnets.map((_) => _.AvailableIpAddressCount ?? 0));
+};
+
+const countFromCidr = (cidr: string): number => {
+  const UNUSABLE_IPS_IN_CIDR_BLOCK = 5;
+
+  const [, mask] = cidr.split("/");
+  const maskAsNumber = Number(mask);
+
+  if (isNaN(maskAsNumber)) {
+    return 0;
+  }
+
+  const hostBits = 32 - maskAsNumber;
+  return Math.pow(2, hostBits) - UNUSABLE_IPS_IN_CIDR_BLOCK;
+};
+
+const totalCapacityOfSubnet = (subnets: SubnetList): number => {
+  const counts = subnets
+    .map((subnet) => subnet.CidrBlock)
+    .map((cidrBlock) => (cidrBlock ? countFromCidr(cidrBlock) : 0));
+
+  return sum(counts.filter((_) => !!_));
+};
+
+export const getVpcsInDetail = async (ec2Client: AWS.EC2): Promise<VpcInDetail[]> => {
+  const vpcs = await getVpcs(ec2Client);
+
+  return await Promise.all(
+    vpcs.map(async (vpc) => {
+      const subnets = await getSubnetsForVpc(vpc, ec2Client);
+
+      const isUsed: boolean = totalCapacityOfSubnet(subnets) - totalUnusedAddressesInSubnet(subnets) !== 0;
+
+      return {
+        ...vpc,
+        subnets,
+        isUsed,
+      };
+    })
+  );
+};

--- a/src/utils/math.test.ts
+++ b/src/utils/math.test.ts
@@ -1,0 +1,8 @@
+import { sum } from "./math";
+
+describe("sum", () => {
+  it("should sum a list of numbers", () => {
+    const numbers = [1, 2, 3, 4, 0];
+    expect(sum(numbers)).toEqual(10);
+  });
+});

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,1 @@
+export const sum = (input: number[]): number => input.reduce<number>((total, current) => total + current, 0);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

GuCDK uses values in SSM parameter store to know into which VPC resources should be launched.

If the parameters do not exist, GuCDK will produce a template that cannot be executed.

This change adds some VPC analysis to the `account-readiness` CLI command. It:
  - Finds all VPCs in the AWS region
  - Determines if the VPC is in use (logic copied from [Prism](https://github.com/guardian/prism/blob/a9f3ecf47a1f2fd4361f61c39832c936a170b6f7/app/collectors/vpc.scala))
  - Expects three SSM parameters to exist for each in use VPC:
    1. `^/account/vpc/([A-z0-9.-_])+/id$`
    2. `^/account/vpc/([A-z0-9.-_])+/subnets/private$`
    3. `^/account/vpc/([A-z0-9.-_])+/subnets/public$`

Typically, an account has one in use VPC.

![image](https://user-images.githubusercontent.com/836140/134325438-9e15feed-1fb9-4155-8252-3cd0fbb42143.png)

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

This _is_ the CLI 😈 .

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

- Checkout branch
- Run `./script/cli account-readiness --profile deployTools`
- Observe output

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Migrating to GuCDK is that much easier.
