### PR TITLE
feat: expose patterns in typedoc

### DIFF
--- a/docs/001-general-usage.md
+++ b/docs/001-general-usage.md
@@ -1,6 +1,7 @@
 # General Usage for @guardian/cdk
 
 ## 🖥 Installation
+
 This library can be installed from [NPM](https://www.npmjs.com/package/@guardian/cdk).
 
 ```
@@ -16,13 +17,17 @@ yarn add @guardian/cdk
 We recommend using TypeScript with `@guardian/cdk` as type safety is wonderful!
 
 ## 🏟 Patterns
+
 Patterns are high level classes which compose a number of constructs to produce standard architectures.
 
 For example, you should be able to get all the resources you need to deploy a new lambda function from one `GuLambdaStack` class.
 
-Patterns should be your default entry point to this library and can be found [here](../src/patterns).
+Patterns should be your default entry point to this library and can be found
+[here](/modules/patterns) (note, link only works when browsing auto-generated
+documentation).
 
 ## 🏗 Constructs
+
 Constructs are lower level classes which will create one or more resources to produce one element of a stack.
 
 For example, the `GuDatabaseInstance` will create an RDS instance as well as a parameter group, if required.
@@ -35,6 +40,7 @@ Where you need to do something outside currently available patterns, you can use
 In this case, consider whether it's worth defining a pattern.
 
 ## Using patterns and constructs
+
 Patterns can be imported from the top level of the library:
 
 ```typescript
@@ -48,19 +54,23 @@ import { GuAutoScalingGroup } from "@guardian/cdk/lib/constructs/autoscaling";
 ```
 
 ## ☁️ AWS Library Versions
+
 Any versions of the `@aws-cdk` libraries that you have installed in your project must be the same version as those used in the `@guardian/cdk` library.
 
 ## 🪡 Synthesising
+
 The `cdk synth` command can be used to generate cloudformation from CDK definitions.
 This will, by default, generate JSON in the `cdk.out` directory.
 
 We recommend using TypeScript with `@guardian/cdk` as type safety is wonderful!
 
 This does, however require the use of `ts-node` to compile on the fly. This can be done in two ways:
-  1. Setting the `app` property in the `cdk.json` configuration file
-  1. Passing the `app` flag to `cdk`. For example `cdk synth --app="ts-node ./bin/my-app.ts"`
+
+1. Setting the `app` property in the `cdk.json` configuration file
+1. Passing the `app` flag to `cdk`. For example `cdk synth --app="ts-node ./bin/my-app.ts"`
 
 ### Synthesising as YAML
+
 For apps with a single stack, the generated YAML will also be printed in the console.
 You can pipe this to disk:
 
@@ -71,12 +81,14 @@ cdk synth --app="ts-node ./bin/my-app.ts" > cloudformation.yaml
 For app with multiple stacks, you can specify a stack to see the YAML output.
 
 ## 🧪 Testing
+
 It is recommended to set up [Jest snapshot testing](https://jestjs.io/docs/snapshot-testing) for your stack and have the test run during CI.
 
 Snapshot tests allow you to very quickly see the changes that will be made to the generated template.
 This is especially useful when upgrading the version of `@guardian/cdk`.
 
 ## 🆙 Upgrading
+
 The `@guardian/cdk` library follows Semantic Versioning.
 
 If you have snapshot testing set up and running in CI, you should feel comfortable updating to any patch or minor release.
@@ -88,6 +100,7 @@ This is because `@guardian/cdk` adds a tracking tag (`gu:cdk:version`) to resour
 To reduce friction, `@guardian/cdk` ships a mock that can be used with Jest, which results in snapshots having a static value for this tag.
 
 ### 🃏 Mocking `gu:cdk:version`
+
 We recommend setting up a global Jest mock for `gu:cdk:version`.
 This can be done with a few config changes.
 
@@ -111,7 +124,7 @@ Finally, update your snapshots. The `gu:cdk:version` tag should now be:
 {
   "Key": "gu:cdk:version",
   "PropagateAtLaunch": true,
-  "Value": "TEST", // <-- would otherwise be the version number of @guardian/cdk in use
+  "Value": "TEST" // <-- would otherwise be the version number of @guardian/cdk in use
 }
 ```
 

--- a/src/constructs/ecs/index.ts
+++ b/src/constructs/ecs/index.ts
@@ -1,0 +1,1 @@
+export * from "./ecs-task";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export * from "./patterns";

--- a/src/utils/cli/index.ts
+++ b/src/utils/cli/index.ts
@@ -1,0 +1,1 @@
+export * from "./vpc";

--- a/typedoc.js
+++ b/typedoc.js
@@ -11,9 +11,8 @@ function getEntryPointsFromSubdirectories(directory) {
 
 module.exports = {
   entryPoints: [
-    "src/index.ts",
+    "src/patterns/index.ts",
     "src/constants/index.ts",
-    // we purposefully do not have an index.ts in `src/constructs` or `src/utils`
     ...getEntryPointsFromSubdirectories(constructsDir),
     ...getEntryPointsFromSubdirectories(utilsDir),
   ],


### PR DESCRIPTION
(For discussion - thought showing the change would be easier to reason about than merely describing it.)

## What does this change?

At the moment we expose patterns directly under /src, but this is non-obvious and inconsistent with how we expose our other constructs etc. The intention is (I'm guessing here) to promote the use of patterns, but I'm not sure this is helping here - as it makes things difficult to find in the autogenerated docs.

Note, projects that use patterns already, will need to update their import paths after this. E.g.

    import { GuEc2App } from '@guardian/cdk'; // old
    import { GuEc2App } from '@guardian/cdk/patterns // new

Some missing `index.ts` files (for ecs and cli) were added too, to ensure we generate docs for these. (It could be argued that we don't want to expose docs for `cli` but I think it is worth it as it is part of our publicly exposed code atm. If we don't want people to use it we need to ensure this more robustly.)

Before:

![Screenshot 2021-12-09 at 14 13 33](https://user-images.githubusercontent.com/858402/145432264-66cd0154-2e97-42d6-8359-611c1bf92cae.png)

After:
![Screenshot 2021-12-09 at 14 10 10](https://user-images.githubusercontent.com/858402/145432307-216df394-0563-4968-9beb-bafb9cfdb654.png)

## How to test

    ./script/start-docs

## How can we measure success?

Easier to find things in the auto-generated docs.

## Have we considered potential risks?

This is a breaking change (as breaks import paths for patterns) so adds a little friction to updating @guardian/cdk version.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

