### PR TITLE
feat: Add `GuStackForInfrastructure` where `Stage` is always `INFRA`

### DIFF
--- a/src/constants/stage.ts
+++ b/src/constants/stage.ts
@@ -1,9 +1,10 @@
-enum Stage {
+export enum Stage {
   CODE = "CODE",
   PROD = "PROD",
 }
 
 // for use in the `allowed values` property of a cloudformation parameter
-const Stages: string[] = Object.values(Stage);
+export const Stages: string[] = Object.values(Stage);
 
-export { Stage, Stages };
+export const StageForInfrastructure = "INFRA";
+export type StageForInfrastructure = "INFRA";

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -3,7 +3,7 @@ import type { AlarmProps } from "@aws-cdk/aws-cloudwatch";
 import { SnsAction } from "@aws-cdk/aws-cloudwatch-actions";
 import { Topic } from "@aws-cdk/aws-sns";
 import type { ITopic } from "@aws-cdk/aws-sns";
-import { Stage } from "../../constants";
+import { Stage, StageForInfrastructure } from "../../constants";
 import type { GuStack } from "../core";
 import type { AppIdentity } from "../core/identity";
 
@@ -28,10 +28,13 @@ export class GuAlarm extends Alarm {
       actionsEnabled: scope.withStageDependentValue({
         app: props.app,
         variableName: "alarmActionsEnabled",
-        stageValues: {
-          [Stage.CODE]: props.actionsEnabledInCode ?? false,
-          [Stage.PROD]: true,
-        },
+        stageValues:
+          scope.stage === StageForInfrastructure
+            ? { [StageForInfrastructure]: true }
+            : {
+                [Stage.CODE]: props.actionsEnabledInCode ?? false,
+                [Stage.PROD]: true,
+              },
       }),
     });
     const topicArn: string = `arn:aws:sns:${scope.region}:${scope.account}:${props.snsTopicName}`;

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -1,5 +1,5 @@
 import { CfnMapping } from "@aws-cdk/core";
-import type { Stage, StageForInfrastructure } from "../../constants";
+import type { StageAwareValue } from "../../types/stage";
 import type { AppIdentity } from "./identity";
 import type { GuStack } from "./stack";
 
