### PR TITLE
fix: Ensure kinesis streams are app aware

### DIFF
--- a/src/constructs/kinesis/kinesis-stream.test.ts
+++ b/src/constructs/kinesis/kinesis-stream.test.ts
@@ -6,14 +6,19 @@ import { GuKinesisStream } from "./kinesis-stream";
 describe("The GuKinesisStream construct", () => {
   test("auto-generates the logicalId by default", () => {
     const stack = simpleGuStackForTesting();
-    new GuKinesisStream(stack, "LoggingStream");
+    new GuKinesisStream(stack, "LoggingStream", { app: "testing" });
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", /^LoggingStream.+$/);
+    expect(stack).toHaveGuTaggedResource("AWS::Kinesis::Stream", { appIdentity: { app: "testing" } });
   });
 
   it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuKinesisStream(stack, "LoggingStream", { existingLogicalId: { logicalId: "MyStream", reason: "testing" } });
+    new GuKinesisStream(stack, "LoggingStream", {
+      existingLogicalId: { logicalId: "MyStream", reason: "testing" },
+      app: "testing",
+    });
 
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::Kinesis::Stream", "MyStream");
+    expect(stack).toHaveGuTaggedResource("AWS::Kinesis::Stream", { appIdentity: { app: "testing" } });
   });
 });

--- a/src/constructs/kinesis/kinesis-stream.ts
+++ b/src/constructs/kinesis/kinesis-stream.ts
@@ -1,10 +1,12 @@
 import { Stream } from "@aws-cdk/aws-kinesis";
 import type { StreamProps } from "@aws-cdk/aws-kinesis";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
+import type { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-export interface GuKinesisStreamProps extends StreamProps, GuMigratingResource {}
+export interface GuKinesisStreamProps extends StreamProps, GuMigratingResource, AppIdentity {}
 
 /**
  * Construct which creates a Kinesis stream.
@@ -23,8 +25,8 @@ export interface GuKinesisStreamProps extends StreamProps, GuMigratingResource {
  * new GuKinesisStream(stack, "LoggingStream", { existingLogicalId: "MyCloudFormedKinesisStream" });
  * ```
  */
-export class GuKinesisStream extends GuStatefulMigratableConstruct(Stream) {
-  constructor(scope: GuStack, id: string, props?: GuKinesisStreamProps) {
+export class GuKinesisStream extends GuStatefulMigratableConstruct(GuAppAwareConstruct(Stream)) {
+  constructor(scope: GuStack, id: string, props: GuKinesisStreamProps) {
     super(scope, id, props);
   }
 }

--- a/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -19,7 +19,7 @@ Object {
     },
   },
   "Resources": Object {
-    "KinesisStream46752A3E": Object {
+    "KinesisStreamTesting925D0A07": Object {
       "Properties": Object {
         "RetentionPeriodHours": 24,
         "ShardCount": 1,
@@ -124,13 +124,13 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "mylambdafunctionTestingKinesisEventSourceTestKinesisStream4CAC6550AE2B7BAE": Object {
+    "mylambdafunctionTestingKinesisEventSourceTestKinesisStreamTestingBDE3BACB9316F9D2": Object {
       "Properties": Object {
         "BatchSize": 100,
         "BisectBatchOnFunctionError": false,
         "EventSourceArn": Object {
           "Fn::GetAtt": Array [
-            "KinesisStream46752A3E",
+            "KinesisStreamTesting925D0A07",
             "Arn",
           ],
         },
@@ -277,7 +277,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "KinesisStream46752A3E",
+                  "KinesisStreamTesting925D0A07",
                   "Arn",
                 ],
               },
@@ -287,7 +287,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "KinesisStream46752A3E",
+                  "KinesisStreamTesting925D0A07",
                   "Arn",
                 ],
               },

--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -5,7 +5,6 @@ import { KinesisEventSource } from "@aws-cdk/aws-lambda-event-sources";
 import type { KinesisEventSourceProps } from "@aws-cdk/aws-lambda-event-sources";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
-import { AppIdentity } from "../constructs/core/identity";
 import type { GuMigratingResource } from "../constructs/core/migrating";
 import { GuKinesisStream } from "../constructs/kinesis";
 import type { GuKinesisStreamProps } from "../constructs/kinesis";
@@ -104,6 +103,7 @@ export class GuKinesisLambda extends GuLambdaFunction {
       errorPercentageMonitoring: props.monitoringConfiguration.noMonitoring ? undefined : props.monitoringConfiguration,
     });
     const kinesisProps: GuKinesisStreamProps = {
+      app: props.app,
       existingLogicalId: props.existingKinesisStream?.existingLogicalId,
       encryption: StreamEncryption.MANAGED,
       ...props.kinesisStreamProps,
@@ -116,7 +116,7 @@ export class GuKinesisLambda extends GuLambdaFunction {
           streamId,
           `arn:aws:kinesis:${scope.region}:${scope.account}:stream/${props.existingKinesisStream.externalKinesisStreamName}`
         )
-      : AppIdentity.taggedConstruct(props, new GuKinesisStream(scope, streamId, kinesisProps));
+      : new GuKinesisStream(scope, streamId, kinesisProps);
 
     const errorHandlingPropsToAwsProps = toAwsErrorHandlingProps(props.errorHandlingConfiguration);
 


### PR DESCRIPTION
Requires #875.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Apply the `GuAppAwareConstruct` mixin, introduced in #853, to the `GuKinesisStream` construct.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See updated tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Higher consistency across app aware constructs? App aware constructs should:

  - include the app in the logical id
  - receive the `App` tag

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This changes the logical id, which is a replacement operation. In reality, I don't think this effects any stack today as I don't think we've used GuCDK to create a new Kinesis stream, but rather we have migrated existing streams into a GuCDK defines stack.