### PR TITLE
chore: Add a composite GitHub Action for CI of GuCDK infrastructure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,54 @@
+# A composite GitHub Action, performing CI of GuCDK infrastructure.
+#
+# Supports npm and yarn.
+# Usage when using npm:
+# - uses: guardian/cdk@main
+#
+# Usage when using yarn:
+# - uses: guardian/cdk@main
+#   with:
+#     packageManager: yarn
+#     lockfile: cdk/yarn.lock
+#
+# See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+
+name: CI for GuCDK
+description: CI for infrastructure defined using GuCDK
+inputs:
+  packageManager:
+    description: 'Which node package manager to use'
+    default: 'npm'
+    required: false
+  lockfile:
+    description: 'Location of the lockfile for the GuCDK project'
+    default: 'cdk/package-lock.json'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: guardian/actions-setup-node@v2.4.1
+      with:
+        cache: ${{ inputs.packageManager }}
+        cache-dependency-path: ${{ inputs.lockfile }}
+    - name: CI for CDK
+      shell: bash
+      working-directory: cdk
+      env:
+        PACKAGE_MANAGER: ${{ inputs.packageManager }}
+      run: |
+        if [ "$PACKAGE_MANAGER" = "npm" ]; then
+          npm ci
+          npm run build
+          npm run lint
+          npm run test
+          npm run synth
+        elif [ "$PACKAGE_MANAGER" = "yarn" ]; then
+          yarn install --frozen-lockfile
+          yarn build
+          yarn lint
+          yarn test
+          yarn synth
+        else
+          echo "$PACKAGE_MANAGER is not supported. Contributions welcomed though!"
+          exit 1
+        fi


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[Composite Actions](https://github.blog/changelog/2020-08-07-github-actions-composite-run-steps/) allow us to simplify workflows, specifically by encapsulating logic in a single place for use elsewhere.

This change introduces a composite action for CDK, it will:
- Install dependencies
- Run tests
- Synth the stack to disk

This action requires there to be a `build`, `lint`, `test` and `synth` script in a `package.json` file. At first glance this is a bit fragile, however with the upcoming changes to GuCDK project creation, we can guarantee the presence of them.

This vastly simplifies downstream repos, for example:
- https://github.com/guardian/tag-janitor/pull/230 (a yarn project)
- https://github.com/guardian/cdk-playground/pull/110 (a npm project)

That is, one can simply add this to a GHA workflow:

```yaml
- uses: guardian/cdk@main
```

We can later combine this with [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) to simplify CI of repositories even further.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

Sort of. It commits us to adding a number of scripts to a `package.json` when we start the project generation work.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See above linked example PRs, their CI should pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

DRYer GHA for CI definitions in repositories.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The advice given [here](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md) is to:

> Warning: do not reference `main` since that is the latest code and can be carrying breaking changes of the next major version.

We publish releases for this repository fairly frequently. If a downstream repository has configured Dependabot to run against GHA workflows, it is likely to get multiple PRs a week.

For this reason, the example usage is `guardian/cdk@main`, committing us to not releasing breaking changes to it. Given its relative simplicity, I think that's possible to fulfil.