### PR TITLE
feat!: Improve the GuCname construct

### DIFF
--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -3,19 +3,14 @@ import type { CertificateProps } from "@aws-cdk/aws-certificatemanager/lib/certi
 import { HostedZone } from "@aws-cdk/aws-route53";
 import { RemovalPolicy } from "@aws-cdk/core";
 import { Stage } from "../../constants";
+import type { GuDomainNameProps } from "../../types/domain-names";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
 import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
 import { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-export type GuCertificateProps = Record<Stage, GuDnsValidatedCertificateProps> & GuMigratingResource;
-export type GuCertificatePropsWithApp = GuCertificateProps & AppIdentity;
-
-export interface GuDnsValidatedCertificateProps {
-  domainName: string;
-  hostedZoneId?: string;
-}
+export type GuCertificatePropsWithApp = GuDomainNameProps & AppIdentity & GuMigratingResource;
 
 /**
  * Construct which creates a DNS-validated ACM Certificate.

--- a/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
+++ b/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
@@ -2,6 +2,16 @@
 
 exports[`The GuCname construct should create the correct resources with minimal config 1`] = `
 Object {
+  "Mappings": Object {
+    "mytestapp": Object {
+      "CODE": Object {
+        "domainName": "xyz.code-guardian.com",
+      },
+      "PROD": Object {
+        "domainName": "xyz.prod-guardian.com",
+      },
+    },
+  },
   "Parameters": Object {
     "Stage": Object {
       "AllowedValues": Array [
@@ -16,7 +26,15 @@ Object {
   "Resources": Object {
     "TestRecord": Object {
       "Properties": Object {
-        "Name": "banana.example.com",
+        "Name": Object {
+          "Fn::FindInMap": Array [
+            "mytestapp",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
         "RecordType": "CNAME",
         "ResourceRecords": Array [
           "apple.example.com",

--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -1,6 +1,8 @@
 import "@aws-cdk/assert/jest";
+import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Duration } from "@aws-cdk/core";
+import { Stage } from "../../constants";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuCname, GuDnsRecordSet, RecordType } from "./dns-records";
 
@@ -15,27 +17,30 @@ describe("The GuDnsRecordSet construct", () => {
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
+  it("should use the exact logical id that is passed in", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDnsRecordSet(stack, "ThisExactLogicalId", {
+      name: "banana.example.com",
+      recordType: RecordType.CNAME,
+      resourceRecords: ["apple.example.com"],
+      ttl: Duration.hours(1),
+    });
+    expect(stack).toHaveResourceOfTypeAndLogicalId("Guardian::DNS::RecordSet", "ThisExactLogicalId");
+  });
 });
 
 describe("The GuCname construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
     new GuCname(stack, "TestRecord", {
-      name: "banana.example.com",
+      domainNameProps: {
+        [Stage.CODE]: { domainName: "xyz.code-guardian.com" },
+        [Stage.PROD]: { domainName: "xyz.prod-guardian.com" },
+      },
+      app: "my-test-app",
       resourceRecord: "apple.example.com",
+      ttl: Duration.hours(1),
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
-  });
-  it("should allow users to override the default TTL", () => {
-    const stack = simpleGuStackForTesting();
-    new GuDnsRecordSet(stack, "TestRecord", {
-      name: "banana.example.com",
-      recordType: RecordType.CNAME,
-      resourceRecords: ["apple.example.com"],
-      ttl: Duration.minutes(1),
-    });
-    expect(stack).toHaveResourceLike("Guardian::DNS::RecordSet", {
-      TTL: 60,
-    });
   });
 });

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -19,8 +19,9 @@ export interface GuDnsRecordSetProps {
 /**
  * This construct can be used to create DNS records in NS1.
  *
- * If you are creating a CNAME for your CODE and PROD stages, for example when creating a CNAME
- * for your load balancer, [[`GuCname`]] may be used instead to reduce boilerplate.
+ * Prefer to use [[`GuCname`]] when creating a CNAME for a CODE or PROD load balancer,
+ * as this requires less boilerplate.
+
  */
 export class GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuDnsRecordSetProps) {

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,5 +1,9 @@
-import { CfnResource, Duration } from "@aws-cdk/core";
+import type { Duration } from "@aws-cdk/core";
+import { CfnResource } from "@aws-cdk/core";
+import { Stage } from "../../constants";
+import type { GuDomainNameProps } from "../../types/domain-names";
 import type { GuStack } from "../core";
+import type { AppIdentity } from "../core/identity";
 
 export enum RecordType {
   CNAME = "CNAME",
@@ -13,7 +17,10 @@ export interface GuDnsRecordSetProps {
 }
 
 /**
- * Do not use this construct directly. Use [[`GuCname`]] instead in order to reduce boilerplate.
+ * This construct can be used to create DNS records in NS1.
+ *
+ * If you are creating a CNAME for your CODE and PROD stages, for example when creating a CNAME
+ * for your load balancer, [[`GuCname`]] may be used instead to reduce boilerplate.
  */
 export class GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuDnsRecordSetProps) {
@@ -32,27 +39,48 @@ export class GuDnsRecordSet {
   }
 }
 
-export interface GuCnameProps {
-  /** The name of the record, for example: xyz.example.com */
-  name: string;
+export interface GuCnameProps extends AppIdentity {
+  /** The name of the records for CODE and PROD stages, for example:
+   * ```typescript
+   * {
+   *   [Stage.CODE]: { domainName: "xyz.code-guardian.com" },
+   *   [Stage.PROD]: { domainName: "xyz.prod-guardian.com" },
+   * }
+   * ```
+   */
+  domainNameProps: GuDomainNameProps;
   /** The record your CNAME should point to, for example your Load Balancer DNS name */
   resourceRecord: string;
-  /** The time to live for the DNS record - this will be set 1 hour by default */
-  ttl?: Duration;
+  /** The time to live for the DNS record */
+  ttl: Duration;
 }
 
 /**
  * Construct for creating CNAME records in NS1.
  *
+ * This is designed to create an appropriate CNAME for your CODE and PROD stages, for example when creating a CNAME
+ * for your load balancer.
+ *
+ * If you need something more unusual (e.g. you only need a CNAME for a standalone INFRA stage) you should use the
+ * lower-level [[`GuDnsRecordSet`]] class.
+ *
  * See [[`GuCnameProps`]] for configuration options.
  */
 export class GuCname extends GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuCnameProps) {
+    const domainName = scope.withStageDependentValue({
+      app: props.app,
+      variableName: "domainName",
+      stageValues: {
+        [Stage.CODE]: props.domainNameProps.CODE.domainName,
+        [Stage.PROD]: props.domainNameProps.PROD.domainName,
+      },
+    });
     super(scope, id, {
+      name: domainName,
       recordType: RecordType.CNAME,
       resourceRecords: [props.resourceRecord],
-      ttl: props.ttl ?? Duration.hours(1),
-      ...props,
+      ttl: props.ttl,
     });
   }
 }

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -8,7 +8,6 @@ import { Duration, Tags } from "@aws-cdk/core";
 import type { Stage } from "../constants";
 import { SSM_PARAMETER_PATHS } from "../constants/ssm-parameter-paths";
 import { TagKeys } from "../constants/tag-keys";
