### PR TITLE
fix: include app in scheduled ecs pattern alarm names 

### DIFF
--- a/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
@@ -69,32 +69,6 @@ Object {
       },
       "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
     },
-    "ExecutionsFailedAlarmCA489332": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          "arn:something:else:here:we:goalarm-topic",
-        ],
-        "AlarmDescription": "ecs-test-TEST job failed ",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "StateMachineArn",
-            "Value": Object {
-              "Ref": "StateMachineEcstest84BB1B77",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "ExecutionsFailed",
-        "Namespace": "AWS/States",
-        "Period": 3600,
-        "Statistic": "Sum",
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "ScheduleRuleEcstest07F5BBD2": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(1 minute)",
@@ -712,7 +686,33 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TimeoutAlarm4022815E": Object {
+    "ecstestexecutionfailedC93F511B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          "arn:something:else:here:we:goalarm-topic",
+        ],
+        "AlarmDescription": "ecs-test-TEST job failed ",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": Object {
+              "Ref": "StateMachineEcstest84BB1B77",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ecstesttimeoutFE335653": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -215,7 +215,7 @@ export class GuScheduledEcsTask {
       );
       const alarms = [
         {
-          name: "ExecutionsFailedAlarm",
+          name: `${props.app}-execution-failed`,
           description: `${props.app}-${props.stage} job failed `,
           metric: stateMachine.metricFailed({
             period: Duration.hours(1),
@@ -223,7 +223,7 @@ export class GuScheduledEcsTask {
           }),
         },
         {
-          name: "TimeoutAlarm",
+          name: `${props.app}-timeout`,
           description: `${props.app}-${props.stage} job timed out `,
           metric: stateMachine.metricTimedOut({
             period: Duration.hours(1),


### PR DESCRIPTION
## What does this change?
This adds the app-stage prefix to alarms generated by the scheduled ecs task pattern. Without this it is not possible to have more than one GuScheduledEcsTask in the same stack

## Does this change require changes to existing projects or CDK CLI?
Currently this pattern is only in use by Lurch so all OK I think!

## Does this change require changes to the library documentation?
No

## How to test
I've tested this using the lurch stack

## How can we measure success?
Being able to have >1 guscheduledecstask in a stack

