### PR TITLE
fix: Ensure sns topics are app aware

### DIFF
--- a/src/constructs/sns/sns-topic.test.ts
+++ b/src/constructs/sns/sns-topic.test.ts
@@ -6,13 +6,18 @@ import { GuSnsTopic } from "./sns-topic";
 describe("The GuSnsTopic construct", () => {
   it("should not override the id by default", () => {
     const stack = simpleGuStackForTesting();
-    new GuSnsTopic(stack, "MySnsTopic");
+    new GuSnsTopic(stack, "MySnsTopic", { app: "testing" });
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", /MySnsTopic.+/);
+    expect(stack).toHaveGuTaggedResource("AWS::SNS::Topic", { appIdentity: { app: "testing" } });
   });
 
   it("overrides the logicalId when existingLogicalId is set in a migrating stack", () => {
     const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
-    new GuSnsTopic(stack, "my-sns-topic", { existingLogicalId: { logicalId: "TheSnsTopic", reason: "testing" } });
+    new GuSnsTopic(stack, "my-sns-topic", {
+      existingLogicalId: { logicalId: "TheSnsTopic", reason: "testing" },
+      app: "testing",
+    });
     expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::SNS::Topic", "TheSnsTopic");
+    expect(stack).toHaveGuTaggedResource("AWS::SNS::Topic", { appIdentity: { app: "testing" } });
   });
 });

--- a/src/constructs/sns/sns-topic.ts
+++ b/src/constructs/sns/sns-topic.ts
@@ -1,10 +1,12 @@
 import { Topic } from "@aws-cdk/aws-sns";
 import type { TopicProps } from "@aws-cdk/aws-sns";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
+import type { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-interface GuSnsTopicProps extends TopicProps, GuMigratingResource {}
+interface GuSnsTopicProps extends TopicProps, GuMigratingResource, AppIdentity {}
 
 /**
  * Construct which creates an SNS Topic.
@@ -22,8 +24,8 @@ interface GuSnsTopicProps extends TopicProps, GuMigratingResource {}
  *  new GuSnsTopic(stack, "SnsTopic", { existingLogicalId: "MyCloudFormedSnsTopic" });
  * ```
  */
-export class GuSnsTopic extends GuStatefulMigratableConstruct(Topic) {
-  constructor(scope: GuStack, id: string, props?: GuSnsTopicProps) {
+export class GuSnsTopic extends GuStatefulMigratableConstruct(GuAppAwareConstruct(Topic)) {
+  constructor(scope: GuStack, id: string, props: GuSnsTopicProps) {
     super(scope, id, props);
   }
 }

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "mylambdafunctionTestingTopicName16F8329F": Object {
       "Value": Object {
         "Fn::GetAtt": Array [
-          "SnsIncomingEventsTopic308392EC",
+          "SnsIncomingEventsTopicTesting17610EEB",
           "TopicName",
         ],
       },
@@ -29,7 +29,7 @@ Object {
     },
   },
   "Resources": Object {
-    "SnsIncomingEventsTopic308392EC": Object {
+    "SnsIncomingEventsTopicTesting17610EEB": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -128,7 +128,7 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
-    "mylambdafunctionTestingAllowInvokeTestSnsIncomingEventsTopicFE4AC0FA2DD1E419": Object {
+    "mylambdafunctionTestingAllowInvokeTestSnsIncomingEventsTopicTesting9FFEA7D4BC7157D6": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -139,7 +139,7 @@ Object {
         },
         "Principal": "sns.amazonaws.com",
         "SourceArn": Object {
-          "Ref": "SnsIncomingEventsTopic308392EC",
+          "Ref": "SnsIncomingEventsTopicTesting17610EEB",
         },
       },
       "Type": "AWS::Lambda::Permission",
@@ -280,7 +280,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "mylambdafunctionTestingSnsIncomingEventsTopic7B5CEAE1": Object {
+    "mylambdafunctionTestingSnsIncomingEventsTopicTestingD3D048E6": Object {
       "Properties": Object {
         "Endpoint": Object {
           "Fn::GetAtt": Array [
@@ -290,7 +290,7 @@ Object {
         },
         "Protocol": "lambda",
         "TopicArn": Object {
-          "Ref": "SnsIncomingEventsTopic308392EC",
+          "Ref": "SnsIncomingEventsTopicTesting17610EEB",
         },
       },
       "Type": "AWS::SNS::Subscription",

--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -3,7 +3,6 @@ import { Topic } from "@aws-cdk/aws-sns";
 import { CfnOutput } from "@aws-cdk/core";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
-import { AppIdentity } from "../constructs/core/identity";
 import type { GuMigratingResource } from "../constructs/core/migrating";
 import { GuLambdaFunction } from "../constructs/lambda";
 import type { GuFunctionProps } from "../constructs/lambda";
@@ -93,12 +92,10 @@ export class GuSnsLambda extends GuLambdaFunction {
           topicId,
           `arn:aws:sns:${scope.region}:${scope.account}:${props.existingSnsTopic.externalTopicName}`
         )
-      : AppIdentity.taggedConstruct(
-          props,
-          new GuSnsTopic(scope, topicId, {
-            existingLogicalId: props.existingSnsTopic?.existingLogicalId,
-          })
-        );
+      : new GuSnsTopic(scope, topicId, {
+          app: props.app,
+          existingLogicalId: props.existingSnsTopic?.existingLogicalId,
+        });
     this.addEventSource(new SnsEventSource(snsTopic));
     new CfnOutput(this, "TopicName", { value: snsTopic.topicName });
   }


### PR DESCRIPTION
Requires #876.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Add the `GuAppAwareConstruct` mixin, introduced in #853, to the `GuSnsTopic` construct.

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

No.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See updated tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Higher consistency across app aware constructs? App aware constructs should:
  - include the app in the logical id
  - receive the `App` tag

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This changes the logical id, which is a replacement operation. In reality, I don't think this effects any stack today as I don't think we've used GuCDK to create a new SNS topic, but rather we have migrated existing topics into a GuCDK defines stack.