### PR TITLE
feat: introduce constructs/core/parameters/base/GuNumberParameter

### DIFF
--- a/src/constructs/core/parameters/base.test.ts
+++ b/src/constructs/core/parameters/base.test.ts
@@ -2,7 +2,7 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert/lib/synth-utils";
 import { simpleGuStackForTesting } from "../../../utils/test";
 import type { SynthedStack } from "../../../utils/test";
-import { GuArnParameter, GuParameter, GuStringParameter } from "./base";
+import { GuArnParameter, GuNumberParameter, GuParameter, GuStringParameter } from "./base";
 
 describe("The GuParameter class", () => {
   it("sets the type as passed through by default", () => {
@@ -99,6 +99,21 @@ describe("The GuStringParameter class", () => {
 
     expect(json.Parameters.Parameter).toEqual({
       Type: "String",
+      Description: "This is a test",
+    });
+  });
+});
+
+describe("The GuNumberParameter class", () => {
+  it("should set the type to number", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuNumberParameter(stack, "Parameter", { description: "This is a test" });
+
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(json.Parameters.Parameter).toEqual({
+      Type: "Number",
       Description: "This is a test",
     });
   });

--- a/src/constructs/core/parameters/base.ts
+++ b/src/constructs/core/parameters/base.ts
@@ -32,6 +32,12 @@ export class GuStringParameter extends GuParameter {
   }
 }
 
+export class GuNumberParameter extends GuParameter {
+  constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
+    super(scope, id, { ...props, type: "Number" });
+  }
+}
+
 export class GuArnParameter extends GuStringParameter {
   constructor(scope: GuStack, id: string, props: GuNoTypeParameterProps) {
     super(scope, id, {


### PR DESCRIPTION
## What does this change?
Introduce constructs/core/parameters/base/GuNumberParameter. We already have GuStringParameter but I am migrating a code base that has

```
const dbPort = new CoreCfnParameter(this, "DBPort", {
  type: "Number",
  description: "The port that the RDS DB will be available on.",
  default: 5432,
});
```
With this change I will be able to write 

```
const dbPort = new GuNumberParameter(this, "DBPort", {
  description: "The port that the RDS DB will be available on.",
  default: 5432,
});
```

Instead of using GuParameter.
