### PR TITLE
feat: add family to task definition

### DIFF
--- a/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-ecs-task.test.ts.snap
@@ -111,7 +111,7 @@ Object {
                   "Arn",
                 ],
               },
-              "\\",\\"TaskDefinition\\":\\"test-ecs-test-TEST\\",\\"NetworkConfiguration\\":{\\"AwsvpcConfiguration\\":{\\"Subnets\\":[\\"abc-123\\"],\\"SecurityGroups\\":[\\"id-123\\"]}},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"LATEST\\"}}}}",
+              "\\",\\"TaskDefinition\\":\\"test-TEST-ecs-test\\",\\"NetworkConfiguration\\":{\\"AwsvpcConfiguration\\":{\\"Subnets\\":[\\"abc-123\\"],\\"SecurityGroups\\":[\\"id-123\\"]}},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"LATEST\\"}}}}",
             ],
           ],
         },
@@ -487,7 +487,7 @@ Object {
             "Arn",
           ],
         },
-        "Family": "test-ecs-test-TEST",
+        "Family": "test-TEST-ecs-test",
         "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": Array [

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -166,7 +166,7 @@ export class GuScheduledEcsTask {
       compatibility: Compatibility.FARGATE,
       cpu: cpu.toString(),
       memoryMiB: memory.toString(),
-      family: `${props.stack}-${props.app}-${props.stage}`,
+      family: `${props.stack}-${props.stage}-${props.app}`,
     });
 
     taskDefinition.addContainer(AppIdentity.suffixText(props, "ScheduledTaskContainer"), {


### PR DESCRIPTION
## What does this change?
This adds the `family` property to task definitions created as part of a GuScheduledEcsTask. Without this, the task definition will be only identifiable by the logical ID, which ends up being the same for CODE and PROD, so we get CODE tasks mixed up with PROD tasks. I'm actually suprised we got away with it as the family property listed as 'required' in the [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html). 

## Does this change require changes to existing projects or CDK CLI?
This will result in existing task definitions being recreated and showing up in the UI with a new name, but they're just config (no data that will be lost - everything is included in the CDK template) so this is fairly non destructive. 

## Does this change require changes to the library documentation?
No

## How to test
I've tested this using LURCH, it makes the task list look a lot nicer.

Before:
<img width="326" alt="Screenshot 2021-10-12 at 11 01 15" src="https://user-images.githubusercontent.com/3606555/136935562-a6810e1e-6578-4bf2-adb6-d38029fc1879.png">
After:
<img width="263" alt="Screenshot 2021-10-12 at 11 01 19" src="https://user-images.githubusercontent.com/3606555/136935568-056460a3-f494-4181-93e6-51f349d542e7.png">

## How can we measure success?
At the moment the scheduled task just runs whichever CODE or PROD stack was most recently deployed 😱 . This puts a stop to that