@@ -7,7 +7,7 @@ export type GuMappingValue = string | number | boolean;
 
 export interface GuStageMappingValue<T extends GuMappingValue> extends AppIdentity {
   variableName: string;
-  stageValues: Record<Stage, T> | Record<StageForInfrastructure, T>;
+  stageValues: StageAwareValue<T>;
 }
 
 export class GuStageMapping {

--- a/src/constructs/core/mappings.ts
+++ b/src/constructs/core/mappings.ts
@@ -1,5 +1,5 @@
 import { CfnMapping } from "@aws-cdk/core";
-import type { Stage } from "../../constants";
+import type { Stage, StageForInfrastructure } from "../../constants";
 import type { AppIdentity } from "./identity";
 import type { GuStack } from "./stack";
 
@@ -7,7 +7,7 @@ export type GuMappingValue = string | number | boolean;
 
 export interface GuStageMappingValue<T extends GuMappingValue> extends AppIdentity {
   variableName: string;
-  stageValues: Record<Stage, T>;
+  stageValues: Record<Stage, T> | Record<StageForInfrastructure, T>;
 }
 
 export class GuStageMapping {

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -3,16 +3,22 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import "../../utils/test/jest";
 import { Role, ServicePrincipal } from "@aws-cdk/aws-iam";
-import { App } from "@aws-cdk/core";
-import { Stage, Stages } from "../../constants";
+import { Annotations, App } from "@aws-cdk/core";
+import { Stage, StageForInfrastructure, Stages } from "../../constants";
 import { ContextKeys } from "../../constants/context-keys";
 import { TagKeys } from "../../constants/tag-keys";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { SynthedStack } from "../../utils/test";
 import { GuParameter } from "./parameters";
-import { GuStack } from "./stack";
+import { GuStack, GuStackForInfrastructure } from "./stack";
 
 describe("The GuStack construct", () => {
+  const warn = jest.spyOn(Annotations.prototype, "addWarning");
+
+  afterEach(() => {
+    warn.mockReset();
+  });
+
   it("requires passing the stack value as props", function () {
     const stack = simpleGuStackForTesting({ stack: "some-stack" });
     expect(stack.stack).toEqual("some-stack");
@@ -77,5 +83,42 @@ describe("The GuStack construct", () => {
     expect(() => stack.getParam<GuParameter>("i-do-not-exist")).toThrowError(
       "Attempting to read parameter i-do-not-exist which does not exist"
     );
+  });
+
+  it("should warn when calling withStageDependentValue with the INFRA stage", () => {
+    const stack = new GuStack(new App(), "Test", { stack: "test" });
+
+    stack.withStageDependentValue({
+      app: "test",
+      variableName: "test",
+      stageValues: {
+        [StageForInfrastructure]: 1,
+      },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "GuStack does not have a stage of INFRA. Setting a mapping value for it has no impact."
+    );
+  });
+});
+
+describe("The GuStackForInfrastructure construct", () => {
+  it("should have a stage of INFRA", () => {
+    const stack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    expect(stack.stage).toBe("INFRA");
+  });
+
+  it("should throw when calling withStageDependentValue with a non-INFRA stage", () => {
+    const stack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+
+    expect(() => {
+      stack.withStageDependentValue({
+        app: "test",
+        variableName: "test",
+        stageValues: {
+          [Stage.CODE]: 1,
+          [Stage.PROD]: 2,
+        },
+      });
+    }).toThrowError("Mapping doesn't contain top-level key 'INFRA'");
   });
 });

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -54,7 +54,6 @@ export interface GuStackProps extends Omit<StackProps, "stackName">, Partial<GuM
  */
 export class GuStack extends Stack implements StackStageIdentity, GuMigratingStack {
   private readonly _stack: string;
-  private readonly _stage: string;
 
   private _mappings?: GuStageMapping;
   private params: Map<string, GuParameter>;
@@ -62,7 +61,7 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
   public readonly migratedFromCloudFormation: boolean;
 
   get stage(): string {
-    return this._stage;
+    return GuStageParameter.getInstance(this).valueAsString;
   }
 
   get stack(): string {
@@ -127,7 +126,6 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
     this.params = new Map<string, GuParameter>();
 
     this._stack = props.stack;
-    this._stage = GuStageParameter.getInstance(this).valueAsString;
 
     this.addTag(TrackingTag.Key, TrackingTag.Value);
 

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,7 +1,8 @@
 import type { Duration } from "@aws-cdk/core";
 import { CfnResource } from "@aws-cdk/core";
-import { Stage } from "../../constants";
+import { Stage, StageForInfrastructure } from "../../constants";
 import type { GuDomainNameProps } from "../../types/domain-names";
+import { StageAwareValue } from "../../types/stage";
 import type { GuStack } from "../core";
 import type { AppIdentity } from "../core/identity";
 
@@ -72,10 +73,14 @@ export class GuCname extends GuDnsRecordSet {
     const domainName = scope.withStageDependentValue({
       app: props.app,
       variableName: "domainName",
-      stageValues: {
-        [Stage.CODE]: props.domainNameProps.CODE.domainName,
-        [Stage.PROD]: props.domainNameProps.PROD.domainName,
-      },
+      stageValues: StageAwareValue.isStageValue(props.domainNameProps)
+        ? {
+            [Stage.CODE]: props.domainNameProps.CODE.domainName,
+            [Stage.PROD]: props.domainNameProps.PROD.domainName,
+          }
+        : {
+            [StageForInfrastructure]: props.domainNameProps.INFRA.domainName,
+          },
     });
     super(scope, id, {
       name: domainName,

--- a/src/constructs/vpc/__snapshots__/vpc.test.ts.snap
+++ b/src/constructs/vpc/__snapshots__/vpc.test.ts.snap
@@ -2,17 +2,6 @@
 
 exports[`The GuVpc construct should match snapshot 1`] = `
 Object {
-  "Parameters": Object {
-    "Stage": Object {
-      "AllowedValues": Array [
-        "CODE",
-        "PROD",
-      ],
-      "Default": "CODE",
-      "Description": "Stage name",
-      "Type": "String",
-    },
-  },
   "Resources": Object {
     "MyVpcF9F0CA6F": Object {
       "Properties": Object {
@@ -39,9 +28,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -68,9 +55,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -131,9 +116,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -181,9 +164,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -225,9 +206,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -286,9 +265,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -369,9 +346,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -407,9 +382,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -447,9 +420,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -497,9 +468,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -545,9 +514,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -583,9 +550,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -612,9 +577,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -673,9 +636,7 @@ Object {
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -724,9 +685,7 @@ Object {
         "Name": "/account/vpc/primary/subnets/private",
         "Tags": Object {
           "Stack": "test-stack",
-          "Stage": Object {
-            "Ref": "Stage",
-          },
+          "Stage": "INFRA",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/cdk",
         },
@@ -753,9 +712,7 @@ Object {
         "Name": "/account/vpc/primary/subnets/public",
         "Tags": Object {
           "Stack": "test-stack",
-          "Stage": Object {
-            "Ref": "Stage",
-          },
+          "Stage": "INFRA",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/cdk",
         },
@@ -782,9 +739,7 @@ Object {
         "Name": "/account/vpc/primary/id",
         "Tags": Object {
           "Stack": "test-stack",
-          "Stage": Object {
-            "Ref": "Stage",
-          },
+          "Stage": "INFRA",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/cdk",
         },

--- a/src/constructs/vpc/vpc.test.ts
+++ b/src/constructs/vpc/vpc.test.ts
@@ -1,18 +1,25 @@
 import "@aws-cdk/assert/jest";
 import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { App } from "@aws-cdk/core";
+import { GuStackForInfrastructure } from "../core";
 import { GuVpc } from "./vpc";
 
 describe("The GuVpc construct", () => {
+  const simpleInfraStack = () => {
+    return new GuStackForInfrastructure(new App(), "Test", {
+      stack: "test-stack",
+    });
+  };
+
   it("should match snapshot", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleInfraStack();
     new GuVpc(stack, "MyVpc");
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 
   it("should create VPC SSM parameters by default", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleInfraStack();
     new GuVpc(stack, "MyVpc", { ssmParameters: true });
     expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
       Name: "/account/vpc/primary/id",
@@ -28,7 +35,7 @@ describe("The GuVpc construct", () => {
   });
 
   it("should not create VPC SSM parameters if set to false", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleInfraStack();
     new GuVpc(stack, "MyVpc", { ssmParameters: false });
 
     expect(stack).toCountResources("AWS::SSM::Parameter", 0);

--- a/src/constructs/vpc/vpc.ts
+++ b/src/constructs/vpc/vpc.ts
@@ -3,7 +3,7 @@ import { GatewayVpcEndpointAwsService, SubnetType, Vpc } from "@aws-cdk/aws-ec2"
 import { StringListParameter, StringParameter } from "@aws-cdk/aws-ssm";
 import { VPC_SSM_PARAMETER_PREFIX } from "../../constants/ssm-parameter-paths";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
-import type { GuStack } from "../core";
+import type { GuStackForInfrastructure } from "../core";
 import type { GuMigratingResource } from "../core/migrating";
 
 export interface GuVpcCustomProps {
@@ -60,7 +60,7 @@ export interface GuVpcProps extends GuVpcCustomProps, VpcProps, GuMigratingResou
  * https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html.
  */
 export class GuVpc extends GuStatefulMigratableConstruct(Vpc) {
-  constructor(scope: GuStack, id: string, props?: GuVpcProps) {
+  constructor(scope: GuStackForInfrastructure, id: string, props?: GuVpcProps) {
     const defaultVpcProps: VpcProps = {
       gatewayEndpoints: {
         s3: {

--- a/src/types/domain-names.ts
+++ b/src/types/domain-names.ts
@@ -1,8 +1,8 @@
-import type { Stage } from "../constants";
-
-export type GuDomainNameProps = Record<Stage, GuDomainName>;
+import type { StageAwareValue } from "./stage";
 
 export interface GuDomainName {
   domainName: string;
   hostedZoneId?: string;
 }
+
+export type GuDomainNameProps = StageAwareValue<GuDomainName>;

--- a/src/types/stage.ts
+++ b/src/types/stage.ts
@@ -1,0 +1,16 @@
+import type { Stage, StageForInfrastructure } from "../constants";
+
+export type StageValue<T> = Record<Stage, T>;
+export type StageForInfrastructureValue<T> = Record<StageForInfrastructure, T>;
+
+export type StageAwareValue<T> = StageValue<T> | StageForInfrastructureValue<T>;
+
+export const StageAwareValue = {
+  isStageValue<T>(value: StageAwareValue<T>): value is StageValue<T> {
+    return (value as StageValue<T>).PROD !== undefined;
+  },
+
+  isStageForInfrastructureValue<T>(value: StageAwareValue<T>): value is StageForInfrastructureValue<T> {
+    return (value as StageForInfrastructureValue<T>).INFRA !== undefined;
+  },
+};

--- a/tools/eslint/rules/valid-constructors.test.ts
+++ b/tools/eslint/rules/valid-constructors.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars -- testing file */
 
-import type { GuStack } from "../../../src/constructs/core";
+import type { GuStack, GuStackForInfrastructure } from "../../../src/constructs/core";
 
 interface MyProps {
   name: string;
@@ -48,5 +48,11 @@ class YetAnotherThreeParamConstructor {
 class PrivateConstructor {
   private constructor(number: number) {
     console.log(number);
+  }
+}
+
+class InfraConstructor {
+  constructor(scope: GuStackForInfrastructure) {
+    console.log(scope);
   }
 }


### PR DESCRIPTION
Possibly easiest to review commit by commit.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Creates `GuStackForInfrastructure`, a sub-class of `GuStack` designed for infrastructure based stacks.

An infrastructure based stack is a singleton - there should only be one in an AWS account (well, per region, per account).

Examples of infrastructure stacks include:
  - [VPC stacks](https://github.com/guardian/cdk/blob/57d427b09a3c3d5fcf9b406f1ad2ecaf927e6152/src/constructs/vpc/vpc.ts)
  - [cloudwatch-logs-management](https://github.com/guardian/cloudwatch-logs-management)
  - [elasticsearch-node-rotation](https://github.com/guardian/elasticsearch-node-rotation)
  - (coming soon) cost anomaly detection

A `GuStack` can have a `Stage` value of either `CODE` or `PROD`. It is not designed for infrastructure/singleton stacks. This means, for example, we currently have to remember there is (and should only be) a `PROD` VPC stack and creating a `CODE` one could cause disruption.

We could use restrictions in Riff-Raff to help us remember this, but we can do better via types! Introducing `GuStackForInfrastructure` ✨ .

A `GuStackForInfrastructure` only has one stage - `INFRA`. It is a sub-class of `GuStack`, thus inherits all the benefits of `GuStack`, such as rich tagging.

For infrastructure/singleton stacks we can use the new `GuStackForInfrastructure` instead of `GuStack` to provide more meaning, clearer tagging and less implicit knowledge.

In this change `GuVpc` has been updated to use `GuStackForInfrastructure`.

Our custom linting rule has been updated too (with tests added).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added tests, in particular the update to the `GuVpc` snapshot.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Singleton stacks are better represented.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Is the API clear enough? As noted in the comments and tests, if one uses the wrong type when calling `withStageDependentValue` on an instance of `GuStackForInfrastructure` an exception will be raised. Is this clear enough?

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
