### PR TITLE
feat: add `scheduleEnabled` to ECS task props

### DIFF
--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -121,6 +121,7 @@ export interface GuScheduledEcsTaskProps extends Identity {
   monitoringConfiguration: NoMonitoring | GuEcsTaskMonitoringProps;
   securityGroups?: ISecurityGroup[];
   customTaskPolicies?: PolicyStatement[];
+  scheduleEnabled?: boolean;
 }
 
 /**
@@ -206,6 +207,7 @@ export class GuScheduledEcsTask {
     const rule = new Rule(scope, AppIdentity.suffixText(props, "ScheduleRule"), {
       schedule: props.schedule,
       targets: [new SfnStateMachine(stateMachine)],
+      enabled: props.scheduleEnabled === undefined ? true : props.scheduleEnabled,
     });
 
     if (!props.monitoringConfiguration.noMonitoring) {


### PR DESCRIPTION
## What does this change?
This PR introduces a `scheduleEnabled` prop to the `GuScheduledEcsTaskProps` interface.
Explicitly setting the prop to `false` disables the rule, otherwise it is enabled by default.

The use case for this change is letting the user determine whether to run a schedule or not, for example depending on the stage. 
We have an example of this in Investigations & Reporting where we only need to run a certain task on PROD but not on CODE. We could use an if statement around `new GuScheduledEcsTask ...` to check the stage, but passing this prop feels like a more sensible way of doing it.

The prop is optional and doesn't break existing scheduled tasks.

## How can you measure success?
Less code required to determine whether to run the task. 