### PR TITLE
fix: Export GuScheduledEcsTask useful types

### DIFF
--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -47,20 +47,20 @@ import { GuGetDistributablePolicyStatement } from "../constructs/iam";
  * ```
  */
 
-type RepositoryContainer = {
+export type RepositoryContainer = {
   repository: IRepository;
   version: string;
   type: "repository";
 };
 
-type RegistryContainer = {
+export type RegistryContainer = {
   id?: string;
   type: "registry";
 };
 
-type ContainerConfiguration = RepositoryContainer | RegistryContainer;
+export type ContainerConfiguration = RepositoryContainer | RegistryContainer;
 
-type GuEcsTaskMonitoringProps = { snsTopicArn: string; noMonitoring: false };
+export type GuEcsTaskMonitoringProps = { snsTopicArn: string; noMonitoring: false };
 
 /**
  * Configuration options for the [[`GuScheduledEcsTask`]] pattern.


### PR DESCRIPTION
On Lurch we'll soon have multiple `GuScheduledEcsTask`s in the same stack. Some of the props will be the same. It's useful to export these types so that we can have functions which take e.g. a containerConfiguration as a parameter