### PR TITLE
refactor!: rename stackName to cloudFormationStackName in GuStackProps

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -13,8 +13,16 @@ import type { GuMappingValue, GuStageMappingValue } from "./mappings";
 import { GuStageParameter } from "./parameters";
 import type { GuParameter } from "./parameters";
 
-export interface GuStackProps extends StackProps, Partial<GuMigratingStack> {
+export interface GuStackProps extends Omit<StackProps, "stackName">, Partial<GuMigratingStack> {
+  /**
+   * The Guardian stack being used (as defined in your riff-raff.yaml).
+   * This will be applied as a tag to all of your resources.
+   */
   stack: string;
+  /**
+   * The AWS CloudFormation stack name (as shown in the AWS CloudFormation UI).
+   */
+  cloudFormationStackName?: string;
 }
 
 /**
@@ -108,7 +116,11 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
 
   // eslint-disable-next-line custom-rules/valid-constructors -- GuStack is the exception as it must take an App
   constructor(app: App, id: string, props: GuStackProps) {
-    super(app, id, props);
+    const mergedProps = {
+      ...props,
+      stackName: props.cloudFormationStackName,
+    };
+    super(app, id, mergedProps);
 
     this.migratedFromCloudFormation = !!props.migratedFromCloudFormation;
 


### PR DESCRIPTION
## What does this change?

BREAKING CHANGE: Removes the `stackName` prop and adds an optional `cloudFormationStackName` prop.
This helps to remove ambiguity between the Guardian concept of a stack and a CloudFormation stack.

## How to test

This is a trivial change so we haven't added a test.

## How can we measure success?

Before there were props called `stack` and `stackName` that referred to two completely separate things - very confusing! Hopefully renaming the latter should make this distinction clearer.

## Have we considered potential risks?

This should be low risk as only a couple of projects currently use this prop (and they are both owned by Developer Experience!). We'll update them once this change is released.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
