### PR TITLE
fix: check update-aws-cdk script dependencies before running

### DIFF
--- a/script/update-aws-cdk
+++ b/script/update-aws-cdk
@@ -5,6 +5,18 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR=$DIR/..
 
+checkDependencies() {
+  if ! [ -x "$(command -v gh)" ]; then
+    echo 'Error: gh is not installed but required. To install run `brew install gh` or see https://cli.github.com/.' >&2
+    exit 1
+  fi
+
+  if ! [ -x "$(command -v jq)" ]; then
+    echo 'Error: jq is not installed but required. To install, run `brew install jq` or see https://stedolan.github.io/jq/.' >&2
+    exit 1
+  fi
+}
+
 checkYarnLock() {
   "${DIR}"/check-yarn-lock
 }
@@ -66,6 +78,7 @@ raisePR() {
 }
 
 main() {
+  checkDependencies
   ensureAtHeadOfOrigin
   checkYarnLock
   updateAwsCdk


### PR DESCRIPTION
Note, PRs currently failing because we are not on latest aws-cdk so ran the script and hit this.

## What does this change?

Checks some of the less common deps for this script. Note, I haven't checked `git` or `npm` as those are expected for a TS project already.

## How to test

Attempt to run the script without the dependencies and get a descriptive error.