### PR TITLE
feat: allow users to opt-out of tagging via GuStack

### DIFF
--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -49,6 +49,16 @@ describe("The GuStack construct", () => {
     expect(stack).toHaveGuTaggedResource("AWS::IAM::Role");
   });
 
+  it("should not apply any tags when withoutTags is set to true", () => {
+    const stack = new GuStack(new App(), "Test", { stack: "test", withoutTags: true });
+
+    new Role(stack, "MyRole", {
+      assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+    });
+
+    expect(stack).not.toHaveGuTaggedResource("AWS::IAM::Role");
+  });
+
   it("should prefer context values for repository information", () => {
     const stack = new GuStack(new App({ context: { [ContextKeys.REPOSITORY_URL]: "my-repository" } }), "Test", {
       stack: "test",

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -24,6 +24,7 @@ export interface GuStackProps extends Omit<StackProps, "stackName">, Partial<GuM
    * The AWS CloudFormation stack name (as shown in the AWS CloudFormation UI).
    */
   cloudFormationStackName?: string;
+  withoutTags?: boolean;
 }
 
 /**
@@ -135,12 +136,14 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
 
     this._stack = props.stack;
 
-    this.addTag(TrackingTag.Key, TrackingTag.Value);
+    if (!props.withoutTags) {
+      this.addTag(TrackingTag.Key, TrackingTag.Value);
 
-    this.addTag("Stack", this.stack);
-    this.addTag("Stage", this.stage);
+      this.addTag("Stack", this.stack);
+      this.addTag("Stage", this.stage);
 
-    this.tryAddRepositoryTag();
+      this.tryAddRepositoryTag();
+    }
   }
 
   /**

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -24,6 +24,10 @@ export interface GuStackProps extends Omit<StackProps, "stackName">, Partial<GuM
    * The AWS CloudFormation stack name (as shown in the AWS CloudFormation UI).
    */
   cloudFormationStackName?: string;
+  /**
+   * Set this to true to stop the GuStack from tagging all of your AWS resources.
+   * This should only be turned on as part of an initial migration from CloudFormation.
+   */
   withoutTags?: boolean;
 }
 


### PR DESCRIPTION
## What does this change?

This PR allows users to opt-out of stack tagging.

As part of the initial migration to `@guardian/cdk` users import their CloudFormation template. This is essentially a no-op, but the change set is huge because we are adding tags to everything. 

This PR allows users to opt-out of tagging, to make the initial change smaller and easier to understand.

Co-authored by @akash1810 and @michaelwmcnamara.

## How to test

We've added a unit test for this.

## How can we measure success?

Users should feel more confident when migrating to `@guardian/cdk`

## Have we considered potential risks?

The main risk here is that people forget to turn tagging on after the initial migration, however Riff-Raff would catch this pretty quickly anyway.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
