### PR TITLE
chore: Swap `actions/setup-node` for `guardian/actions-setup-node`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,21 +7,12 @@ on:
 jobs:
   CD:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.15.1]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.0
+      - name: Setup node
+        uses: guardian/actions-setup-node@v2.4.1
         with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
       - name: CD
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,21 +19,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CI:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.15.1]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.0
+      - name: Setup node
+        uses: guardian/actions-setup-node@v2.4.1
         with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
       - run: ./script/ci
   approve-and-merge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[`guardian/actions-setup-node`](https://github.com/guardian/actions-setup-node) is a fork of `actions/setup-node` and adds node version auto-discovery. Using it results in simpler GitHub workflows.

It also makes changing the node version as simple as updating `.nvmrc`, keeping `node-version` within the workflow files in sync with `.nvmrc`.

Additionally `actions/setup-node` (and thus ``guardian/actions-setup-node`) [uses `actions/cache` under the hood](https://github.com/actions/setup-node#caching-packages-dependencies). This means we can further simplify the workflows.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should continue to function.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler configuration and a simpler story for node upgrades in the future.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We introduced caching to solve a specific issue (#532). Does this change impact that? Hopefully not as, ultimately, we still use `actions/cache`.

We'll need to update our branch protection rule as the check `CI (14.15.1)` will no longer exist and is replaced with `CI / CI (pull_request)`.

![image](https://user-images.githubusercontent.com/836140/135401653-bbac3628-40d8-494f-912c-6a07bf18e41f.png)
