### PR TITLE
refactor: Create skeleton for 'new' command in preparation for copying this command from cdk-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,9 @@ Commands:
                                GuCDK ready
   @guardian/cdk check-package-json  Check a package.json file for compatibility with
                                GuCDK
+  @guardian/cdk new                 Creates a new CDK stack
 
 Options:
-      --profile  AWS profile                                            [string]
-      --region   AWS region                      [string] [default: "eu-west-1"]
       --version  Show version number                                   [boolean]
   -h, --help     Show help                                             [boolean]
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -39,7 +39,7 @@ const parseCommandLineArguments = () => {
       )
       .command(Commands.New, "Creates a new CDK stack", (yargs) =>
         yargs
-          .option("multiApp", {
+          .option("multi-app", {
             type: "boolean",
             description:
               "Create the stack files within sub directories as the project defines multiple apps (defaults to false)",
@@ -61,7 +61,7 @@ const parseCommandLineArguments = () => {
               "The Guardian stack being used (as defined in your riff-raff.yaml). This will be applied as a tag to all of your resources.",
             demandOption: true,
           })
-          .option("yamlTemplateLocation", {
+          .option("yaml-template-location", {
             type: "string",
             description: "Path to the YAML CloudFormation template",
           })
@@ -87,7 +87,7 @@ parseCommandLineArguments()
         return checkPackageJson(directory);
       }
       case Commands.New: {
-        const { init, multiApp, app, stack, yamlTemplateLocation } = argv;
+        const { init, "multi-app": multiApp, app, stack, "yaml-template-location": yamlTemplateLocation } = argv;
         return Promise.resolve(
           `Test: New command has been received. \ninit = ${init.toString()},\n multi-app  = ${multiApp.toString()},\n app = ${app},\n stack = ${stack},\n ymalTemplateLocation = ${yamlTemplateLocation}`
         );

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -87,11 +87,7 @@ parseCommandLineArguments()
         return checkPackageJson(directory);
       }
       case Commands.New: {
-        const { init } = argv;
-        const { multiApp } = argv;
-        const { app } = argv;
-        const { stack } = argv;
-        const { yamlTemplateLocation } = argv;
+        const { init, multiApp, app, stack, yamlTemplateLocation } = argv;
         return Promise.resolve(
           `Test: New command has been received. \ninit = ${init.toString()},\n multi-app  = ${multiApp.toString()},\n app = ${app},\n stack = ${stack},\n ymalTemplateLocation = ${yamlTemplateLocation}`
         );

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -66,7 +66,6 @@ const parseCommandLineArguments = () => {
           .option("yaml-template-location", {
             type: "string",
             description: "Path to the YAML CloudFormation template",
-            default: "",
           })
       )
       .version(`${LibraryInfo.VERSION} (using @aws-cdk ${LibraryInfo.AWS_CDK_VERSION})`)
@@ -91,9 +90,9 @@ parseCommandLineArguments()
         return checkPackageJson(directory);
       }
       case Commands.New: {
-        const { init, "multi-app": multiApp, app, stack, "yaml-template-location": yamlTemplateLocation } = argv;
+        const { init, "multi-app": multiApp, app, stack } = argv;
         return Promise.resolve(
-          `Test: New command has been received. \ninit = ${init.toString()},\n multi-app  = ${multiApp.toString()},\n app = ${app},\n stack = ${stack},\n ymalTemplateLocation = ${yamlTemplateLocation}`
+          `Test: New command has been received. \ninit = ${init.toString()},\n multi-app  = ${multiApp.toString()},\n app = ${app},\n stack = ${stack}`
         );
       }
       default:

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -25,10 +25,12 @@ const parseCommandLineArguments = () => {
   return Promise.resolve(
     yargs
       .usage("$0 COMMAND [args]")
-      .option("profile", { type: "string", description: "AWS profile" })
-      .option("region", { type: "string", description: "AWS region", default: "eu-west-1" })
       .command(Commands.AwsCdkVersion, "Print the version of @aws-cdk libraries being used")
-      .command(Commands.AccountReadiness, "Perform checks on an AWS account to see if it is GuCDK ready")
+      .command(Commands.AccountReadiness, "Perform checks on an AWS account to see if it is GuCDK ready", (yargs) =>
+        yargs
+          .option("profile", { type: "string", description: "AWS profile" })
+          .option("region", { type: "string", description: "AWS region", default: "eu-west-1" })
+      )
       .command(Commands.CheckPackageJson, "Check a package.json file for compatibility with GuCDK", (yargs) =>
         yargs.option("directory", {
           type: "string",
@@ -76,12 +78,13 @@ const parseCommandLineArguments = () => {
 parseCommandLineArguments()
   .then((argv): CliCommandResponse => {
     const command = argv._[0];
-    const { profile, region } = argv;
     switch (command) {
       case Commands.AwsCdkVersion:
         return awsCdkVersionCommand();
-      case Commands.AccountReadiness:
+      case Commands.AccountReadiness: {
+        const { profile, region } = argv;
         return accountReadinessCommand({ credentialProvider: awsCredentialProviderChain(profile), region });
+      }
       case Commands.CheckPackageJson: {
         const { directory } = argv;
         return checkPackageJson(directory);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -12,6 +12,7 @@ const Commands = {
   AwsCdkVersion: "aws-cdk-version",
   AccountReadiness: "account-readiness",
   CheckPackageJson: "check-package-json",
+  New: "new",
 };
 
 const parseCommandLineArguments = () => {
@@ -36,6 +37,35 @@ const parseCommandLineArguments = () => {
           defaultDescription: "The current working directory",
         })
       )
+      .command(Commands.New, "Creates a new CDK stack", (yargs) =>
+        yargs
+          .option("multiApp", {
+            type: "boolean",
+            description:
+              "Create the stack files within sub directories as the project defines multiple apps (defaults to false)",
+            default: false,
+          })
+          .option("init", {
+            type: "boolean",
+            description: "Create the cdk directory before building the app and stack files (defaults to true)",
+            default: true,
+          })
+          .option("app", {
+            type: "string",
+            description: "The name of your application e.g. Amigo",
+            demandOption: true,
+          })
+          .option("stack", {
+            type: "string",
+            description:
+              "The Guardian stack being used (as defined in your riff-raff.yaml). This will be applied as a tag to all of your resources.",
+            demandOption: true,
+          })
+          .option("yamlTemplateLocation", {
+            type: "string",
+            description: "Path to the YAML CloudFormation template",
+          })
+      )
       .version(`${LibraryInfo.VERSION} (using @aws-cdk ${LibraryInfo.AWS_CDK_VERSION})`)
       .demandCommand(1, "") // just print help
       .help()
@@ -55,6 +85,16 @@ parseCommandLineArguments()
       case Commands.CheckPackageJson: {
         const { directory } = argv;
         return checkPackageJson(directory);
+      }
+      case Commands.New: {
+        const { init } = argv;
+        const { multiApp } = argv;
+        const { app } = argv;
+        const { stack } = argv;
+        const { yamlTemplateLocation } = argv;
+        return Promise.resolve(
+          `Test: New command has been received. \ninit = ${init.toString()},\n multi-app  = ${multiApp.toString()},\n app = ${app},\n stack = ${stack},\n ymalTemplateLocation = ${yamlTemplateLocation}`
+        );
       }
       default:
         throw new Error(`Unknown command: ${command}`);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -66,6 +66,7 @@ const parseCommandLineArguments = () => {
           .option("yaml-template-location", {
             type: "string",
             description: "Path to the YAML CloudFormation template",
+            default: "",
           })
       )
       .version(`${LibraryInfo.VERSION} (using @aws-cdk ${LibraryInfo.AWS_CDK_VERSION})`)


### PR DESCRIPTION
## What does this change?
This adds the ability to accept and parse a 'new' command for cdk.
It is an implementation for yargs of the 'new' command from the cdk-cli:
https://github.com/guardian/cdk-cli/blob/dd3460d17937a9de3c24bfe11f8bad0bba0f66e5/src/commands/new.ts#L41-L70

The command accepts and processes all the inputs the real 'new' command will use, but just displays some testing text to show the arguments have been received.
 
This is the first part of the "merge cdk-cli into cdk" trello card: https://trello.com/c/xSsYX4zR/992-merge-cdk-cli-into-cdk
This change also refactors the profile and region yargs from the global scope to within the 'account-readiness' code as this is the only command that makes use of these.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->-
 
- To test the 'new' command:
Run `./script/cli new --multiApp true --app "myApp" --stack "myStack" --yaml-template-location "thing"`

- To test the  'account-readiness' command:
Run `./script/cli account-readiness --profile deployTools`

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

It will be easier to port across the full functionality for the 'new' command.
All other commands are unaffected by this change

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This change has negligible risk.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [] I have updated the documentation as required for the described changes [^2] - this will be done as part of the implementation of the 'new' functionality in the next PR

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
