### PR TITLE
feat!: Make `GuStageMapping` app aware

### DIFF
--- a/src/constructs/acm/__snapshots__/certificate.test.ts.snap
+++ b/src/constructs/acm/__snapshots__/certificate.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`The GuCertificate class should create a new certificate (which requires manual DNS changes) if hosted zone ids are not provided 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testing": Object {
       "CODE": Object {
         "domainName": "code-guardian.com",
       },
@@ -29,7 +29,7 @@ Object {
       "Properties": Object {
         "DomainName": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testing",
             Object {
               "Ref": "Stage",
             },
@@ -72,7 +72,7 @@ Object {
 exports[`The GuCertificate class should create a new certificate when hosted zone ids are provided 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testing": Object {
       "CODE": Object {
         "domainName": "code-guardian.com",
         "hostedZoneId": "id123",
@@ -100,7 +100,7 @@ Object {
       "Properties": Object {
         "DomainName": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testing",
             Object {
               "Ref": "Stage",
             },
@@ -111,7 +111,7 @@ Object {
           Object {
             "DomainName": Object {
               "Fn::FindInMap": Array [
-                "stagemapping",
+                "testing",
                 Object {
                   "Ref": "Stage",
                 },
@@ -120,7 +120,7 @@ Object {
             },
             "HostedZoneId": Object {
               "Fn::FindInMap": Array [
-                "stagemapping",
+                "testing",
                 Object {
                   "Ref": "Stage",
                 },

--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -67,15 +67,23 @@ export class GuCertificate extends GuStatefulMigratableConstruct(GuAppAwareConst
             scope,
             AppIdentity.suffixText({ app: props.app }, "HostedZone"),
             scope.withStageDependentValue({
+              app: props.app,
               variableName: "hostedZoneId",
-              stageValues: { [Stage.CODE]: props.CODE.hostedZoneId, [Stage.PROD]: props.PROD.hostedZoneId },
+              stageValues: {
+                [Stage.CODE]: props.CODE.hostedZoneId,
+                [Stage.PROD]: props.PROD.hostedZoneId,
+              },
             })
           )
         : undefined;
     const awsCertificateProps: CertificateProps & GuMigratingResource & AppIdentity = {
       domainName: scope.withStageDependentValue({
+        app: props.app,
         variableName: "domainName",
-        stageValues: { [Stage.CODE]: props.CODE.domainName, [Stage.PROD]: props.PROD.domainName },
+        stageValues: {
+          [Stage.CODE]: props.CODE.domainName,
+          [Stage.PROD]: props.PROD.domainName,
+        },
       }),
       validation: CertificateValidation.fromDns(maybeHostedZone),
       existingLogicalId: props.existingLogicalId,

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -216,7 +216,7 @@ describe("The GuAutoScalingGroup", () => {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Mappings).toEqual({
-      stagemapping: {
+      [app.app]: {
         CODE: {
           minInstances: 1,
           maxInstances: 5,
@@ -313,14 +313,14 @@ describe("The GuAutoScalingGroup", () => {
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::AutoScalingGroup", {
-      MinSize: { "Fn::FindInMap": ["stagemapping", { Ref: "Stage" }, "minInstances"] },
-      MaxSize: { "Fn::FindInMap": ["stagemapping", { Ref: "Stage" }, "maxInstances"] },
+      MinSize: { "Fn::FindInMap": ["TestApp", { Ref: "Stage" }, "minInstances"] },
+      MaxSize: { "Fn::FindInMap": ["TestApp", { Ref: "Stage" }, "maxInstances"] },
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Mappings).toEqual({
-      stagemapping: {
+      TestApp: {
         CODE: { minInstances: 1, maxInstances: 2 },
         PROD: { minInstances: 3, maxInstances: 6 },
       },
@@ -342,14 +342,14 @@ describe("The GuAutoScalingGroup", () => {
     });
 
     expect(stack).toHaveResource("AWS::AutoScaling::AutoScalingGroup", {
-      MinSize: { "Fn::FindInMap": ["stagemapping", { Ref: "Stage" }, "minInstances"] },
-      MaxSize: { "Fn::FindInMap": ["stagemapping", { Ref: "Stage" }, "maxInstances"] },
+      MinSize: { "Fn::FindInMap": ["TestApp", { Ref: "Stage" }, "minInstances"] },
+      MaxSize: { "Fn::FindInMap": ["TestApp", { Ref: "Stage" }, "maxInstances"] },
     });
 
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Mappings).toEqual({
-      stagemapping: {
+      TestApp: {
         CODE: { minInstances: 2, maxInstances: 4 },
         PROD: { minInstances: 5, maxInstances: 10 },
       },

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -60,9 +60,14 @@ interface AwsAsgCapacityProps {
   maxCapacity: number;
 }
 
-function wireStageDependentProps(stack: GuStack, stageDependentProps: GuStageDependentAsgProps): AwsAsgCapacityProps {
+function wireStageDependentProps(
+  stack: GuStack,
+  app: string,
+  stageDependentProps: GuStageDependentAsgProps
+): AwsAsgCapacityProps {
   return {
     minCapacity: stack.withStageDependentValue({
+      app,
       variableName: "minInstances",
       stageValues: {
         [Stage.CODE]: stageDependentProps.CODE.minimumInstances,
@@ -70,6 +75,7 @@ function wireStageDependentProps(stack: GuStack, stageDependentProps: GuStageDep
       },
     }),
     maxCapacity: stack.withStageDependentValue({
+      app,
       variableName: "maxInstances",
       stageValues: {
         [Stage.CODE]: stageDependentProps.CODE.maximumInstances ?? stageDependentProps.CODE.minimumInstances * 2,
@@ -118,7 +124,7 @@ export class GuAutoScalingGroup extends GuStatefulMigratableConstruct(GuAppAware
 
     const mergedProps = {
       ...props,
-      ...wireStageDependentProps(scope, props.stageDependentProps ?? defaultStageDependentProps),
+      ...wireStageDependentProps(scope, props.app, props.stageDependentProps ?? defaultStageDependentProps),
       role: props.role ?? new GuInstanceRole(scope, { app: props.app }),
       machineImage: { getImage: getImage },
       userData,

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`The Gu5xxPercentageAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testing": Object {
       "CODE": Object {
         "alarmActionsEnabled": false,
       },
@@ -127,7 +127,7 @@ Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testing",
             Object {
               "Ref": "Stage",
             },
@@ -254,7 +254,7 @@ Object {
 exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testing": Object {
       "CODE": Object {
         "alarmActionsEnabled": false,
       },
@@ -449,7 +449,7 @@ Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testing",
             Object {
               "Ref": "Stage",
             },

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`The GuLambdaErrorPercentageAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testing": Object {
       "CODE": Object {
         "alarmActionsEnabled": false,
       },
@@ -238,7 +238,7 @@ Object {
       "Properties": Object {
         "ActionsEnabled": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testing",
             Object {
               "Ref": "Stage",
             },

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -17,6 +17,7 @@ describe("The GuAlarm class", () => {
       app: "testing",
     });
     new GuAlarm(stack, "alarm", {
+      app: "testing",
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
       metric: lambda.metricErrors(),
@@ -37,6 +38,7 @@ describe("The GuAlarm class", () => {
       app: "testing",
     });
     new GuAlarm(stack, "alarm", {
+      app: "testing",
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
       metric: lambda.metricErrors(),
@@ -76,6 +78,7 @@ describe("The GuAlarm class", () => {
       app: "testing",
     });
     new GuAlarm(stack, "alarm", {
+      app: "testing",
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
       metric: lambda.metricErrors(),
@@ -86,7 +89,7 @@ describe("The GuAlarm class", () => {
     });
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(json.Mappings).toEqual({
-      stagemapping: {
+      testing: {
         CODE: {
           alarmActionsEnabled: false,
         },
@@ -106,6 +109,7 @@ describe("The GuAlarm class", () => {
       app: "testing",
     });
     new GuAlarm(stack, "alarm", {
+      app: "testing",
       actionsEnabledInCode: true,
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
@@ -117,7 +121,7 @@ describe("The GuAlarm class", () => {
     });
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
     expect(json.Mappings).toEqual({
-      stagemapping: {
+      testing: {
         CODE: {
           alarmActionsEnabled: true,
         },

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -10,7 +10,7 @@ import type { GuAlarmProps } from "./alarm";
 export interface Http5xxAlarmProps
   extends Omit<
     GuAlarmProps,
-    "snsTopicName" | "evaluationPeriods" | "metric" | "period" | "threshold" | "treatMissingData"
+    "snsTopicName" | "evaluationPeriods" | "metric" | "period" | "threshold" | "treatMissingData" | "app"
   > {
   tolerated5xxPercentage: number;
   numberOfMinutesAboveThresholdBeforeAlarm?: number;

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -6,7 +6,10 @@ import { GuAlarm } from "./alarm";
 import type { GuAlarmProps } from "./alarm";
 
 export interface GuLambdaErrorPercentageMonitoringProps
-  extends Omit<GuAlarmProps, "metric" | "threshold" | "comparisonOperator" | "evaluationPeriods" | "treatMissingData"> {
+  extends Omit<
+    GuAlarmProps,
+    "metric" | "threshold" | "comparisonOperator" | "evaluationPeriods" | "treatMissingData" | "app"
+  > {
   toleratedErrorPercentage: number;
   numberOfMinutesAboveThresholdBeforeAlarm?: number;
   noMonitoring?: false;
@@ -29,8 +32,9 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
     });
     const defaultAlarmName = `High error % from ${props.lambda.functionName} lambda in ${scope.stage}`;
     const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
-    const alarmProps = {
+    const alarmProps: GuAlarmProps = {
       ...props,
+      app: props.lambda.app,
       metric: mathExpression,
       treatMissingData: TreatMissingData.NOT_BREACHING,
       threshold: props.toleratedErrorPercentage,

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -1,14 +1,46 @@
 import { CfnMapping } from "@aws-cdk/core";
 import type { Stage } from "../../constants";
+import type { AppIdentity } from "./identity";
 import type { GuStack } from "./stack";
 
-export interface GuStageDependentValue<T extends string | number | boolean> {
+export type GuMappingValue = string | number | boolean;
+
+export interface GuStageMappingValue<T extends GuMappingValue> extends AppIdentity {
   variableName: string;
   stageValues: Record<Stage, T>;
 }
 
-export class GuStageMapping extends CfnMapping {
+export class GuStageMapping {
+  private readonly scope: GuStack;
+
+  // the key in this Map is an app string
+  private mappings: Map<string, CfnMapping>;
+
   constructor(scope: GuStack) {
-    super(scope, "stage-mapping");
+    this.scope = scope;
+    this.mappings = new Map<string, CfnMapping>();
+  }
+
+  private getCfnMapping(app: string): CfnMapping {
+    if (!this.mappings.has(app)) {
+      const emptyCfnMapping = new CfnMapping(this.scope, app);
+      this.mappings.set(app, emptyCfnMapping);
+      return emptyCfnMapping;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `this.mappings.has` above is `true`, so we can safely assert non-null
+    return this.mappings.get(app)!;
+  }
+
+  withValue<T extends GuMappingValue>(mappingValue: GuStageMappingValue<T>): T {
+    const { app, variableName, stageValues } = mappingValue;
+
+    const cfnMapping = this.getCfnMapping(app);
+
+    for (const [stage, value] of Object.entries(stageValues)) {
+      cfnMapping.setValue(stage, variableName, value);
+    }
+
+    return cfnMapping.findInMap(this.scope.stage, variableName) as T;
   }
 }

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -2,7 +2,6 @@ import { Stack, Tags } from "@aws-cdk/core";
 import type { App, StackProps } from "@aws-cdk/core";
 import execa from "execa";
 import gitUrlParse from "git-url-parse";
-import { Stage } from "../../constants";
 import { ContextKeys } from "../../constants/context-keys";
 import { TagKeys } from "../../constants/tag-keys";
 import { TrackingTag } from "../../constants/tracking-tag";
@@ -10,7 +9,7 @@ import type { GuMigratingStack } from "../../types/migrating";
 import { Logger } from "../../utils/logger";
 import type { StackStageIdentity } from "./identity";
 import { GuStageMapping } from "./mappings";
-import type { GuStageDependentValue } from "./mappings";
+import type { GuMappingValue, GuStageMappingValue } from "./mappings";
 import { GuStageParameter } from "./parameters";
 import type { GuParameter } from "./parameters";
 
@@ -75,10 +74,8 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
    * as Parameters are not resolved at synth-time. This helper function creates CloudFormation
    * Mappings to work around this limitation.
    */
-  withStageDependentValue<T extends string | number | boolean>(stageDependentValue: GuStageDependentValue<T>): T {
-    this.mappings.setValue(Stage.CODE, stageDependentValue.variableName, stageDependentValue.stageValues.CODE);
-    this.mappings.setValue(Stage.PROD, stageDependentValue.variableName, stageDependentValue.stageValues.PROD);
-    return this.mappings.findInMap(this.stage, stageDependentValue.variableName) as unknown as T;
+  withStageDependentValue<T extends GuMappingValue>(mappingValue: GuStageMappingValue<T>): T {
+    return this.mappings.withValue(mappingValue);
   }
 
   /**

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -47,6 +47,8 @@ function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
  * consider using a pattern which instantiates a Lambda with a trigger e.g. [[`GuScheduledLambda`]].
  */
 export class GuLambdaFunction extends Function {
+  public readonly app: string;
+
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const { app, fileName, runtime, memorySize, timeout } = props;
 
@@ -73,6 +75,8 @@ export class GuLambdaFunction extends Function {
       timeout: timeout ?? Duration.seconds(30),
       code,
     });
+
+    this.app = app;
 
     if (props.errorPercentageMonitoring) {
       new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {

--- a/src/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specific CIDR ranges 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testguec2app": Object {
       "CODE": Object {
         "domainName": "code-guardian.com",
         "hostedZoneId": "id123",
@@ -79,7 +79,7 @@ Object {
         },
         "MaxSize": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testguec2app",
             Object {
               "Ref": "Stage",
             },
@@ -88,7 +88,7 @@ Object {
         },
         "MinSize": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testguec2app",
             Object {
               "Ref": "Stage",
             },
@@ -192,7 +192,7 @@ Object {
       "Properties": Object {
         "DomainName": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testguec2app",
             Object {
               "Ref": "Stage",
             },
@@ -203,7 +203,7 @@ Object {
           Object {
             "DomainName": Object {
               "Fn::FindInMap": Array [
-                "stagemapping",
+                "testguec2app",
                 Object {
                   "Ref": "Stage",
                 },
@@ -212,7 +212,7 @@ Object {
             },
             "HostedZoneId": Object {
               "Fn::FindInMap": Array [
-                "stagemapping",
+                "testguec2app",
                 Object {
                   "Ref": "Stage",
                 },
@@ -861,7 +861,7 @@ Object {
 exports[`the GuEC2App pattern should produce a functional EC2 app with minimal arguments 1`] = `
 Object {
   "Mappings": Object {
-    "stagemapping": Object {
+    "testguec2app": Object {
       "CODE": Object {
         "domainName": "code-guardian.com",
         "hostedZoneId": "id123",
@@ -937,7 +937,7 @@ Object {
         },
         "MaxSize": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testguec2app",
             Object {
               "Ref": "Stage",
             },
@@ -946,7 +946,7 @@ Object {
         },
         "MinSize": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testguec2app",
             Object {
               "Ref": "Stage",
             },
@@ -1050,7 +1050,7 @@ Object {
       "Properties": Object {
         "DomainName": Object {
           "Fn::FindInMap": Array [
-            "stagemapping",
+            "testguec2app",
             Object {
               "Ref": "Stage",
             },
@@ -1061,7 +1061,7 @@ Object {
           Object {
             "DomainName": Object {
               "Fn::FindInMap": Array [
-                "stagemapping",
+                "testguec2app",
                 Object {
                   "Ref": "Stage",
                 },
@@ -1070,7 +1070,7 @@ Object {
             },
             "HostedZoneId": Object {
               "Fn::FindInMap": Array [
-                "stagemapping",
+                "testguec2app",
                 Object {
                   "Ref": "Stage",
                 },

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -349,15 +349,19 @@ describe("the GuEC2App pattern", function () {
     const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
 
     expect(json.Mappings).toEqual({
-      stagemapping: {
-        CODE: expect.objectContaining({
+      testguec2app: {
+        CODE: {
+          hostedZoneId: "id123",
+          domainName: "code-guardian.com",
           minInstances: 3,
           maxInstances: 6,
-        }) as Record<string, number>,
-        PROD: expect.objectContaining({
+        },
+        PROD: {
+          hostedZoneId: "id124",
+          domainName: "prod-guardian.com",
           minInstances: 5,
           maxInstances: 12,
-        }) as Record<string, number>,
+        },
       },
     });
   });

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -542,7 +542,18 @@ describe("the GuEC2App pattern", function () {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
-      certificateProps: getCertificateProps(),
+      certificateProps: {
+        [Stage.CODE]: {
+          domainName: "node-app.code.example.com",
+        },
+        [Stage.PROD]: {
+          domainName: "node-app.example.com",
+        },
+      },
+      scaling: {
+        CODE: { minimumInstances: 0 },
+        PROD: { minimumInstances: 1 },
+      },
     });
 
     new GuEc2App(stack, {
@@ -552,7 +563,47 @@ describe("the GuEC2App pattern", function () {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
-      certificateProps: getCertificateProps(),
+      certificateProps: {
+        [Stage.CODE]: {
+          domainName: "play-app.code.example.com",
+        },
+        [Stage.PROD]: {
+          domainName: "play-app.example.com",
+        },
+      },
+      scaling: {
+        CODE: { minimumInstances: 1 },
+        PROD: { minimumInstances: 3 },
+      },
+    });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Mappings).toEqual({
+      NodeApp: {
+        CODE: {
+          domainName: "node-app.code.example.com",
+          minInstances: 0,
+          maxInstances: 0,
+        },
+        PROD: {
+          domainName: "node-app.example.com",
+          minInstances: 1,
+          maxInstances: 2,
+        },
+      },
+      PlayApp: {
+        CODE: {
+          domainName: "play-app.code.example.com",
+          minInstances: 1,
+          maxInstances: 2,
+        },
+        PROD: {
+          domainName: "play-app.example.com",
+          minInstances: 3,
+          maxInstances: 6,
+        },
+      },
     });
 
     expect(stack).toHaveGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {


### PR DESCRIPTION
Fixes #850.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

As reported in #850 it isn't possible to define stage dependent values for multiple apps in a single stack.

Let's say we have two apps: `api` and `login`. The mappings currently produced look like:

```json
"stagemapping": {
  "CODE": {
    "domainName": "login.code.example.com",
    "minInstances": 1,
    "maxInstances": 2
  },
  "PROD": {
    "domainName": "login.example.com",
    "minInstances": 3,
    "maxInstances": 6
  }
}
```

That is the `Mappings` for `api` have been lost as they're overwritten by those from `login` as it's last write wins.

This change makes `Mappings` app aware, resulting in this:

```json
"api": {
  "CODE": {
    "domainName": "api.code.example.com",
    "minInstances": 1,
    "maxInstances": 2
  },
  "PROD": {
    "domainName": "api.example.com",
    "minInstances": 5,
    "maxInstances": 10
  }
},
"login": {
  "CODE": {
    "domainName": "login.code.example.com",
    "minInstances": 1,
    "maxInstances": 2
  },
  "PROD": {
    "domainName": "login.example.com",
    "minInstances": 3,
    "maxInstances": 6
  }
}
```

BREAKING CHANGE: `AppIdentity` is required in more places.

Arguments for `withStageDependentValue` on `GuStack` now require an `AppIdentity`. Add an `app` property to the function arguments.

From:

```ts
scope.withStageDependentValue({
  variableName: "something",
  stageValues: {
    [Stage.CODE]: "value-for-code-stage",
    [Stage.PROD]: "value-for-prod-stage",
  },
})
```

To:

```ts
scope.withStageDependentValue({
  app: "my-app", // <- new
  variableName: "something",
  stageValues: {
    [Stage.CODE]: "value-for-code-stage",
    [Stage.PROD]: "value-for-prod-stage",
  },
})
```

`GuAlarm` now requires an `AppIdentity` when instantiated.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See CI and the added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It is possible to define different stage dependent values for different apps within a single stack.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

As [commented](https://github.com/guardian/cdk/issues/850#issuecomment-957167109) it would be preferable to follow the Stack Stage App specificity in the mapping. This isn't possible, however as we'd require to know the value of stage at compile time, but it is a [token](https://docs.aws.amazon.com/cdk/latest/guide/tokens.html) as the result of it being a parameter of the CloudFormation stack. We don't lose too much with this solution.