### PR TITLE
ci: Use correct tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     needs: [CI]
     steps:
       - name: Validate, approve and merge release PRs
-        uses: guardian/actions-merge-release-changes-to-protected-branch@1.2.0
+        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           npm-lockfile-version: 2


### PR DESCRIPTION
Fixes a typo - the correct tag of `guardian/actions-merge-release-changes-to-protected-branch` to use is `v1.2.0` not `1.2.0`.

(I have created a [`1.2.0` tag temporarily](https://github.com/guardian/actions-merge-release-changes-to-protected-branch/tags) to fix CI for all the dependabot PRs that have just been raised!)