### PR TITLE
fix: fix Github Actions Role OIDC token url

### DIFF
--- a/src/constructs/iam/roles/__snapshots__/github-actions.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/github-actions.test.ts.snap
@@ -53,7 +53,7 @@ Object {
         "ThumbprintList": Array [
           "a031c46782e6e6c662c2c87c76da9aa62ccabd8e",
         ],
-        "Url": "https://vstoken.actions.githubusercontent.com",
+        "Url": "https://token.actions.githubusercontent.com",
       },
       "Type": "AWS::IAM::OIDCProvider",
     },
@@ -65,7 +65,7 @@ Object {
               "Action": "sts:AssumeRoleWithWebIdentity",
               "Condition": Object {
                 "StringLike": Object {
-                  "vstoken.actions.githubusercontent.com:sub": "repo:guardian/*",
+                  "token.actions.githubusercontent.com:sub": "repo:guardian/*",
                 },
               },
               "Effect": "Allow",

--- a/src/constructs/iam/roles/github-actions.test.ts
+++ b/src/constructs/iam/roles/github-actions.test.ts
@@ -39,7 +39,7 @@ describe("The GitHubActionsRole construct", () => {
             Action: "sts:AssumeRoleWithWebIdentity",
             Condition: {
               StringLike: {
-                "vstoken.actions.githubusercontent.com:sub": "repo:guardian/platform-*",
+                "token.actions.githubusercontent.com:sub": "repo:guardian/platform-*",
               },
             },
           },

--- a/src/constructs/iam/roles/github-actions.ts
+++ b/src/constructs/iam/roles/github-actions.ts
@@ -4,7 +4,7 @@ import type { GuStack } from "../../core";
 import type { GuPolicy } from "../policies";
 import { GuRole } from "./roles";
 
-const GITHUB_ACTIONS_ID_TOKEN_REQUEST_DOMAIN = "vstoken.actions.githubusercontent.com";
+const GITHUB_ACTIONS_ID_TOKEN_REQUEST_DOMAIN = "token.actions.githubusercontent.com";
 
 /*
 Thumbprint of `GITHUB_ACTIONS_ID_TOKEN_REQUEST_DOMAIN`.


### PR DESCRIPTION
Following from https://github.com/guardian/deploy-tools-platform/pull/544 - this uses the correct url for the GuGithubActionsRole OIDC token

GuGithubActionsRole is brand new as of an hour ago: https://github.com/guardian/cdk/pull/823 so I don't expect this to impact anyone (but will fix the construct)