-import type { GuCertificateProps } from "../constructs/acm";
 import { GuCertificate } from "../constructs/acm";
 import type { GuAsgCapacityProps, GuUserDataProps } from "../constructs/autoscaling";
 import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
@@ -25,6 +24,7 @@ import {
   GuApplicationTargetGroup,
   GuHttpsApplicationListener,
 } from "../constructs/loadbalancing";
+import type { GuDomainNameProps } from "../types/domain-names";
 
 export enum AccessScope {
   PUBLIC = "Public",
@@ -170,7 +170,7 @@ export interface GuEc2AppProps extends AppIdentity {
   userData: GuUserDataProps | string;
   access: AppAccess;
   applicationPort: number;
-  certificateProps: GuCertificateProps;
+  certificateProps: GuDomainNameProps;
   roleConfiguration?: GuInstanceRoleProps;
   monitoringConfiguration: Alarms | NoMonitoring;
   instanceType: InstanceType;

--- a/src/types/domain-names.ts
+++ b/src/types/domain-names.ts
@@ -1,0 +1,8 @@
+import type { Stage } from "../constants";
+
+export type GuDomainNameProps = Record<Stage, GuDomainName>;
+
+export interface GuDomainName {
+  domainName: string;
+  hostedZoneId?: string;
+}


### PR DESCRIPTION
## What does this change?

This PR updates the `GuCname` construct so that it is optimised for our most typical use case. That is, creating CNAMEs which point to a load balancer or API gateway instance for the `CODE` and `PROD` stages. 

It is still possible to create CNAMEs which don't align with this use-case (e.g. using a non-standard `Stage`), but as that is moving away from the paved road, it must be achieved via the lower-level `GuDnsRecordSet` (which requires a little more thought and boilerplate).

In order to achieve this, we have made **breaking changes**:

* Setting the TTL is now mandatory when you create a `GuCname`
* `GuCname` now requires an app name
* Domain names for `CODE` and `PROD` stages are also required

## How to test

I have tested this by releasing to beta and [making the change to AMIgo](https://github.com/guardian/amigo/pull/655/files). The snapshot tests confirm that there are no changes to the generated CloudFormation template.

## How can we measure success?

* Users should be able to start managing their DNS records more easily. More specifically, as the construct creates an appropriate mapping for users under the hood, it should be harder to [make mistakes when wiring up the stage-dependent](https://github.com/guardian/lurch/pull/15#discussion_r596952548) domain name.
* Users are also forced to explicitly think about/acknowledge the TTL, which is important for reducing risk as part of the migration from CloudFormation to `@guardian/cdk`.
* Although users will need to work with this construct directly (that is, [we don't plan to create this construct via the pattern](https://github.com/guardian/cdk/discussions/913)), this change ensures that we're not adding [much code/complexity](https://github.com/guardian/amigo/pull/655/files#diff-78d894e83ca4cb48af587f94e9f8986cc0592d412273ef99246b30c644ae5098R275-R279) to the infrastructure definition.

## Have we considered potential risks?

I can't think of any particular risks associated with this PR. A GitHub search suggests that AMIgo is the only project using this construct in `main` at the moment.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
