### PR TITLE
fix: Ensure lambdas are app aware

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -29,10 +29,10 @@ Object {
     },
   },
   "Resources": Object {
-    "lambda8B5974B5": Object {
+    "lambdaTestingDF42012E": Object {
       "DependsOn": Array [
-        "lambdaServiceRoleDefaultPolicyBF6FA5E7",
-        "lambdaServiceRole494E4CA6",
+        "lambdaTestingServiceRoleDefaultPolicy6824E72F",
+        "lambdaTestingServiceRoleA8ACCBD2",
       ],
       "Properties": Object {
         "Code": Object {
@@ -65,7 +65,7 @@ Object {
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "lambdaServiceRole494E4CA6",
+            "lambdaTestingServiceRoleA8ACCBD2",
             "Arn",
           ],
         },
@@ -98,7 +98,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "lambdaServiceRole494E4CA6": Object {
+    "lambdaTestingServiceRoleA8ACCBD2": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -153,7 +153,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaServiceRoleDefaultPolicyBF6FA5E7": Object {
+    "lambdaTestingServiceRoleDefaultPolicy6824E72F": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -225,10 +225,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "lambdaServiceRoleDefaultPolicyBF6FA5E7",
+        "PolicyName": "lambdaTestingServiceRoleDefaultPolicy6824E72F",
         "Roles": Array [
           Object {
-            "Ref": "lambdaServiceRole494E4CA6",
+            "Ref": "lambdaTestingServiceRoleA8ACCBD2",
           },
         ],
       },
@@ -268,7 +268,7 @@ Object {
             "",
             Array [
               Object {
-                "Ref": "lambda8B5974B5",
+                "Ref": "lambdaTestingDF42012E",
               },
               " exceeded 80% error rate",
             ],
@@ -280,7 +280,7 @@ Object {
             Array [
               "High error % from ",
               Object {
-                "Ref": "lambda8B5974B5",
+                "Ref": "lambdaTestingDF42012E",
               },
               " lambda in ",
               Object {
@@ -301,7 +301,7 @@ Object {
                 Array [
                   "Error % of ",
                   Object {
-                    "Ref": "lambda8B5974B5",
+                    "Ref": "lambdaTestingDF42012E",
                   },
                 ],
               ],
@@ -315,7 +315,7 @@ Object {
                   Object {
                     "Name": "FunctionName",
                     "Value": Object {
-                      "Ref": "lambda8B5974B5",
+                      "Ref": "lambdaTestingDF42012E",
                     },
                   },
                 ],
@@ -335,7 +335,7 @@ Object {
                   Object {
                     "Name": "FunctionName",
                     "Value": Object {
-                      "Ref": "lambda8B5974B5",
+                      "Ref": "lambdaTestingDF42012E",
                     },
                   },
                 ],

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -3,11 +3,12 @@ import type { FunctionProps, Runtime } from "@aws-cdk/aws-lambda";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration } from "@aws-cdk/core";
 import { GuDistributable } from "../../types/distributable";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import { GuLambdaErrorPercentageAlarm } from "../cloudwatch";
 import type { GuLambdaErrorPercentageMonitoringProps } from "../cloudwatch";
 import { GuDistributionBucketParameter } from "../core";
 import type { GuStack } from "../core";
-import { AppIdentity } from "../core/identity";
+import type { AppIdentity } from "../core/identity";
 import { GuParameterStoreReadPolicyStatement } from "../iam";
 
 export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code">, AppIdentity {
@@ -46,7 +47,7 @@ function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
  * Note that this construct creates a Lambda without a trigger/event source. Depending on your use-case, you may wish to
  * consider using a pattern which instantiates a Lambda with a trigger e.g. [[`GuScheduledLambda`]].
  */
-export class GuLambdaFunction extends Function {
+export class GuLambdaFunction extends GuAppAwareConstruct(Function) {
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const { app, fileName, runtime, memorySize, timeout } = props;
 
@@ -85,7 +86,5 @@ export class GuLambdaFunction extends Function {
 
     const ssmParamReadPolicy = new GuParameterStoreReadPolicyStatement(scope, props);
     this.addToRolePolicy(ssmParamReadPolicy);
-
-    AppIdentity.taggedConstruct(props, this);
   }
 }

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`The GuApiLambda pattern should create the correct resources with minimal config 1`] = `
 Object {
   "Outputs": Object {
-    "lambdaapi2Endpoint9DFE39DE": Object {
+    "lambdaTestingapi2Endpoint37091F13": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
           Array [
             "https://",
             Object {
-              "Ref": "lambdaapi239350ECC",
+              "Ref": "lambdaTestingapi28AB84DCC",
             },
             ".execute-api.",
             Object {
@@ -22,21 +22,21 @@ Object {
             },
             "/",
             Object {
-              "Ref": "lambdaapi2DeploymentStageprodCC9E3016",
+              "Ref": "lambdaTestingapi2DeploymentStageprod16764D97",
             },
             "/",
           ],
         ],
       },
     },
-    "lambdaapiEndpoint3B6C471A": Object {
+    "lambdaTestingapiEndpoint0007E52B": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
           Array [
             "https://",
             Object {
-              "Ref": "lambdaapiC1812993",
+              "Ref": "lambdaTestingapi99365783",
             },
             ".execute-api.",
             Object {
@@ -48,7 +48,7 @@ Object {
             },
             "/",
             Object {
-              "Ref": "lambdaapiDeploymentStageprod9598BC2F",
+              "Ref": "lambdaTestingapiDeploymentStageprodA162DA5C",
             },
             "/",
           ],
@@ -73,10 +73,10 @@ Object {
     },
   },
   "Resources": Object {
-    "lambda8B5974B5": Object {
+    "lambdaTestingDF42012E": Object {
       "DependsOn": Array [
-        "lambdaServiceRoleDefaultPolicyBF6FA5E7",
-        "lambdaServiceRole494E4CA6",
+        "lambdaTestingServiceRoleDefaultPolicy6824E72F",
+        "lambdaTestingServiceRoleA8ACCBD2",
       ],
       "Properties": Object {
         "Code": Object {
@@ -109,7 +109,7 @@ Object {
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "lambdaServiceRole494E4CA6",
+            "lambdaTestingServiceRoleA8ACCBD2",
             "Arn",
           ],
         },
@@ -142,7 +142,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "lambdaServiceRole494E4CA6": Object {
+    "lambdaTestingServiceRoleA8ACCBD2": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -197,7 +197,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaServiceRoleDefaultPolicyBF6FA5E7": Object {
+    "lambdaTestingServiceRoleDefaultPolicy6824E72F": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -269,16 +269,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "lambdaServiceRoleDefaultPolicyBF6FA5E7",
+        "PolicyName": "lambdaTestingServiceRoleDefaultPolicy6824E72F",
         "Roles": Array [
           Object {
-            "Ref": "lambdaServiceRole494E4CA6",
+            "Ref": "lambdaTestingServiceRoleA8ACCBD2",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "lambdaapi239350ECC": Object {
+    "lambdaTestingapi28AB84DCC": Object {
       "Properties": Object {
         "Description": "this is a test2",
         "Name": "api2",
@@ -309,12 +309,12 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "lambdaapi2ANYApiPermissionTestTestlambdaapi29FEAC710ANYB2B37DB0": Object {
+    "lambdaTestingapi2ANYApiPermissionTestTestlambdaTestingapi2CC5FC6E4ANY6FBA4345": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "lambda8B5974B5",
+            "lambdaTestingDF42012E",
             "Arn",
           ],
         },
@@ -337,7 +337,7 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaapi239350ECC",
+                "Ref": "lambdaTestingapi28AB84DCC",
               },
               "/test-invoke-stage/*/",
             ],
@@ -346,12 +346,12 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapi2ANYApiPermissionTestlambdaapi29FEAC710ANY878BC567": Object {
+    "lambdaTestingapi2ANYApiPermissionTestlambdaTestingapi2CC5FC6E4ANY75AF3556": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "lambda8B5974B5",
+            "lambdaTestingDF42012E",
             "Arn",
           ],
         },
@@ -374,11 +374,11 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaapi239350ECC",
+                "Ref": "lambdaTestingapi28AB84DCC",
               },
               "/",
               Object {
-                "Ref": "lambdaapi2DeploymentStageprodCC9E3016",
+                "Ref": "lambdaTestingapi2DeploymentStageprod16764D97",
               },
               "/*/",
             ],
@@ -387,7 +387,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapi2ANYFE9D5EA6": Object {
+    "lambdaTestingapi2ANYCA940789": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "ANY",
@@ -409,7 +409,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "lambda8B5974B5",
+                    "lambdaTestingDF42012E",
                     "Arn",
                   ],
                 },
@@ -420,31 +420,31 @@ Object {
         },
         "ResourceId": Object {
           "Fn::GetAtt": Array [
-            "lambdaapi239350ECC",
+            "lambdaTestingapi28AB84DCC",
             "RootResourceId",
           ],
         },
         "RestApiId": Object {
-          "Ref": "lambdaapi239350ECC",
+          "Ref": "lambdaTestingapi28AB84DCC",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaapi2AccountFAF30ECB": Object {
+    "lambdaTestingapi2Account89F5AA25": Object {
       "DependsOn": Array [
-        "lambdaapi239350ECC",
+        "lambdaTestingapi28AB84DCC",
       ],
       "Properties": Object {
         "CloudWatchRoleArn": Object {
           "Fn::GetAtt": Array [
-            "lambdaapi2CloudWatchRole72740AA5",
+            "lambdaTestingapi2CloudWatchRoleFB24C031",
             "Arn",
           ],
         },
       },
       "Type": "AWS::ApiGateway::Account",
     },
-    "lambdaapi2CloudWatchRole72740AA5": Object {
+    "lambdaTestingapi2CloudWatchRoleFB24C031": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -499,27 +499,27 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB93733f2a465bd3376b026a790d1cda259491": Object {
+    "lambdaTestingapi2DeploymentB6FE91DAdef4920dcc3d3fcf9957608836763dd1": Object {
       "DependsOn": Array [
-        "lambdaapi2proxyANY3F8E1D36",
-        "lambdaapi2proxyE68FDFBC",
-        "lambdaapi2ANYFE9D5EA6",
+        "lambdaTestingapi2proxyANY688199AE",
+        "lambdaTestingapi2proxy2151564D",
+        "lambdaTestingapi2ANYCA940789",
       ],
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
-          "Ref": "lambdaapi239350ECC",
+          "Ref": "lambdaTestingapi28AB84DCC",
         },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "lambdaapi2DeploymentStageprodCC9E3016": Object {
+    "lambdaTestingapi2DeploymentStageprod16764D97": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB93733f2a465bd3376b026a790d1cda259491",
+          "Ref": "lambdaTestingapi2DeploymentB6FE91DAdef4920dcc3d3fcf9957608836763dd1",
         },
         "RestApiId": Object {
-          "Ref": "lambdaapi239350ECC",
+          "Ref": "lambdaTestingapi28AB84DCC",
         },
         "StageName": "prod",
         "Tags": Array [
@@ -549,7 +549,22 @@ Object {
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "lambdaapi2proxyANY3F8E1D36": Object {
+    "lambdaTestingapi2proxy2151564D": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "lambdaTestingapi28AB84DCC",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "lambdaTestingapi28AB84DCC",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "lambdaTestingapi2proxyANY688199AE": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "ANY",
@@ -571,7 +586,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "lambda8B5974B5",
+                    "lambdaTestingDF42012E",
                     "Arn",
                   ],
                 },
@@ -581,20 +596,20 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "lambdaapi2proxyE68FDFBC",
+          "Ref": "lambdaTestingapi2proxy2151564D",
         },
         "RestApiId": Object {
-          "Ref": "lambdaapi239350ECC",
+          "Ref": "lambdaTestingapi28AB84DCC",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaapi2proxyANYApiPermissionTestTestlambdaapi29FEAC710ANYproxy20D9E3C9": Object {
+    "lambdaTestingapi2proxyANYApiPermissionTestTestlambdaTestingapi2CC5FC6E4ANYproxyFB60773A": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "lambda8B5974B5",
+            "lambdaTestingDF42012E",
             "Arn",
           ],
         },
@@ -617,7 +632,7 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaapi239350ECC",
+                "Ref": "lambdaTestingapi28AB84DCC",
               },
               "/test-invoke-stage/*/*",
             ],
@@ -626,12 +641,12 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapi2proxyANYApiPermissionTestlambdaapi29FEAC710ANYproxy33429FF8": Object {
+    "lambdaTestingapi2proxyANYApiPermissionTestlambdaTestingapi2CC5FC6E4ANYproxyD0B026C9": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "lambda8B5974B5",
+            "lambdaTestingDF42012E",
             "Arn",
           ],
         },
@@ -654,11 +669,11 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaapi239350ECC",
+                "Ref": "lambdaTestingapi28AB84DCC",
               },
               "/",
               Object {
-                "Ref": "lambdaapi2DeploymentStageprodCC9E3016",
+                "Ref": "lambdaTestingapi2DeploymentStageprod16764D97",
               },
               "/*/*",
             ],
@@ -667,157 +682,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapi2proxyE68FDFBC": Object {
-      "Properties": Object {
-        "ParentId": Object {
-          "Fn::GetAtt": Array [
-            "lambdaapi239350ECC",
-            "RootResourceId",
-          ],
-        },
-        "PathPart": "{proxy+}",
-        "RestApiId": Object {
-          "Ref": "lambdaapi239350ECC",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "lambdaapiANY4EBCADD1": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "ANY",
-        "Integration": Object {
-          "IntegrationHttpMethod": "POST",
-          "Type": "AWS_PROXY",
-          "Uri": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                Object {
-                  "Ref": "AWS::Region",
-                },
-                ":lambda:path/2015-03-31/functions/",
-                Object {
-                  "Fn::GetAtt": Array [
-                    "lambda8B5974B5",
-                    "Arn",
-                  ],
-                },
-                "/invocations",
-              ],
-            ],
-          },
-        },
-        "ResourceId": Object {
-          "Fn::GetAtt": Array [
-            "lambdaapiC1812993",
-            "RootResourceId",
-          ],
-        },
-        "RestApiId": Object {
-          "Ref": "lambdaapiC1812993",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "lambdaapiANYApiPermissionTestTestlambdaapi0E958EEBANY3DF279D1": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "lambda8B5974B5",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "lambdaapiC1812993",
-              },
-              "/test-invoke-stage/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "lambdaapiANYApiPermissionTestlambdaapi0E958EEBANYA0BDE5E2": Object {
-      "Properties": Object {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "lambda8B5974B5",
-            "Arn",
-          ],
-        },
-        "Principal": "apigateway.amazonaws.com",
-        "SourceArn": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "arn:",
-              Object {
-                "Ref": "AWS::Partition",
-              },
-              ":execute-api:",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ":",
-              Object {
-                "Ref": "AWS::AccountId",
-              },
-              ":",
-              Object {
-                "Ref": "lambdaapiC1812993",
-              },
-              "/",
-              Object {
-                "Ref": "lambdaapiDeploymentStageprod9598BC2F",
-              },
-              "/*/",
-            ],
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "lambdaapiAccountAF0DCB01": Object {
-      "DependsOn": Array [
-        "lambdaapiC1812993",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "lambdaapiCloudWatchRole7E36513A",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "lambdaapiC1812993": Object {
+    "lambdaTestingapi99365783": Object {
       "Properties": Object {
         "Description": "this is a test",
         "Name": "api",
@@ -848,7 +713,142 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "lambdaapiCloudWatchRole7E36513A": Object {
+    "lambdaTestingapiANYApiPermissionTestTestlambdaTestingapi60071196ANY7CB94407": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambdaTestingDF42012E",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaTestingapi99365783",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaTestingapiANYApiPermissionTestlambdaTestingapi60071196ANY5401B9F6": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambdaTestingDF42012E",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaTestingapi99365783",
+              },
+              "/",
+              Object {
+                "Ref": "lambdaTestingapiDeploymentStageprodA162DA5C",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaTestingapiANYFBEBECB5": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "lambdaTestingDF42012E",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "lambdaTestingapi99365783",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaTestingapi99365783",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdaTestingapiAccountFD257ED4": Object {
+      "DependsOn": Array [
+        "lambdaTestingapi99365783",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "lambdaTestingapiCloudWatchRole3F985611",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "lambdaTestingapiCloudWatchRole3F985611": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -903,27 +903,27 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B585280b2dd8620eae880b6845467e6ee11e": Object {
+    "lambdaTestingapiDeployment85E67007560f44a30e5b46e321b636da2609b66f": Object {
       "DependsOn": Array [
-        "lambdaapiproxyANYA94E968A",
-        "lambdaapiproxyB573C729",
-        "lambdaapiANY4EBCADD1",
+        "lambdaTestingapiproxyANY0AC28039",
+        "lambdaTestingapiproxyB770BAF0",
+        "lambdaTestingapiANYFBEBECB5",
       ],
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
-          "Ref": "lambdaapiC1812993",
+          "Ref": "lambdaTestingapi99365783",
         },
       },
       "Type": "AWS::ApiGateway::Deployment",
     },
-    "lambdaapiDeploymentStageprod9598BC2F": Object {
+    "lambdaTestingapiDeploymentStageprodA162DA5C": Object {
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B585280b2dd8620eae880b6845467e6ee11e",
+          "Ref": "lambdaTestingapiDeployment85E67007560f44a30e5b46e321b636da2609b66f",
         },
         "RestApiId": Object {
-          "Ref": "lambdaapiC1812993",
+          "Ref": "lambdaTestingapi99365783",
         },
         "StageName": "prod",
         "Tags": Array [
@@ -953,7 +953,7 @@ Object {
       },
       "Type": "AWS::ApiGateway::Stage",
     },
-    "lambdaapiproxyANYA94E968A": Object {
+    "lambdaTestingapiproxyANY0AC28039": Object {
       "Properties": Object {
         "AuthorizationType": "NONE",
         "HttpMethod": "ANY",
@@ -975,7 +975,7 @@ Object {
                 ":lambda:path/2015-03-31/functions/",
                 Object {
                   "Fn::GetAtt": Array [
-                    "lambda8B5974B5",
+                    "lambdaTestingDF42012E",
                     "Arn",
                   ],
                 },
@@ -985,20 +985,20 @@ Object {
           },
         },
         "ResourceId": Object {
-          "Ref": "lambdaapiproxyB573C729",
+          "Ref": "lambdaTestingapiproxyB770BAF0",
         },
         "RestApiId": Object {
-          "Ref": "lambdaapiC1812993",
+          "Ref": "lambdaTestingapi99365783",
         },
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdaapiproxyANYApiPermissionTestTestlambdaapi0E958EEBANYproxy716A4EB4": Object {
+    "lambdaTestingapiproxyANYApiPermissionTestTestlambdaTestingapi60071196ANYproxy49D7C76F": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "lambda8B5974B5",
+            "lambdaTestingDF42012E",
             "Arn",
           ],
         },
@@ -1021,7 +1021,7 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaapiC1812993",
+                "Ref": "lambdaTestingapi99365783",
               },
               "/test-invoke-stage/*/*",
             ],
@@ -1030,12 +1030,12 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapiproxyANYApiPermissionTestlambdaapi0E958EEBANYproxy81BB250D": Object {
+    "lambdaTestingapiproxyANYApiPermissionTestlambdaTestingapi60071196ANYproxy997A0B24": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "lambda8B5974B5",
+            "lambdaTestingDF42012E",
             "Arn",
           ],
         },
@@ -1058,11 +1058,11 @@ Object {
               },
               ":",
               Object {
-                "Ref": "lambdaapiC1812993",
+                "Ref": "lambdaTestingapi99365783",
               },
               "/",
               Object {
-                "Ref": "lambdaapiDeploymentStageprod9598BC2F",
+                "Ref": "lambdaTestingapiDeploymentStageprodA162DA5C",
               },
               "/*/*",
             ],
@@ -1071,17 +1071,17 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdaapiproxyB573C729": Object {
+    "lambdaTestingapiproxyB770BAF0": Object {
       "Properties": Object {
         "ParentId": Object {
           "Fn::GetAtt": Array [
-            "lambdaapiC1812993",
+            "lambdaTestingapi99365783",
             "RootResourceId",
           ],
         },
         "PathPart": "{proxy+}",
         "RestApiId": Object {
-          "Ref": "lambdaapiC1812993",
+          "Ref": "lambdaTestingapi99365783",
         },
       },
       "Type": "AWS::ApiGateway::Resource",

--- a/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -54,10 +54,10 @@ Object {
       },
       "Type": "AWS::Kinesis::Stream",
     },
-    "mylambdafunction8D341B54": Object {
+    "mylambdafunctionTesting9BE73C37": Object {
       "DependsOn": Array [
-        "mylambdafunctionServiceRoleDefaultPolicy769897D4",
-        "mylambdafunctionServiceRoleE82C2E25",
+        "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79",
+        "mylambdafunctionTestingServiceRole279EB564",
       ],
       "Properties": Object {
         "Code": Object {
@@ -91,7 +91,7 @@ Object {
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunctionServiceRoleE82C2E25",
+            "mylambdafunctionTestingServiceRole279EB564",
             "Arn",
           ],
         },
@@ -124,7 +124,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "mylambdafunctionKinesisEventSourceTestKinesisStream4CAC6550FA5E175D": Object {
+    "mylambdafunctionTestingKinesisEventSourceTestKinesisStream4CAC6550AE2B7BAE": Object {
       "Properties": Object {
         "BatchSize": 100,
         "BisectBatchOnFunctionError": false,
@@ -135,14 +135,69 @@ Object {
           ],
         },
         "FunctionName": Object {
-          "Ref": "mylambdafunction8D341B54",
+          "Ref": "mylambdafunctionTesting9BE73C37",
         },
         "MaximumRetryAttempts": 1,
         "StartingPosition": "LATEST",
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "mylambdafunctionServiceRoleDefaultPolicy769897D4": Object {
+    "mylambdafunctionTestingServiceRole279EB564": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -240,69 +295,14 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "mylambdafunctionServiceRoleDefaultPolicy769897D4",
+        "PolicyName": "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79",
         "Roles": Array [
           Object {
-            "Ref": "mylambdafunctionServiceRoleE82C2E25",
+            "Ref": "mylambdafunctionTestingServiceRole279EB564",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "mylambdafunctionServiceRoleE82C2E25": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "testing",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -19,10 +19,10 @@ Object {
     },
   },
   "Resources": Object {
-    "mylambdafunction8D341B54": Object {
+    "mylambdafunctionTesting9BE73C37": Object {
       "DependsOn": Array [
-        "mylambdafunctionServiceRoleDefaultPolicy769897D4",
-        "mylambdafunctionServiceRoleE82C2E25",
+        "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79",
+        "mylambdafunctionTestingServiceRole279EB564",
       ],
       "Properties": Object {
         "Code": Object {
@@ -56,7 +56,7 @@ Object {
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunctionServiceRoleE82C2E25",
+            "mylambdafunctionTestingServiceRole279EB564",
             "Arn",
           ],
         },
@@ -89,7 +89,62 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "mylambdafunctionServiceRoleDefaultPolicy769897D4": Object {
+    "mylambdafunctionTestingServiceRole279EB564": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -161,71 +216,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "mylambdafunctionServiceRoleDefaultPolicy769897D4",
+        "PolicyName": "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79",
         "Roles": Array [
           Object {
-            "Ref": "mylambdafunctionServiceRoleE82C2E25",
+            "Ref": "mylambdafunctionTestingServiceRole279EB564",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "mylambdafunctionServiceRoleE82C2E25": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "testing",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "mylambdafunctionmylambdafunctionrate1minute06AD0015D": Object {
+    "mylambdafunctionTestingmylambdafunctionrate1minute04A7B4C6F": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(1 minute)",
         "State": "ENABLED",
@@ -233,7 +233,7 @@ Object {
           Object {
             "Arn": Object {
               "Fn::GetAtt": Array [
-                "mylambdafunction8D341B54",
+                "mylambdafunctionTesting9BE73C37",
                 "Arn",
               ],
             },
@@ -243,19 +243,19 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "mylambdafunctionmylambdafunctionrate1minute0AllowEventRuleTestmylambdafunction4858F7ED96852F99": Object {
+    "mylambdafunctionTestingmylambdafunctionrate1minute0AllowEventRuleTestmylambdafunctionTesting3166EF317372AB80": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunction8D341B54",
+            "mylambdafunctionTesting9BE73C37",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunctionmylambdafunctionrate1minute06AD0015D",
+            "mylambdafunctionTestingmylambdafunctionrate1minute04A7B4C6F",
             "Arn",
           ],
         },

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`The GuSnsLambda pattern should create the correct resources for a new stack with minimal config 1`] = `
 Object {
   "Outputs": Object {
-    "mylambdafunctionTopicNameA4E69772": Object {
+    "mylambdafunctionTestingTopicName16F8329F": Object {
       "Value": Object {
         "Fn::GetAtt": Array [
           "SnsIncomingEventsTopic308392EC",
@@ -58,10 +58,10 @@ Object {
       },
       "Type": "AWS::SNS::Topic",
     },
-    "mylambdafunction8D341B54": Object {
+    "mylambdafunctionTesting9BE73C37": Object {
       "DependsOn": Array [
-        "mylambdafunctionServiceRoleDefaultPolicy769897D4",
-        "mylambdafunctionServiceRoleE82C2E25",
+        "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79",
+        "mylambdafunctionTestingServiceRole279EB564",
       ],
       "Properties": Object {
         "Code": Object {
@@ -95,7 +95,7 @@ Object {
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunctionServiceRoleE82C2E25",
+            "mylambdafunctionTestingServiceRole279EB564",
             "Arn",
           ],
         },
@@ -128,12 +128,12 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "mylambdafunctionAllowInvokeTestSnsIncomingEventsTopicFE4AC0FA7C8D8231": Object {
+    "mylambdafunctionTestingAllowInvokeTestSnsIncomingEventsTopicFE4AC0FA2DD1E419": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunction8D341B54",
+            "mylambdafunctionTesting9BE73C37",
             "Arn",
           ],
         },
@@ -144,7 +144,62 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "mylambdafunctionServiceRoleDefaultPolicy769897D4": Object {
+    "mylambdafunctionTestingServiceRole279EB564": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -216,75 +271,20 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "mylambdafunctionServiceRoleDefaultPolicy769897D4",
+        "PolicyName": "mylambdafunctionTestingServiceRoleDefaultPolicy39A11B79",
         "Roles": Array [
           Object {
-            "Ref": "mylambdafunctionServiceRoleE82C2E25",
+            "Ref": "mylambdafunctionTestingServiceRole279EB564",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "mylambdafunctionServiceRoleE82C2E25": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "testing",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "mylambdafunctionSnsIncomingEventsTopic6726218D": Object {
+    "mylambdafunctionTestingSnsIncomingEventsTopic7B5CEAE1": Object {
       "Properties": Object {
         "Endpoint": Object {
           "Fn::GetAtt": Array [
-            "mylambdafunction8D341B54",
+            "mylambdafunctionTesting9BE73C37",
             "Arn",
           ],
         },


### PR DESCRIPTION
Requires #872.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Add the `GuAppAwareConstruct` mixin, introduced in #853, to the `GuLambdaFunction` construct. This results in construct, and sub-classes, get tagged with the app identifier and also having a logicalId with the app identifier.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See updated tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Higher consistency across app aware constructs? App aware constructs should:
  - include the app in the logical id
  - receive the `App` tag

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The logical id for lambdas change with this PR, this will cause a replacement once deployed. This should be fine as lambdas do not hold state.