### PR TITLE
feat: Introduce GuEcsTask (pulled from GuScheduledEcsTask)

### DIFF
--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The GuScheduledEcsTask pattern should create the correct resources with lots of config 1`] = `
+exports[`The GuEcsTask pattern should create the correct resources with lots of config 1`] = `
 Object {
   "Outputs": Object {
     "StateMachineArnOutputEcstest": Object {
@@ -69,27 +69,6 @@ Object {
       },
       "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
     },
-    "ScheduleRuleEcstest07F5BBD2": Object {
-      "Properties": Object {
-        "ScheduleExpression": "rate(1 minute)",
-        "State": "ENABLED",
-        "Targets": Array [
-          Object {
-            "Arn": Object {
-              "Ref": "StateMachineEcstest84BB1B77",
-            },
-            "Id": "Target0",
-            "RoleArn": Object {
-              "Fn::GetAtt": Array [
-                "StateMachineEcstestEventsRole50FE033D",
-                "Arn",
-              ],
-            },
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
     "StateMachineEcstest84BB1B77": Object {
       "DependsOn": Array [
         "StateMachineEcstestRoleDefaultPolicy1EED542B",
@@ -148,70 +127,6 @@ Object {
         ],
       },
       "Type": "AWS::StepFunctions::StateMachine",
-    },
-    "StateMachineEcstestEventsRole50FE033D": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "StateMachineEcstestEventsRoleDefaultPolicy2A914AF8": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "states:StartExecution",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Ref": "StateMachineEcstest84BB1B77",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "StateMachineEcstestEventsRoleDefaultPolicy2A914AF8",
-        "Roles": Array [
-          Object {
-            "Ref": "StateMachineEcstestEventsRole50FE033D",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "StateMachineEcstestRoleAFD3E1C6": Object {
       "Properties": Object {
@@ -468,7 +383,7 @@ Object {
               "LogDriver": "awslogs",
               "Options": Object {
                 "awslogs-group": Object {
-                  "Ref": "TaskDefinitionEcstestScheduledTaskContainerEcstestLogGroup1508FA51",
+                  "Ref": "TaskDefinitionEcstestTaskContainerEcstestLogGroupE23928B1",
                 },
                 "awslogs-region": Object {
                   "Ref": "AWS::Region",
@@ -477,7 +392,7 @@ Object {
               },
             },
             "Memory": 1024,
-            "Name": "ScheduledTaskContainerEcstest",
+            "Name": "TaskContainerEcstest",
           },
         ],
         "Cpu": "1024",
@@ -579,7 +494,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "TaskDefinitionEcstestScheduledTaskContainerEcstestLogGroup1508FA51",
+                  "TaskDefinitionEcstestTaskContainerEcstestLogGroupE23928B1",
                   "Arn",
                 ],
               },
@@ -596,7 +511,7 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TaskDefinitionEcstestScheduledTaskContainerEcstestLogGroup1508FA51": Object {
+    "TaskDefinitionEcstestTaskContainerEcstestLogGroupE23928B1": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "RetentionInDays": 14,

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`The GuEcsTask pattern should create the correct resources with lots of config 1`] = `
 Object {
   "Outputs": Object {
-    "StateMachineArnOutputEcstest": Object {
+    "testecstaskecstestStateMachineArnOutput": Object {
       "Value": Object {
-        "Ref": "StateMachineEcstest84BB1B77",
+        "Ref": "testecstaskecstestStateMachineC0B6383F",
       },
     },
   },
@@ -26,7 +26,72 @@ Object {
     },
   },
   "Resources": Object {
-    "ClusterEcstest1892FB90": Object {
+    "ecstestexecutionfailedC93F511B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          "arn:something:else:here:we:goalarm-topic",
+        ],
+        "AlarmDescription": "ecs-test-TEST job failed ",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": Object {
+              "Ref": "testecstaskecstestStateMachineC0B6383F",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ecstesttimeoutFE335653": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          "arn:something:else:here:we:goalarm-topic",
+        ],
+        "AlarmDescription": "ecs-test-TEST job timed out ",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": Object {
+              "Ref": "testecstaskecstestStateMachineC0B6383F",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsTimedOut",
+        "Namespace": "AWS/States",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testecstaskecstestCluster71BC62CB": Object {
+      "Properties": Object {
+        "CapacityProviders": Array [
+          "FARGATE",
+          "FARGATE_SPOT",
+        ],
+        "Cluster": Object {
+          "Ref": "testecstaskecstestClusterCBD4036C",
+        },
+        "DefaultCapacityProviderStrategy": Array [],
+      },
+      "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
+    },
+    "testecstaskecstestClusterCBD4036C": Object {
       "Properties": Object {
         "ClusterName": "ecs-test-cluster-TEST",
         "Tags": Array [
@@ -56,37 +121,24 @@ Object {
       },
       "Type": "AWS::ECS::Cluster",
     },
-    "ClusterEcstestAB072685": Object {
-      "Properties": Object {
-        "CapacityProviders": Array [
-          "FARGATE",
-          "FARGATE_SPOT",
-        ],
-        "Cluster": Object {
-          "Ref": "ClusterEcstest1892FB90",
-        },
-        "DefaultCapacityProviderStrategy": Array [],
-      },
-      "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
-    },
-    "StateMachineEcstest84BB1B77": Object {
+    "testecstaskecstestStateMachineC0B6383F": Object {
       "DependsOn": Array [
-        "StateMachineEcstestRoleDefaultPolicy1EED542B",
-        "StateMachineEcstestRoleAFD3E1C6",
+        "testecstaskecstestStateMachineRoleDefaultPolicy81B8C5B5",
+        "testecstaskecstestStateMachineRole93D08A02",
       ],
       "Properties": Object {
         "DefinitionString": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"StartAt\\":\\"ecs-test-task\\",\\"States\\":{\\"ecs-test-task\\":{\\"End\\":true,\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"ResultPath\\":null,\\"Resource\\":\\"arn:",
+              "{\\"StartAt\\":\\"test-ecs-task-ecs-test-task\\",\\"States\\":{\\"test-ecs-task-ecs-test-task\\":{\\"End\\":true,\\"Type\\":\\"Task\\",\\"TimeoutSeconds\\":3600,\\"ResultPath\\":null,\\"Resource\\":\\"arn:",
               Object {
                 "Ref": "AWS::Partition",
               },
               ":states:::ecs:runTask.sync\\",\\"Parameters\\":{\\"Cluster\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ClusterEcstest1892FB90",
+                  "testecstaskecstestClusterCBD4036C",
                   "Arn",
                 ],
               },
@@ -96,7 +148,7 @@ Object {
         },
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "StateMachineEcstestRoleAFD3E1C6",
+            "testecstaskecstestStateMachineRole93D08A02",
             "Arn",
           ],
         },
@@ -128,7 +180,7 @@ Object {
       },
       "Type": "AWS::StepFunctions::StateMachine",
     },
-    "StateMachineEcstestRoleAFD3E1C6": Object {
+    "testecstaskecstestStateMachineRole93D08A02": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -180,7 +232,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "StateMachineEcstestRoleDefaultPolicy1EED542B": Object {
+    "testecstaskecstestStateMachineRoleDefaultPolicy81B8C5B5": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -199,7 +251,7 @@ Object {
                           "Fn::Split": Array [
                             ":",
                             Object {
-                              "Ref": "TaskDefinitionEcstest258379BD",
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
                             },
                           ],
                         },
@@ -213,7 +265,7 @@ Object {
                           "Fn::Split": Array [
                             ":",
                             Object {
-                              "Ref": "TaskDefinitionEcstest258379BD",
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
                             },
                           ],
                         },
@@ -227,7 +279,7 @@ Object {
                           "Fn::Split": Array [
                             ":",
                             Object {
-                              "Ref": "TaskDefinitionEcstest258379BD",
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
                             },
                           ],
                         },
@@ -241,7 +293,7 @@ Object {
                           "Fn::Split": Array [
                             ":",
                             Object {
-                              "Ref": "TaskDefinitionEcstest258379BD",
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
                             },
                           ],
                         },
@@ -261,7 +313,7 @@ Object {
                                   "Fn::Split": Array [
                                     ":",
                                     Object {
-                                      "Ref": "TaskDefinitionEcstest258379BD",
+                                      "Ref": "testecstaskecstestTaskDefinition4BF687D5",
                                     },
                                   ],
                                 },
@@ -285,7 +337,7 @@ Object {
                                   "Fn::Split": Array [
                                     ":",
                                     Object {
-                                      "Ref": "TaskDefinitionEcstest258379BD",
+                                      "Ref": "testecstaskecstestTaskDefinition4BF687D5",
                                     },
                                   ],
                                 },
@@ -313,13 +365,13 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "TaskDefinitionEcstestTaskRoleD5169AE2",
+                    "testecstaskecstestTaskDefinitionTaskRole4D626B6F",
                     "Arn",
                   ],
                 },
                 Object {
                   "Fn::GetAtt": Array [
-                    "TaskDefinitionEcstestExecutionRole9D2A7D47",
+                    "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
                     "Arn",
                   ],
                 },
@@ -356,16 +408,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "StateMachineEcstestRoleDefaultPolicy1EED542B",
+        "PolicyName": "testecstaskecstestStateMachineRoleDefaultPolicy81B8C5B5",
         "Roles": Array [
           Object {
-            "Ref": "StateMachineEcstestRoleAFD3E1C6",
+            "Ref": "testecstaskecstestStateMachineRole93D08A02",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TaskDefinitionEcstest258379BD": Object {
+    "testecstaskecstestTaskDefinition4BF687D5": Object {
       "Properties": Object {
         "ContainerDefinitions": Array [
           Object {
@@ -383,7 +435,7 @@ Object {
               "LogDriver": "awslogs",
               "Options": Object {
                 "awslogs-group": Object {
-                  "Ref": "TaskDefinitionEcstestTaskContainerEcstestLogGroupE23928B1",
+                  "Ref": "testecstaskecstestTaskDefinitiontestecstaskecstestTaskContainerLogGroup3F63585A",
                 },
                 "awslogs-region": Object {
                   "Ref": "AWS::Region",
@@ -392,13 +444,13 @@ Object {
               },
             },
             "Memory": 1024,
-            "Name": "TaskContainerEcstest",
+            "Name": "test-ecs-task-ecs-test-TaskContainer",
           },
         ],
         "Cpu": "1024",
         "ExecutionRoleArn": Object {
           "Fn::GetAtt": Array [
-            "TaskDefinitionEcstestExecutionRole9D2A7D47",
+            "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
             "Arn",
           ],
         },
@@ -434,55 +486,14 @@ Object {
         ],
         "TaskRoleArn": Object {
           "Fn::GetAtt": Array [
-            "TaskDefinitionEcstestTaskRoleD5169AE2",
+            "testecstaskecstestTaskDefinitionTaskRole4D626B6F",
             "Arn",
           ],
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
-    "TaskDefinitionEcstestExecutionRole9D2A7D47": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "TaskDefinitionEcstestExecutionRoleDefaultPolicy562096CB": Object {
+    "testecstaskecstestTaskDefinitionExecutionRoleDefaultPolicy85ED5386": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -494,7 +505,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "TaskDefinitionEcstestTaskContainerEcstestLogGroupE23928B1",
+                  "testecstaskecstestTaskDefinitiontestecstaskecstestTaskContainerLogGroup3F63585A",
                   "Arn",
                 ],
               },
@@ -502,24 +513,16 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "TaskDefinitionEcstestExecutionRoleDefaultPolicy562096CB",
+        "PolicyName": "testecstaskecstestTaskDefinitionExecutionRoleDefaultPolicy85ED5386",
         "Roles": Array [
           Object {
-            "Ref": "TaskDefinitionEcstestExecutionRole9D2A7D47",
+            "Ref": "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TaskDefinitionEcstestTaskContainerEcstestLogGroupE23928B1": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "RetentionInDays": 14,
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "TaskDefinitionEcstestTaskRoleD5169AE2": Object {
+    "testecstaskecstestTaskDefinitionExecutionRoleF588BC50": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -560,7 +563,48 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "TaskDefinitionEcstestTaskRoleDefaultPolicyC6A4D178": Object {
+    "testecstaskecstestTaskDefinitionTaskRole4D626B6F": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testecstaskecstestTaskDefinitionTaskRoleDefaultPolicy65D034C8": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -592,66 +636,22 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "TaskDefinitionEcstestTaskRoleDefaultPolicyC6A4D178",
+        "PolicyName": "testecstaskecstestTaskDefinitionTaskRoleDefaultPolicy65D034C8",
         "Roles": Array [
           Object {
-            "Ref": "TaskDefinitionEcstestTaskRoleD5169AE2",
+            "Ref": "testecstaskecstestTaskDefinitionTaskRole4D626B6F",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ecstestexecutionfailedC93F511B": Object {
+    "testecstaskecstestTaskDefinitiontestecstaskecstestTaskContainerLogGroup3F63585A": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          "arn:something:else:here:we:goalarm-topic",
-        ],
-        "AlarmDescription": "ecs-test-TEST job failed ",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "StateMachineArn",
-            "Value": Object {
-              "Ref": "StateMachineEcstest84BB1B77",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "ExecutionsFailed",
-        "Namespace": "AWS/States",
-        "Period": 3600,
-        "Statistic": "Sum",
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
+        "RetentionInDays": 14,
       },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ecstesttimeoutFE335653": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          "arn:something:else:here:we:goalarm-topic",
-        ],
-        "AlarmDescription": "ecs-test-TEST job timed out ",
-        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "Dimensions": Array [
-          Object {
-            "Name": "StateMachineArn",
-            "Value": Object {
-              "Ref": "StateMachineEcstest84BB1B77",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "ExecutionsTimedOut",
-        "Namespace": "AWS/States",
-        "Period": 3600,
-        "Statistic": "Sum",
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -28,7 +28,7 @@ describe("The GuEcsTask pattern", () => {
   it("should use the specified container", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuEcsTask(stack, {
+    new GuEcsTask(stack, "test-ecs-task", {
       containerConfiguration: { id: "node:10", type: "registry" },
       monitoringConfiguration: { noMonitoring: true },
       vpc: makeVpc(stack),
@@ -41,7 +41,7 @@ describe("The GuEcsTask pattern", () => {
   });
 
   const generateComplexStack = (stack: GuStack, app: string, vpc: IVpc) => {
-    new GuEcsTask(stack, {
+    new GuEcsTask(stack, `test-ecs-task-${app}`, {
       containerConfiguration: { id: "node:10", type: "registry" },
       vpc,
       stack: "test",

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -1,0 +1,79 @@
+import "@aws-cdk/assert/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import type { IVpc } from "@aws-cdk/aws-ec2";
+import { SecurityGroup, Vpc } from "@aws-cdk/aws-ec2";
+import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
+import { simpleGuStackForTesting } from "../../utils/test";
+import type { GuStack } from "../core";
+import { GuEcsTask } from "./ecs-task";
+import "../../utils/test/jest";
+
+const makeVpc = (stack: GuStack) =>
+  Vpc.fromVpcAttributes(stack, "VPC", {
+    vpcId: "test",
+    availabilityZones: [""],
+    publicSubnetIds: [""],
+    privateSubnetIds: ["abc-123"],
+  });
+
+const securityGroup = (stack: GuStack, app?: string) =>
+  SecurityGroup.fromSecurityGroupId(stack, `hehe-${app ?? ""}`, "id-123");
+const testPolicy = new PolicyStatement({
+  effect: Effect.ALLOW,
+  actions: ["s3:GetObject"],
+  resources: ["databaseSecretArn"],
+});
+
+describe("The GuEcsTask pattern", () => {
+  it("should use the specified container", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEcsTask(stack, {
+      containerConfiguration: { id: "node:10", type: "registry" },
+      monitoringConfiguration: { noMonitoring: true },
+      vpc: makeVpc(stack),
+      stack: "test",
+      stage: "TEST",
+      app: "ecs-test",
+    });
+
+    expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", { ContainerDefinitions: [{ Image: "node:10" }] });
+  });
+
+  const generateComplexStack = (stack: GuStack, app: string, vpc: IVpc) => {
+    new GuEcsTask(stack, {
+      containerConfiguration: { id: "node:10", type: "registry" },
+      vpc,
+      stack: "test",
+      stage: "TEST",
+      app: app,
+      taskTimeoutInMinutes: 60,
+      cpu: 1024,
+      memory: 1024,
+      monitoringConfiguration: { snsTopicArn: "arn:something:else:here:we:goalarm-topic", noMonitoring: false },
+      taskCommand: `echo "yo ho row ho it's a pirates life for me"`,
+      securityGroups: [securityGroup(stack, app)],
+      customTaskPolicies: [testPolicy],
+    });
+  };
+
+  it("should create the correct resources with lots of config", () => {
+    const stack = simpleGuStackForTesting();
+
+    generateComplexStack(stack, "ecs-test", makeVpc(stack));
+
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+
+  it("should support having more than one scheduled task in the same stack", () => {
+    const stack = simpleGuStackForTesting();
+
+    const vpc = makeVpc(stack);
+
+    generateComplexStack(stack, "ecs-test2", vpc);
+    generateComplexStack(stack, "ecs-test", vpc);
+
+    expect(stack).toHaveGuTaggedResource("AWS::ECS::TaskDefinition", { appIdentity: { app: "ecs-test" } });
+    expect(stack).toHaveGuTaggedResource("AWS::ECS::TaskDefinition", { appIdentity: { app: "ecs-test2" } });
+  });
+});

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -1,0 +1,231 @@
+import { Alarm, TreatMissingData } from "@aws-cdk/aws-cloudwatch";
+import { SnsAction } from "@aws-cdk/aws-cloudwatch-actions";
+import type { ISecurityGroup, IVpc } from "@aws-cdk/aws-ec2";
+import type { IRepository } from "@aws-cdk/aws-ecr";
+import {
+  Cluster,
+  Compatibility,
+  ContainerImage,
+  FargatePlatformVersion,
+  LogDrivers,
+  TaskDefinition,
+} from "@aws-cdk/aws-ecs";
+import type { PolicyStatement } from "@aws-cdk/aws-iam";
+import { Topic } from "@aws-cdk/aws-sns";
+import { IntegrationPattern, StateMachine } from "@aws-cdk/aws-stepfunctions";
+import { EcsFargateLaunchTarget, EcsRunTask } from "@aws-cdk/aws-stepfunctions-tasks";
+import { CfnOutput, Duration } from "@aws-cdk/core";
+import type { NoMonitoring } from "../cloudwatch";
+import type { GuStack } from "../core";
+import type { Identity } from "../core/identity";
+import { AppIdentity } from "../core/identity";
+import { GuGetDistributablePolicyStatement } from "../iam";
+
+/**
+ * Configuration to determine what container to use for the task
+ * For example, to run the task in the latest node container:
+ *
+ * ```typescript
+ * const containerConfiguration = {
+ *     id: 'node:latest'
+ * }
+ * ```
+ *
+ * Alternatively you can specify a repository and version, for example for an ECR repository:
+ * ```typescript
+ * import { Repository } from "@aws-cdk/aws-ecr";
+ * const repository = new Repository(scope, `${app}-repository`, {
+    repositoryName: app,
+  });
+ * const containerConfiguration = {
+ *     repository: Repository.fromRepositoryArn("<repository arn>"),
+ *     version: '1'
+ * }
+ * ```
+ */
+
+export type RepositoryContainer = {
+  repository: IRepository;
+  version: string;
+  type: "repository";
+};
+
+export type RegistryContainer = {
+  id?: string;
+  type: "registry";
+};
+
+export type ContainerConfiguration = RepositoryContainer | RegistryContainer;
+
+export type GuEcsTaskMonitoringProps = { snsTopicArn: string; noMonitoring: false };
+
+/**
+ * Configuration options for the [[`GuEcsTask`]] pattern.
+ *
+ * See [[`ContainerConfiguration`]] for details of how to configure the container used to run the task.
+ *
+ * `taskTimeoutInMinutes` does what is says on the tin. The default timeout is 15 minutes.
+ *
+ * The `taskCommand` prop allows you to specify a command to run when the task starts (this can also be done via a CMD statement in
+ * your Dockerfile). For example:
+ *
+ * const props = {
+ *    //other props
+ *    taskCommand: `aws s3 cp s3://${distbucket}/${stack}/${stage}/${app}/task.sh . && ./task.sh
+    }
+ *
+ * It is advisable to configure alarms for when the job fails/times out. To do this specify the alarmSnsTopicArn prop.
+ *
+ * `customTaskPolicies` allows your task to interact with other AWS services. By default a task
+ * will have read access to the distribution bucket for your account.
+ *
+ * You can specify security groups to apply to task using the `securityGroups` prop.
+ *
+ * You can also set the memory and cpu units for your task. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+ * for further details.
+ *
+ */
+export interface GuEcsTaskProps extends Identity {
+  vpc: IVpc;
+  containerConfiguration: ContainerConfiguration;
+  taskTimeoutInMinutes?: number;
+  cpu?: number;
+  memory?: number;
+  taskCommand?: string;
+  monitoringConfiguration: NoMonitoring | GuEcsTaskMonitoringProps;
+  securityGroups?: ISecurityGroup[];
+  customTaskPolicies?: PolicyStatement[];
+}
+
+/**
+ * Containers can be specified either via a repository and version or by container id (in which case it will
+ * be fetched from docker hub).
+ */
+const getContainer = (config: ContainerConfiguration) => {
+  if (config.type == "repository") {
+    return ContainerImage.fromEcrRepository(config.repository, config.version);
+  } else {
+    return ContainerImage.fromRegistry(config.id ?? "ubuntu:focal");
+  }
+};
+
+/**
+ * Pattern which creates all of the resources needed for a fargate task
+ *
+ * The task will be wrapped in a step function to allow for easier triggering and alarming on failure.
+ *
+ * For all configuration options, see [[`GuEcsTaskProps`]].
+ *
+ * Note that if your task reliably completes in less than 15 minutes then you should probably use a [[`GuLambda`]] instead. This
+ * pattern was mainly created to work around the 15 minute lambda timeout.
+ */
+export class GuEcsTask {
+  stateMachine: StateMachine;
+
+  constructor(scope: GuStack, props: GuEcsTaskProps) {
+    const timeout = props.taskTimeoutInMinutes ?? 15;
+
+    // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu for details
+    const defaultCpu = 2048; // 2 cores and from 4-16GB memory
+    const defaultMemory = 4096; // 4GB
+
+    const cpu = props.cpu ?? defaultCpu;
+    const memory = props.memory ?? defaultMemory;
+
+    const cluster = new Cluster(scope, AppIdentity.suffixText(props, "Cluster"), {
+      clusterName: `${props.app}-cluster-${props.stage}`,
+      enableFargateCapacityProviders: true,
+      vpc: props.vpc,
+    });
+
+    const taskDefinition = new TaskDefinition(scope, AppIdentity.suffixText(props, "TaskDefinition"), {
+      compatibility: Compatibility.FARGATE,
+      cpu: cpu.toString(),
+      memoryMiB: memory.toString(),
+      family: `${props.stack}-${props.stage}-${props.app}`,
+    });
+
+    taskDefinition.addContainer(AppIdentity.suffixText(props, "TaskContainer"), {
+      image: getContainer(props.containerConfiguration),
+      entryPoint: props.taskCommand ? ["/bin/sh"] : undefined,
+      command: props.taskCommand ? ["-c", `${props.taskCommand}`] : undefined, // if unset, falls back to CMD in docker file, or no command will be run
+      cpu,
+      memoryLimitMiB: props.memory,
+      logging: LogDrivers.awsLogs({
+        streamPrefix: props.app,
+        logRetention: 14,
+      }),
+    });
+
+    const distPolicy = new GuGetDistributablePolicyStatement(scope, { app: props.app });
+
+    taskDefinition.addToTaskRolePolicy(distPolicy);
+    (props.customTaskPolicies ?? []).forEach((p) => taskDefinition.addToTaskRolePolicy(p));
+
+    const task = new EcsRunTask(scope, `${props.app}-task`, {
+      cluster: cluster,
+      launchTarget: new EcsFargateLaunchTarget({
+        platformVersion: FargatePlatformVersion.LATEST,
+      }),
+      taskDefinition: taskDefinition,
+      integrationPattern: IntegrationPattern.RUN_JOB,
+      resultPath: "DISCARD",
+      timeout: Duration.minutes(timeout),
+      securityGroups: props.securityGroups ?? [],
+    });
+
+    this.stateMachine = new StateMachine(scope, AppIdentity.suffixText(props, "StateMachine"), {
+      definition: task,
+      stateMachineName: `${props.app}-${props.stage}`,
+    });
+
+    if (!props.monitoringConfiguration.noMonitoring) {
+      const alarmTopic = Topic.fromTopicArn(
+        scope,
+        AppIdentity.suffixText(props, "AlarmTopic"),
+        props.monitoringConfiguration.snsTopicArn
+      );
+      const alarms = [
+        {
+          name: `${props.app}-execution-failed`,
+          description: `${props.app}-${props.stage} job failed `,
+          metric: this.stateMachine.metricFailed({
+            period: Duration.hours(1),
+            statistic: "sum",
+          }),
+        },
+        {
+          name: `${props.app}-timeout`,
+          description: `${props.app}-${props.stage} job timed out `,
+          metric: this.stateMachine.metricTimedOut({
+            period: Duration.hours(1),
+            statistic: "sum",
+          }),
+        },
+      ];
+
+      alarms.forEach((a) => {
+        const alarm = new Alarm(scope, a.name, {
+          alarmDescription: a.description,
+          actionsEnabled: true,
+          metric: a.metric,
+          // default for comparisonOperator is GreaterThanOrEqualToThreshold
+          threshold: 1,
+          evaluationPeriods: 1,
+          treatMissingData: TreatMissingData.NOT_BREACHING,
+        });
+        alarm.addAlarmAction(new SnsAction(alarmTopic));
+        AppIdentity.taggedConstruct({ app: props.app }, alarm);
+      });
+    }
+
+    // Tag all constructs with correct app tag
+    [cluster, task, taskDefinition, this.stateMachine].forEach((c) =>
+      AppIdentity.taggedConstruct({ app: props.app }, c)
+    );
+
+    new CfnOutput(scope, AppIdentity.suffixText(props, "StateMachineArnOutput"), {
+      value: this.stateMachine.stateMachineArn,
+    });
+  }
+}

--- a/src/patterns/scheduled-ecs-task.test.ts
+++ b/src/patterns/scheduled-ecs-task.test.ts
@@ -1,14 +1,11 @@
 import "@aws-cdk/assert/jest";
-import { SynthUtils } from "@aws-cdk/assert";
-import type { IVpc } from "@aws-cdk/aws-ec2";
-import { SecurityGroup, Vpc } from "@aws-cdk/aws-ec2";
+import "../utils/test/jest";
+import { IVpc, Vpc } from "@aws-cdk/aws-ec2";
 import { Schedule } from "@aws-cdk/aws-events";
-import { Effect, PolicyStatement } from "@aws-cdk/aws-iam";
 import { Duration } from "@aws-cdk/core";
 import type { GuStack } from "../constructs/core";
 import { simpleGuStackForTesting } from "../utils/test";
 import { GuScheduledEcsTask } from "./scheduled-ecs-task";
-import "../utils/test/jest";
 
 const makeVpc = (stack: GuStack) =>
   Vpc.fromVpcAttributes(stack, "VPC", {
@@ -18,31 +15,7 @@ const makeVpc = (stack: GuStack) =>
     privateSubnetIds: ["abc-123"],
   });
 
-const securityGroup = (stack: GuStack, app?: string) =>
-  SecurityGroup.fromSecurityGroupId(stack, `hehe-${app ?? ""}`, "id-123");
-const testPolicy = new PolicyStatement({
-  effect: Effect.ALLOW,
-  actions: ["s3:GetObject"],
-  resources: ["databaseSecretArn"],
-});
-
 describe("The GuScheduledEcsTask pattern", () => {
-  it("should use the specified container", () => {
-    const stack = simpleGuStackForTesting();
-
-    new GuScheduledEcsTask(stack, {
-      schedule: Schedule.rate(Duration.minutes(1)),
-      containerConfiguration: { id: "node:10", type: "registry" },
-      monitoringConfiguration: { noMonitoring: true },
-      vpc: makeVpc(stack),
-      stack: "test",
-      stage: "TEST",
-      app: "ecs-test",
-    });
-
-    expect(stack).toHaveResourceLike("AWS::ECS::TaskDefinition", { ContainerDefinitions: [{ Image: "node:10" }] });
-  });
-
   it("should use the specified schedule", () => {
     const stack = simpleGuStackForTesting();
 
@@ -57,43 +30,5 @@ describe("The GuScheduledEcsTask pattern", () => {
     });
 
     expect(stack).toHaveResourceLike("AWS::Events::Rule", { ScheduleExpression: "rate(1 minute)" });
-  });
-
-  const generateComplexStack = (stack: GuStack, app: string, vpc: IVpc) => {
-    new GuScheduledEcsTask(stack, {
-      schedule: Schedule.rate(Duration.minutes(1)),
-      containerConfiguration: { id: "node:10", type: "registry" },
-      vpc,
-      stack: "test",
-      stage: "TEST",
-      app: app,
-      taskTimeoutInMinutes: 60,
-      cpu: 1024,
-      memory: 1024,
-      monitoringConfiguration: { snsTopicArn: "arn:something:else:here:we:goalarm-topic", noMonitoring: false },
-      taskCommand: `echo "yo ho row ho it's a pirates life for me"`,
-      securityGroups: [securityGroup(stack, app)],
-      customTaskPolicies: [testPolicy],
-    });
-  };
-
-  it("should create the correct resources with lots of config", () => {
-    const stack = simpleGuStackForTesting();
-
-    generateComplexStack(stack, "ecs-test", makeVpc(stack));
-
-    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
-  });
-
-  it("should support having more than one scheduled task in the same stack", () => {
-    const stack = simpleGuStackForTesting();
-
-    const vpc = makeVpc(stack);
-
-    generateComplexStack(stack, "ecs-test2", vpc);
-    generateComplexStack(stack, "ecs-test", vpc);
-
-    expect(stack).toHaveGuTaggedResource("AWS::ECS::TaskDefinition", { appIdentity: { app: "ecs-test" } });
-    expect(stack).toHaveGuTaggedResource("AWS::ECS::TaskDefinition", { appIdentity: { app: "ecs-test2" } });
   });
 });

--- a/src/patterns/scheduled-ecs-task.test.ts
+++ b/src/patterns/scheduled-ecs-task.test.ts
@@ -19,7 +19,7 @@ describe("The GuScheduledEcsTask pattern", () => {
   it("should use the specified schedule", () => {
     const stack = simpleGuStackForTesting();
 
-    new GuScheduledEcsTask(stack, {
+    new GuScheduledEcsTask(stack, "test", {
       schedule: Schedule.rate(Duration.minutes(1)),
       containerConfiguration: { id: "node:10", type: "registry" },
       monitoringConfiguration: { noMonitoring: true },

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -5,6 +5,7 @@ import type { GuStack } from "../constructs/core";
 import { AppIdentity } from "../constructs/core/identity";
 import type { GuEcsTaskProps } from "../constructs/ecs/ecs-task";
 import { GuEcsTask } from "../constructs/ecs/ecs-task";
+import { GuAppAwareConstruct } from "../utils/mixin/app-aware-construct";
 
 /**
  * Configuration options for the [[`GuScheduledEcsTask`]] pattern.
@@ -47,15 +48,14 @@ export interface GuScheduledEcsTaskProps extends GuEcsTaskProps {
  * Note that if your task reliably completes in less than 15 minutes then you should probably use a [[`GuScheduledLambda`]] instead. This
  * pattern was mainly created to work around the 15 minute lambda timeout.
  */
-export class GuScheduledEcsTask extends GuEcsTask {
-  constructor(scope: GuStack, props: GuScheduledEcsTaskProps) {
-    super(scope, props);
+export class GuScheduledEcsTask extends GuAppAwareConstruct(GuEcsTask) {
+  constructor(scope: GuStack, id: string, props: GuScheduledEcsTaskProps) {
+    super(scope, id, props);
 
-    const rule = new Rule(scope, AppIdentity.suffixText(props, "ScheduleRule"), {
+    new Rule(scope, `${id}-ScheduleRule`, {
       schedule: props.schedule,
       targets: [new SfnStateMachine(this.stateMachine)],
       enabled: true,
     });
-    AppIdentity.taggedConstruct({ app: props.app }, rule);
   }
 }

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -2,7 +2,6 @@ import type { Schedule } from "@aws-cdk/aws-events";
 import { Rule } from "@aws-cdk/aws-events";
 import { SfnStateMachine } from "@aws-cdk/aws-events-targets";
 import type { GuStack } from "../constructs/core";
-import { AppIdentity } from "../constructs/core/identity";
 import type { GuEcsTaskProps } from "../constructs/ecs/ecs-task";
 import { GuEcsTask } from "../constructs/ecs/ecs-task";
 import { GuAppAwareConstruct } from "../utils/mixin/app-aware-construct";

--- a/src/patterns/scheduled-ecs-task.ts
+++ b/src/patterns/scheduled-ecs-task.ts
@@ -1,72 +1,16 @@
-import { Alarm, TreatMissingData } from "@aws-cdk/aws-cloudwatch";
-import { SnsAction } from "@aws-cdk/aws-cloudwatch-actions";
-import type { ISecurityGroup, IVpc } from "@aws-cdk/aws-ec2";
-import type { IRepository } from "@aws-cdk/aws-ecr";
-import {
-  Cluster,
-  Compatibility,
-  ContainerImage,
-  FargatePlatformVersion,
-  LogDrivers,
-  TaskDefinition,
-} from "@aws-cdk/aws-ecs";
 import type { Schedule } from "@aws-cdk/aws-events";
 import { Rule } from "@aws-cdk/aws-events";
 import { SfnStateMachine } from "@aws-cdk/aws-events-targets";
-import type { PolicyStatement } from "@aws-cdk/aws-iam";
-import { Topic } from "@aws-cdk/aws-sns";
-import { IntegrationPattern, StateMachine } from "@aws-cdk/aws-stepfunctions";
-import { EcsFargateLaunchTarget, EcsRunTask } from "@aws-cdk/aws-stepfunctions-tasks";
-import { CfnOutput, Duration } from "@aws-cdk/core";
-import type { NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
-import type { Identity } from "../constructs/core/identity";
 import { AppIdentity } from "../constructs/core/identity";
-import { GuGetDistributablePolicyStatement } from "../constructs/iam";
-
-/**
- * Configuration to determine what container to use for the task
- * For example, to run the task in the latest node container:
- *
- * ```typescript
- * const containerConfiguration = {
- *     id: 'node:latest'
- * }
- * ```
- *
- * Alternatively you can specify a repository and version, for example for an ECR repository:
- * ```typescript
- * import { Repository } from "@aws-cdk/aws-ecr";
- * const repository = new Repository(scope, `${app}-repository`, {
-    repositoryName: app,
-  });
- * const containerConfiguration = {
- *     repository: Repository.fromRepositoryArn("<repository arn>"),
- *     version: '1'
- * }
- * ```
- */
-
-export type RepositoryContainer = {
-  repository: IRepository;
-  version: string;
-  type: "repository";
-};
-
-export type RegistryContainer = {
-  id?: string;
-  type: "registry";
-};
-
-export type ContainerConfiguration = RepositoryContainer | RegistryContainer;
-
-export type GuEcsTaskMonitoringProps = { snsTopicArn: string; noMonitoring: false };
+import type { GuEcsTaskProps } from "../constructs/ecs/ecs-task";
+import { GuEcsTask } from "../constructs/ecs/ecs-task";
 
 /**
  * Configuration options for the [[`GuScheduledEcsTask`]] pattern.
  *
  * The `schedule` property determines when your task is invoked. For example, to invoke
- * the lambda every 5 minutes, use:
+ * the task every 5 minutes, use:
  * ```typescript
  * import { Schedule } from "@aws-cdk/aws-events";
  * import { Duration } from "@aws-cdk/core";
@@ -86,54 +30,12 @@ export type GuEcsTaskMonitoringProps = { snsTopicArn: string; noMonitoring: fals
  *   schedule: Schedule.expression("cron(0 8 ? * MON-FRI *)"),
  * }
  * ```
- *
- * See [[`ContainerConfiguration`]] for details of how to configure the container used to run the task.
- *
- * `taskTimeoutInMinutes` does what is says on the tin. The default timeout is 15 minutes.
- *
- * The `taskCommand` prop allows you to specify a command to run when the task starts (this can also be done via a CMD statement in
- * your Dockerfile). For example:
- *
- * const props = {
- *    //other props
- *    taskCommand: `aws s3 cp s3://${distbucket}/${stack}/${stage}/${app}/task.sh . && ./task.sh
-    }
- *
- * It is advisable to configure alarms for when the job fails/times out. To do this specify the alarmSnsTopicArn prop.
- *
- * `customTaskPolicies` allows your task to interact with other AWS services. By default a task
- * will have read access to the distribution bucket for your account.
- *
- * You can specify security groups to apply to task using the `securityGroups` prop.
- *
- * You can also set the memory and cpu units for your task. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
- * for further details.
+ * See [[`GuEcsTask`]] for details of other props
  *
  */
-export interface GuScheduledEcsTaskProps extends Identity {
-  vpc: IVpc;
+export interface GuScheduledEcsTaskProps extends GuEcsTaskProps {
   schedule: Schedule;
-  containerConfiguration: ContainerConfiguration;
-  taskTimeoutInMinutes?: number;
-  cpu?: number;
-  memory?: number;
-  taskCommand?: string;
-  monitoringConfiguration: NoMonitoring | GuEcsTaskMonitoringProps;
-  securityGroups?: ISecurityGroup[];
-  customTaskPolicies?: PolicyStatement[];
 }
-
-/**
- * Containers can be specified either via a repository and version or by container id (in which case it will
- * be fetched from docker hub).
- */
-const getContainer = (config: ContainerConfiguration) => {
-  if (config.type == "repository") {
-    return ContainerImage.fromEcrRepository(config.repository, config.version);
-  } else {
-    return ContainerImage.fromRegistry(config.id ?? "ubuntu:focal");
-  }
-};
 
 /**
  * Pattern which creates all of the resources needed to invoke a fargate task on a schedule.
@@ -145,116 +47,15 @@ const getContainer = (config: ContainerConfiguration) => {
  * Note that if your task reliably completes in less than 15 minutes then you should probably use a [[`GuScheduledLambda`]] instead. This
  * pattern was mainly created to work around the 15 minute lambda timeout.
  */
-export class GuScheduledEcsTask {
+export class GuScheduledEcsTask extends GuEcsTask {
   constructor(scope: GuStack, props: GuScheduledEcsTaskProps) {
-    const timeout = props.taskTimeoutInMinutes ?? 15;
-
-    // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu for details
-    const defaultCpu = 2048; // 2 cores and from 4-16GB memory
-    const defaultMemory = 4096; // 4GB
-
-    const cpu = props.cpu ?? defaultCpu;
-    const memory = props.memory ?? defaultMemory;
-
-    const cluster = new Cluster(scope, AppIdentity.suffixText(props, "Cluster"), {
-      clusterName: `${props.app}-cluster-${props.stage}`,
-      enableFargateCapacityProviders: true,
-      vpc: props.vpc,
-    });
-
-    const taskDefinition = new TaskDefinition(scope, AppIdentity.suffixText(props, "TaskDefinition"), {
-      compatibility: Compatibility.FARGATE,
-      cpu: cpu.toString(),
-      memoryMiB: memory.toString(),
-      family: `${props.stack}-${props.stage}-${props.app}`,
-    });
-
-    taskDefinition.addContainer(AppIdentity.suffixText(props, "ScheduledTaskContainer"), {
-      image: getContainer(props.containerConfiguration),
-      entryPoint: props.taskCommand ? ["/bin/sh"] : undefined,
-      command: props.taskCommand ? ["-c", `${props.taskCommand}`] : undefined, // if unset, falls back to CMD in docker file, or no command will be run
-      cpu,
-      memoryLimitMiB: props.memory,
-      logging: LogDrivers.awsLogs({
-        streamPrefix: props.app,
-        logRetention: 14,
-      }),
-    });
-
-    const distPolicy = new GuGetDistributablePolicyStatement(scope, { app: props.app });
-
-    taskDefinition.addToTaskRolePolicy(distPolicy);
-    (props.customTaskPolicies ?? []).forEach((p) => taskDefinition.addToTaskRolePolicy(p));
-
-    const task = new EcsRunTask(scope, `${props.app}-task`, {
-      cluster: cluster,
-      launchTarget: new EcsFargateLaunchTarget({
-        platformVersion: FargatePlatformVersion.LATEST,
-      }),
-      taskDefinition: taskDefinition,
-      integrationPattern: IntegrationPattern.RUN_JOB,
-      resultPath: "DISCARD",
-      timeout: Duration.minutes(timeout),
-      securityGroups: props.securityGroups ?? [],
-    });
-
-    const stateMachine = new StateMachine(scope, AppIdentity.suffixText(props, "StateMachine"), {
-      definition: task,
-      stateMachineName: `${props.app}-${props.stage}`,
-    });
+    super(scope, props);
 
     const rule = new Rule(scope, AppIdentity.suffixText(props, "ScheduleRule"), {
       schedule: props.schedule,
-      targets: [new SfnStateMachine(stateMachine)],
+      targets: [new SfnStateMachine(this.stateMachine)],
+      enabled: true,
     });
-
-    if (!props.monitoringConfiguration.noMonitoring) {
-      const alarmTopic = Topic.fromTopicArn(
-        scope,
-        AppIdentity.suffixText(props, "AlarmTopic"),
-        props.monitoringConfiguration.snsTopicArn
-      );
-      const alarms = [
-        {
-          name: `${props.app}-execution-failed`,
-          description: `${props.app}-${props.stage} job failed `,
-          metric: stateMachine.metricFailed({
-            period: Duration.hours(1),
-            statistic: "sum",
-          }),
-        },
-        {
-          name: `${props.app}-timeout`,
-          description: `${props.app}-${props.stage} job timed out `,
-          metric: stateMachine.metricTimedOut({
-            period: Duration.hours(1),
-            statistic: "sum",
-          }),
-        },
-      ];
-
-      alarms.forEach((a) => {
-        const alarm = new Alarm(scope, a.name, {
-          alarmDescription: a.description,
-          actionsEnabled: true,
-          metric: a.metric,
-          // default for comparisonOperator is GreaterThanOrEqualToThreshold
-          threshold: 1,
-          evaluationPeriods: 1,
-          treatMissingData: TreatMissingData.NOT_BREACHING,
-        });
-        alarm.addAlarmAction(new SnsAction(alarmTopic));
-        AppIdentity.taggedConstruct({ app: props.app }, alarm);
-      });
-    }
-
-    // Tag all constructs with correct app tag
-    [cluster, task, taskDefinition, stateMachine, rule].forEach((c) =>
-      AppIdentity.taggedConstruct({ app: props.app }, c)
-    );
-
-    new CfnOutput(scope, AppIdentity.suffixText(props, "StateMachineArnOutput"), {
-      value: stateMachine.stateMachineArn,
-    });
+    AppIdentity.taggedConstruct({ app: props.app }, rule);
   }
 }


### PR DESCRIPTION
## What does this change?
This pulls out the guts of GuScheduledEcsTask pattern and moves them into a new GuEcsTask construct. This is to support the creation of fargate tasks which do not run on a schedule. 

The investigations team needs this to support our our migrations task - which we run every time we need to make a change to the database. This is currently a lambda but can take longer than 15 minutes. We could run it on our bastion/locally, but this would mean adding psql and node to the bastion which we'd rather avoid for the usual security reasons. The downside of running them locally (as is done for discussion and flexible-content) is that someone could switch their laptop off/lose network connection part way through.

Note the change set isn't as big as it seems - this is mostly a copy paste job of scheduled-ecs-task to ecs-task, with some stuff then pulled back into scheduled-ecs-task

## How to test
I've tested this against https://github.com/guardian/lurch which is the only project using this pattern  as far as I know

## Checklist

- [ x I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
