### PR TITLE
docs: Add the CLI docs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ find useful scripts within the [`script`][directory-script] directory for common
 - `./script/lint` to lint the code using ESLint
 - `./script/test` to run the Jest unit tests
 - `./script/build` to compile TypeScript to JS
+- `./script/cli-docs` to update the CLI documentation in this file
 
 There are also some other commands defined in `package.json`:
 
@@ -90,6 +91,29 @@ If they don't, please let us know about your use-case so that we can consider su
 Alternatively, PRs are always welcome!
 
 There are more details on using the CDK library in [docs][directory-docs]
+
+### Using the `@guardian/cdk` CLI
+
+<!-- cli -->
+```
+@guardian/cdk COMMAND [args]
+
+Commands:
+  @guardian/cdk aws-cdk-version     Print the version of @aws-cdk libraries being
+                               used
+  @guardian/cdk account-readiness   Perform checks on an AWS account to see if it is
+                               GuCDK ready
+  @guardian/cdk check-package-json  Check a package.json file for compatibility with
+                               GuCDK
+
+Options:
+      --profile  AWS profile                                            [string]
+      --region   AWS region                      [string] [default: "eu-west-1"]
+      --version  Show version number                                   [boolean]
+  -h, --help     Show help                                             [boolean]
+
+```
+<!-- clistop -->
 
 ## Releasing
 

--- a/script/ci
+++ b/script/ci
@@ -17,6 +17,17 @@ runIntegrationTest() {
   )
 }
 
+keepReadmeUpdated() {
+  "${DIR}"/cli-docs
+
+  if git diff --quiet; then
+    exit 0
+  else
+    echo "The CLI docs in README.md are out of date. Run './script/cli-docs' to update them."
+    exit 1
+  fi
+}
+
 main() {
   preamble
 
@@ -27,6 +38,7 @@ main() {
   npm run test
 
   runIntegrationTest
+  keepReadmeUpdated
 }
 
 main

--- a/script/cli-docs
+++ b/script/cli-docs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const { readFile, writeFile } = require("fs/promises");
+const path = require("path");
+const { execSync } = require("child_process");
+
+async function main () {
+  const readmePath = path.join(__dirname, "..", "README.md")
+  const readme = (await readFile(readmePath)).toString()
+
+  console.log(`Updating CLI instructions in ${readmePath}`);
+
+  const startMark = "<!-- cli -->";
+  const stopMark = "<!-- clistop -->";
+  const codeBlock = "```";
+
+  const rawCliHelp = execSync("npm run --silent cli:dev -- --help").toString();
+  const cliHelp = rawCliHelp.replace(/index\.ts/g, "@guardian/cdk");
+
+  const content = [codeBlock, cliHelp, codeBlock];
+
+  if(readme.includes(startMark) && readme.includes(stopMark)){
+    // Find text between markers and replace it with the start marker
+    const re = new RegExp(`${startMark}(.|\n)*${stopMark}`, "m");
+    const resetReadme = readme.replace(re, startMark);
+
+    // replace the now singular start marker with the start marker, content and stop marker
+    const updatedReadme = resetReadme.replace(startMark, [startMark, ...content, stopMark].join("\n"));
+
+    // save changes
+    await writeFile(readmePath, updatedReadme);
+    console.log(`Changes written to ${readmePath}`);
+  }
+}
+
+main()
+  .then(() => {
+    console.log("Done");
+  })
+  .catch((err) => {
+    console.error(err);
+  });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds the CLI docs to README.md and also adds a script to update the contents of README.md over time.

This script is also executed during CI to ensure the README.md file is up to date.

This is useful because we're going to be adding to the CLI more and more, so it's useful to keep the docs updated too.

See it [here](https://github.com/guardian/cdk/tree/aa-cli-docs#using-the-guardiancdk-cli).

Inspired by [oclif](https://github.com/oclif/oclif/blob/589a5d91742d1ad8602ca4cbed4b41f442e78237/src/commands/readme.ts#L71-L79).

## Does this change require changes to existing projects or CDK CLI?
<!-- Consider whether this is something that will mean changes to projects that have already been migrated or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs --->

No.

## Does this change require changes to the library documentation?
<!-- If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid? --->

This is the documentation.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

- Checkout branch
- Run `./script/cli-doc`
- Observe a no-op as there are no changes needed (confirm with `git status`)
- Remove the content in README.md between the markers, but not the markers themselves
- Run `./script/cli-doc`
- Observe the README.md file has been written to

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It's slightly easier to keep docs up to date.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a