### PR TITLE
feat: Support environment overrides in EcsTask

### DIFF
--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -142,7 +142,7 @@ Object {
                   "Arn",
                 ],
               },
-              "\\",\\"TaskDefinition\\":\\"test-TEST-ecs-test\\",\\"NetworkConfiguration\\":{\\"AwsvpcConfiguration\\":{\\"Subnets\\":[\\"abc-123\\"],\\"SecurityGroups\\":[\\"id-123\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"TaskContainerEcstest\\"}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"LATEST\\"}}}}",
+              "\\",\\"TaskDefinition\\":\\"test-TEST-ecs-test\\",\\"NetworkConfiguration\\":{\\"AwsvpcConfiguration\\":{\\"Subnets\\":[\\"abc-123\\"],\\"SecurityGroups\\":[\\"id-123\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"test-ecs-task-ecs-test-TaskContainer\\"}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"LATEST\\"}}}}",
             ],
           ],
         },

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -142,7 +142,7 @@ Object {
                   "Arn",
                 ],
               },
-              "\\",\\"TaskDefinition\\":\\"test-TEST-ecs-test\\",\\"NetworkConfiguration\\":{\\"AwsvpcConfiguration\\":{\\"Subnets\\":[\\"abc-123\\"],\\"SecurityGroups\\":[\\"id-123\\"]}},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"LATEST\\"}}}}",
+              "\\",\\"TaskDefinition\\":\\"test-TEST-ecs-test\\",\\"NetworkConfiguration\\":{\\"AwsvpcConfiguration\\":{\\"Subnets\\":[\\"abc-123\\"],\\"SecurityGroups\\":[\\"id-123\\"]}},\\"Overrides\\":{\\"ContainerOverrides\\":[{\\"Name\\":\\"TaskContainerEcstest\\"}]},\\"LaunchType\\":\\"FARGATE\\",\\"PlatformVersion\\":\\"LATEST\\"}}}}",
             ],
           ],
         },

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -85,6 +85,20 @@ export type GuEcsTaskMonitoringProps = { snsTopicArn: string; noMonitoring: fals
  * You can also set the memory and cpu units for your task. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
  * for further details.
  *
+ * If you want to pass input from the step function into your EcsTask you can do so via the `environmentOverrides` prop, which allows you to wire up
+ * step function input JSON to environment variables set on the container. For example,
+ * const props = {
+ *  ...otherProps
+ *   environmentOverrides: [
+      {
+        name: "VERSION",
+        value: JsonPath.stringAt("$.version"),
+      },
+    }
+ * With the above override, your task will attempt to find a `version` property in the JSON input passed to the step function, and apply it to the
+ * VERSION environment variable. Alternatively, you could hard code a value for the variable in CDK.
+ * See https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html for further detail and  other override options - this construct currently
+ * only supports environment variables.
  */
 export interface GuEcsTaskProps extends Identity {
   vpc: IVpc;


### PR DESCRIPTION
## What does this change?
This adds an `environmentOverrides` prop to `EcsTask` which can be used to set an environment variable in the container running the task. This is useful for adding config properties, but can also be used to override environment variables at the point the function is run.

This was a bit of a faff to work out the syntax, I found these pages useful:
 - https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html
 - https://stackoverflow.com/questions/60573180/how-do-i-pass-json-to-an-ecs-task-in-an-aws-stepfunction
 - https://docs.aws.amazon.com/cdk/api/latest/docs/aws-stepfunctions-tasks-readme.html

Depends on https://github.com/guardian/cdk/pull/921

## How to test
I've tested this using Lurch's CODE stack and was able to pass an environment variable to the task.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
