### PR TITLE
refactor: Use `GuAppAwareConstruct` mixin to DRY codebase

### DIFF
--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -12,7 +12,7 @@ describe("The GuSecurityGroup class", () => {
     publicSubnetIds: [""],
   });
 
-  it("applies the Stage, Stage and App tags", () => {
+  it("applies the Stack, Stage and App tags", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuSecurityGroup(stack, "TestSecurityGroup", {
       vpc,

--- a/src/constructs/ec2/security-groups/base.test.ts
+++ b/src/constructs/ec2/security-groups/base.test.ts
@@ -12,6 +12,17 @@ describe("The GuSecurityGroup class", () => {
     publicSubnetIds: [""],
   });
 
+  it("applies the Stage, Stage and App tags", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+    new GuSecurityGroup(stack, "TestSecurityGroup", {
+      vpc,
+      existingLogicalId: { logicalId: "TestSG", reason: "testing" },
+      app: "testing",
+    });
+
+    expect(stack).toHaveGuTaggedResource("AWS::EC2::SecurityGroup", { appIdentity: { app: "testing" } });
+  });
+
   it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
     new GuSecurityGroup(stack, "TestSecurityGroup", {

--- a/src/constructs/ec2/security-groups/base.ts
+++ b/src/constructs/ec2/security-groups/base.ts
@@ -1,8 +1,9 @@
 import { Peer, Port, SecurityGroup } from "@aws-cdk/aws-ec2";
 import type { IPeer, SecurityGroupProps } from "@aws-cdk/aws-ec2";
 import { GuMigratableConstruct } from "../../../utils/mixin";
+import { GuAppAwareConstruct } from "../../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../../core";
-import { AppIdentity } from "../../core/identity";
+import type { AppIdentity } from "../../core/identity";
 import type { GuMigratingResource } from "../../core/migrating";
 
 /**
@@ -47,8 +48,8 @@ export interface GuSecurityGroupProps extends GuBaseSecurityGroupProps, AppIdent
  * - [[GuPublicInternetAccessSecurityGroup]]
  * - [[GuHttpsEgressSecurityGroup]]
  */
-export abstract class GuBaseSecurityGroup extends GuMigratableConstruct(SecurityGroup) {
-  protected constructor(scope: GuStack, id: string, props: GuBaseSecurityGroupProps) {
+export class GuBaseSecurityGroup extends GuMigratableConstruct(SecurityGroup) {
+  constructor(scope: GuStack, id: string, props: GuBaseSecurityGroupProps) {
     super(scope, id, props);
 
     props.ingresses?.forEach(({ range, port, description }) => {
@@ -68,10 +69,9 @@ export abstract class GuBaseSecurityGroup extends GuMigratableConstruct(Security
   }
 }
 
-export class GuSecurityGroup extends GuBaseSecurityGroup {
+export class GuSecurityGroup extends GuAppAwareConstruct(GuBaseSecurityGroup) {
   constructor(scope: GuStack, id: string, props: GuSecurityGroupProps) {
-    super(scope, AppIdentity.suffixText(props, id), props);
-    AppIdentity.taggedConstruct(props, this);
+    super(scope, id, props);
   }
 }
 

--- a/src/constructs/iam/policies/base-policy.ts
+++ b/src/constructs/iam/policies/base-policy.ts
@@ -8,8 +8,8 @@ export interface GuPolicyProps extends PolicyProps, GuMigratingResource {}
 
 export type GuNoStatementsPolicyProps = Omit<GuPolicyProps, "statements">;
 
-export abstract class GuPolicy extends GuMigratableConstruct(Policy) {
-  protected constructor(scope: GuStack, id: string, props: GuPolicyProps) {
+export class GuPolicy extends GuMigratableConstruct(Policy) {
+  constructor(scope: GuStack, id: string, props: GuPolicyProps) {
     super(scope, id, props);
   }
 }

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -1,6 +1,7 @@
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import { GuAppAwareConstruct } from "../../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../../core";
-import { AppIdentity } from "../../core/identity";
+import type { AppIdentity } from "../../core/identity";
 import { GuPolicy } from "./base-policy";
 
 export class GuParameterStoreReadPolicyStatement extends PolicyStatement {
@@ -13,13 +14,12 @@ export class GuParameterStoreReadPolicyStatement extends PolicyStatement {
   }
 }
 
-export class GuParameterStoreReadPolicy extends GuPolicy {
+export class GuParameterStoreReadPolicy extends GuAppAwareConstruct(GuPolicy) {
   constructor(scope: GuStack, props: AppIdentity) {
-    super(scope, AppIdentity.suffixText(props, "ParameterStoreRead"), {
+    super(scope, "ParameterStoreRead", {
       policyName: "parameter-store-read-policy",
       statements: [new GuParameterStoreReadPolicyStatement(scope, props)],
+      ...props,
     });
-
-    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/constructs/iam/policies/s3-get-object.ts
+++ b/src/constructs/iam/policies/s3-get-object.ts
@@ -1,8 +1,9 @@
 import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import type { GuPrivateS3ConfigurationProps } from "../../../utils/ec2";
+import { GuAppAwareConstruct } from "../../../utils/mixin/app-aware-construct";
 import { GuDistributionBucketParameter } from "../../core";
 import type { GuStack } from "../../core";
-import { AppIdentity } from "../../core/identity";
+import type { AppIdentity } from "../../core/identity";
 import { GuAllowPolicy } from "./base-policy";
 import type { GuNoStatementsPolicyProps } from "./base-policy";
 
@@ -48,15 +49,14 @@ export class GuGetS3ObjectsPolicy extends GuAllowPolicy {
  *
  * @see GuDistributionBucketParameter
  */
-export class GuGetDistributablePolicy extends GuGetS3ObjectsPolicy {
+export class GuGetDistributablePolicy extends GuAppAwareConstruct(GuGetS3ObjectsPolicy) {
   constructor(scope: GuStack, props: AppIdentity) {
     const path = [scope.stack, scope.stage, props.app, "*"].join("/");
-    super(scope, AppIdentity.suffixText(props, "GetDistributablePolicy"), {
+    super(scope, "GetDistributablePolicy", {
       ...props,
       bucketName: GuDistributionBucketParameter.getInstance(scope).valueAsString,
       paths: [path],
     });
-    AppIdentity.taggedConstruct(props, this);
   }
 }
 

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -1,6 +1,7 @@
 import { ServicePrincipal } from "@aws-cdk/aws-iam";
+import { GuAppAwareConstruct } from "../../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../../core";
-import { AppIdentity } from "../../core/identity";
+import type { AppIdentity } from "../../core/identity";
 import {
   GuDescribeEC2Policy,
   GuGetDistributablePolicy,
@@ -32,12 +33,12 @@ export type GuInstanceRolePropsWithApp = GuInstanceRoleProps & AppIdentity;
  *
  * If log shipping is not required, opt out by setting the `withoutLogShipping` prop to `true`.
  */
-export class GuInstanceRole extends GuRole {
+export class GuInstanceRole extends GuAppAwareConstruct(GuRole) {
   constructor(scope: GuStack, props: GuInstanceRolePropsWithApp) {
-    super(scope, AppIdentity.suffixText(props, "InstanceRole"), {
+    super(scope, "InstanceRole", {
       path: "/",
       assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
-      // not setting existingLogicalId results in the logicalId always being auto-generated
+      ...props,
     });
 
     const sharedPolicies = [
@@ -54,7 +55,5 @@ export class GuInstanceRole extends GuRole {
     ];
 
     policies.forEach((p) => p.attachToRole(this));
-
-    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/constructs/loadbalancing/elb.ts
+++ b/src/constructs/loadbalancing/elb.ts
@@ -7,9 +7,10 @@ import type {
 } from "@aws-cdk/aws-elasticloadbalancing";
 import { Duration } from "@aws-cdk/core";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import { GuArnParameter } from "../core";
 import type { GuStack } from "../core";
-import { AppIdentity } from "../core/identity";
+import type { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
 interface GuClassicLoadBalancerProps extends Omit<LoadBalancerProps, "healthCheck">, GuMigratingResource, AppIdentity {
@@ -46,7 +47,7 @@ interface GuClassicLoadBalancerProps extends Omit<LoadBalancerProps, "healthChec
  * If you are running an application which only accepts traffic over HTTPs, consider using [[`GuHttpsClassicLoadBalancer`]]
  * to reduce the amount of boilerplate needed when configuring your load balancer.
  */
-export class GuClassicLoadBalancer extends GuStatefulMigratableConstruct(LoadBalancer) {
+export class GuClassicLoadBalancer extends GuStatefulMigratableConstruct(GuAppAwareConstruct(LoadBalancer)) {
   static DefaultHealthCheck = {
     port: 9000,
     path: "/healthcheck",
@@ -63,8 +64,7 @@ export class GuClassicLoadBalancer extends GuStatefulMigratableConstruct(LoadBal
       healthCheck: { ...GuClassicLoadBalancer.DefaultHealthCheck, ...props.healthCheck },
     };
 
-    super(scope, AppIdentity.suffixText({ app: props.app }, id), mergedProps);
-    AppIdentity.taggedConstruct({ app: props.app }, this);
+    super(scope, id, mergedProps);
 
     const cfnLb = this.node.defaultChild as CfnLoadBalancer;
 

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -118,6 +118,7 @@ describe("The GuDatabaseInstance class", () => {
     });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::RDS::DBInstance", /^DatabaseInstance.+$/);
+    expect(stack).toHaveGuTaggedResource("AWS::RDS::DBInstance", { appIdentity: { app: "testing" } });
   });
 
   test("sets the deletion protection value to true by default", () => {

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -3,6 +3,7 @@ import { DatabaseInstance, ParameterGroup } from "@aws-cdk/aws-rds";
 import type { DatabaseInstanceProps, IParameterGroup } from "@aws-cdk/aws-rds";
 import { Fn } from "@aws-cdk/core";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
 import { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
@@ -15,7 +16,7 @@ export interface GuDatabaseInstanceProps
   parameters?: Record<string, string>;
 }
 
-export class GuDatabaseInstance extends GuStatefulMigratableConstruct(DatabaseInstance) {
+export class GuDatabaseInstance extends GuStatefulMigratableConstruct(GuAppAwareConstruct(DatabaseInstance)) {
   constructor(scope: GuStack, id: string, props: GuDatabaseInstanceProps) {
     // CDK just wants "t3.micro" format, whereas
     // some CFN yaml might have the older "db.t3.micro" with the "db." prefix
@@ -40,6 +41,5 @@ export class GuDatabaseInstance extends GuStatefulMigratableConstruct(DatabaseIn
     });
 
     parameterGroup && AppIdentity.taggedConstruct(props, parameterGroup);
-    AppIdentity.taggedConstruct(props, this);
   }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Refactors some constructs to make use of the `GuAppAwareConstruct` mixin introduced in #853. This mixin ensures the logicalId of a construct includes the app identifier and also ensures the construct gets an `App` tag.

This is a no-op, as evidenced in the diff - there are only _additional_ tests and assertions in previous tests continue to hold true.

Note: This doesn't change all app aware constructs in the codebase, just the ones where refactoring is a no-op. There are more changes incoming to update the other constructs.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

Observe CI, it should go green.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A DRYer codebase and simpler construct definition as we only need to add a mixin rather than mutating the `id` and adding tags.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a