### PR TITLE
feat: add CDK constructs for Guardian::DNS::RecordSet

### DIFF
--- a/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
+++ b/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuCname construct should create the correct resources with minimal config 1`] = `
+Object {
+  "Parameters": Object {
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "TestRecord": Object {
+      "Properties": Object {
+        "Name": "banana.example.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          "apple.example.com",
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+  },
+}
+`;
+
+exports[`The GuDnsRecordSet construct should create the correct resources with minimal config 1`] = `
+Object {
+  "Parameters": Object {
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "TestRecord": Object {
+      "Properties": Object {
+        "Name": "banana.example.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          "apple.example.com",
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+  },
+}
+`;

--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -1,5 +1,6 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
+import { Duration } from "@aws-cdk/core";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuCname, GuDnsRecordSet, RecordType } from "./dns-records";
 
@@ -10,21 +11,9 @@ describe("The GuDnsRecordSet construct", () => {
       name: "banana.example.com",
       recordType: RecordType.CNAME,
       resourceRecords: ["apple.example.com"],
+      ttl: Duration.hours(1),
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
-  });
-
-  it("should allow users to override the default TTL", () => {
-    const stack = simpleGuStackForTesting();
-    new GuDnsRecordSet(stack, "TestRecord", {
-      name: "banana.example.com",
-      recordType: RecordType.CNAME,
-      resourceRecords: ["apple.example.com"],
-      ttl: 123,
-    });
-    expect(stack).toHaveResourceLike("Guardian::DNS::RecordSet", {
-      TTL: 123,
-    });
   });
 });
 
@@ -36,5 +25,17 @@ describe("The GuCname construct", () => {
       resourceRecord: "apple.example.com",
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+  it("should allow users to override the default TTL", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDnsRecordSet(stack, "TestRecord", {
+      name: "banana.example.com",
+      recordType: RecordType.CNAME,
+      resourceRecords: ["apple.example.com"],
+      ttl: Duration.minutes(1),
+    });
+    expect(stack).toHaveResourceLike("Guardian::DNS::RecordSet", {
+      TTL: 60,
+    });
   });
 });

--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -1,0 +1,40 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { simpleGuStackForTesting } from "../../utils/test";
+import { GuCname, GuDnsRecordSet, RecordType } from "./dns-records";
+
+describe("The GuDnsRecordSet construct", () => {
+  it("should create the correct resources with minimal config", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDnsRecordSet(stack, "TestRecord", {
+      name: "banana.example.com",
+      recordType: RecordType.CNAME,
+      resourceRecords: ["apple.example.com"],
+    });
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+
+  it("should allow users to override the default TTL", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDnsRecordSet(stack, "TestRecord", {
+      name: "banana.example.com",
+      recordType: RecordType.CNAME,
+      resourceRecords: ["apple.example.com"],
+      ttl: 123,
+    });
+    expect(stack).toHaveResourceLike("Guardian::DNS::RecordSet", {
+      TTL: 123,
+    });
+  });
+});
+
+describe("The GuCname construct", () => {
+  it("should create the correct resources with minimal config", () => {
+    const stack = simpleGuStackForTesting();
+    new GuCname(stack, "TestRecord", {
+      name: "banana.example.com",
+      resourceRecord: "apple.example.com",
+    });
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+});

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,0 +1,44 @@
+import { CfnResource } from "@aws-cdk/core";
+import type { GuStack } from "../core";
+
+export enum RecordType {
+  CNAME = "CNAME",
+}
+
+export interface GuDnsRecordSetProps {
+  name: string;
+  recordType: RecordType;
+  resourceRecords: string[];
+  ttl?: number;
+}
+
+export class GuDnsRecordSet {
+  constructor(scope: GuStack, id: string, props: GuDnsRecordSetProps) {
+    new CfnResource(scope, id, {
+      type: "Guardian::DNS::RecordSet",
+      properties: {
+        Name: props.name,
+        ResourceRecords: props.resourceRecords,
+        RecordType: props.recordType,
+        TTL: props.ttl ?? 3600,
+        Stage: scope.stage,
+      },
+    });
+  }
+}
+
+export interface GuCnameProps {
+  name: string;
+  resourceRecord: string;
+  ttl?: number;
+}
+
+export class GuCname extends GuDnsRecordSet {
+  constructor(scope: GuStack, id: string, props: GuCnameProps) {
+    super(scope, id, {
+      recordType: RecordType.CNAME,
+      resourceRecords: [props.resourceRecord],
+      ...props,
+    });
+  }
+}

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -12,8 +12,13 @@ export interface GuDnsRecordSetProps {
   ttl?: number;
 }
 
+/**
+ * Do not use this construct directly. Use [[`GuCname`]] instead in order to reduce boilerplate.
+ */
 export class GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuDnsRecordSetProps) {
+    // The spec for this private resource type can be found here:
+    // https://github.com/guardian/cfn-private-resource-types/tree/main/dns/guardian-dns-record-set-type/docs#syntax
     new CfnResource(scope, id, {
       type: "Guardian::DNS::RecordSet",
       properties: {
@@ -28,11 +33,19 @@ export class GuDnsRecordSet {
 }
 
 export interface GuCnameProps {
+  /** The name of the record, for example: xyz.example.com */
   name: string;
+  /** The record your CNAME should point to, for example your Load Balancer DNS name */
   resourceRecord: string;
+  /** The time to live in seconds for the DNS record - this will be set to 3600 seconds (1 hour) by default */
   ttl?: number;
 }
 
+/**
+ * Construct for creating CNAME records in NS1.
+ *
+ * See [[`GuCnameProps`]] for configuration options.
+ */
 export class GuCname extends GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuCnameProps) {
     super(scope, id, {

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,4 +1,4 @@
-import { CfnResource } from "@aws-cdk/core";
+import { CfnResource, Duration } from "@aws-cdk/core";
 import type { GuStack } from "../core";
 
 export enum RecordType {
@@ -9,7 +9,7 @@ export interface GuDnsRecordSetProps {
   name: string;
   recordType: RecordType;
   resourceRecords: string[];
-  ttl?: number;
+  ttl: Duration;
 }
 
 /**
@@ -25,7 +25,7 @@ export class GuDnsRecordSet {
         Name: props.name,
         ResourceRecords: props.resourceRecords,
         RecordType: props.recordType,
-        TTL: props.ttl ?? 3600,
+        TTL: props.ttl.toSeconds(),
         Stage: scope.stage,
       },
     });
@@ -37,8 +37,8 @@ export interface GuCnameProps {
   name: string;
   /** The record your CNAME should point to, for example your Load Balancer DNS name */
   resourceRecord: string;
-  /** The time to live in seconds for the DNS record - this will be set to 3600 seconds (1 hour) by default */
-  ttl?: number;
+  /** The time to live for the DNS record - this will be set 1 hour by default */
+  ttl?: Duration;
 }
 
 /**
@@ -51,6 +51,7 @@ export class GuCname extends GuDnsRecordSet {
     super(scope, id, {
       recordType: RecordType.CNAME,
       resourceRecords: [props.resourceRecord],
+      ttl: props.ttl ?? Duration.hours(1),
       ...props,
     });
   }

--- a/src/constructs/dns/index.ts
+++ b/src/constructs/dns/index.ts
@@ -1,0 +1,1 @@
+export * from "./dns-records";


### PR DESCRIPTION
## What does this change?

This PR allows users to create DNS records in NS1 via `@guardian/cdk`.

## Does this change require changes to existing projects or CDK CLI?

No, this is new functionality. Some projects will now be able to 'inherit' their existing DNS records, but this is not mandatory.

## Does this change require changes to the library documentation?

Yes, I've added some minimal documentation.

## How to test

I've added unit tests for this. I've also confirmed that the CFN that gets produced can create a `Guardian::DNS::RecordSet` in the Developer Playground.

## How can we measure success?

Apps which use `@guardian/cdk` to define their infrastructure can now create and manage CNAMEs in their source code, with minimal boilerplate.

## Have we considered potential risks?

I think the risks associated with this change are managed via https://github.com/guardian/cfn-private-resource-types. This PR just makes it easier to use the private resource type!