### PR TITLE
fix: expose vpc props for auto-gen docs

### DIFF
--- a/src/constructs/vpc/vpc.ts
+++ b/src/constructs/vpc/vpc.ts
@@ -6,7 +6,7 @@ import { GuStatefulMigratableConstruct } from "../../utils/mixin";
 import type { GuStack } from "../core";
 import type { GuMigratingResource } from "../core/migrating";
 
-interface GuVpcCustomProps {
+export interface GuVpcCustomProps {
   /**
    * Whether to add SSM Parameters containing VPC metadata, which are expected
    * to exist by many other Guardian CDK patterns.
@@ -27,7 +27,7 @@ interface GuVpcCustomProps {
   ssmParametersNamespace?: string;
 }
 
-interface GuVpcProps extends GuVpcCustomProps, VpcProps, GuMigratingResource {}
+export interface GuVpcProps extends GuVpcCustomProps, VpcProps, GuMigratingResource {}
 
 /**
  * Construct which creates a Virtual Private Cloud.


### PR DESCRIPTION
## What does this change?

Exposes VPC props so that they appear in the auto-generated ts docs.

## Does this change require changes to existing projects or CDK CLI?

No

## Does this change require changes to the library documentation?

No

## How to test

Generate docs locally. (DONE)

Before:
![Screenshot 2021-10-27 at 10 27 01](https://user-images.githubusercontent.com/858402/139039263-d3c3dccc-6754-4d27-bb18-922ffb451873.png)

After (linked):
![Screenshot 2021-10-27 at 10 28 42](https://user-images.githubusercontent.com/858402/139039280-a8be5af4-ad03-4c08-844f-96aae5526c67.png)
