### PR TITLE
feat: Add Stack Set support

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -1,5 +1,6 @@
-import { Annotations, Stack, Tags } from "@aws-cdk/core";
-import type { App, StackProps } from "@aws-cdk/core";
+import { SynthUtils } from "@aws-cdk/assert";
+import { Annotations, App, Stack, Tags } from "@aws-cdk/core";
+import type { StackProps } from "@aws-cdk/core";
 import execa from "execa";
 import gitUrlParse from "git-url-parse";
 import { StageForInfrastructure } from "../../constants";
@@ -126,6 +127,10 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
     return this.params.get(key) as T;
   }
 
+  get parameterKeys(): string[] {
+    return Array.from(this.params.keys());
+  }
+
   // eslint-disable-next-line custom-rules/valid-constructors -- GuStack is the exception as it must take an App
   constructor(app: App, id: string, props: GuStackProps) {
     const mergedProps = {
@@ -194,5 +199,21 @@ export class GuStackForInfrastructure extends GuStack {
     // Yep, we're just calling the super class's implementation...
     // We're overriding to add some helpful documentation in the doc string.
     return super.withStageDependentValue(mappingValue);
+  }
+}
+
+/**
+ * A GuStack but designed for Stack Set instances.
+ *
+ * In a stack set application, `GuStackForStackSetInstance` is used to represent the infrastructure to provision in target AWS accounts.
+ */
+export class GuStackForStackSetInstance extends GuStackForInfrastructure {
+  // eslint-disable-next-line custom-rules/valid-constructors -- GuStackForStackSet should have a unique `App`
+  constructor(id: string, props: GuStackProps) {
+    super(new App(), id, props);
+  }
+
+  get cfnJson(): string {
+    return JSON.stringify(SynthUtils.toCloudFormation(this), null, 2);
   }
 }

--- a/src/constructs/stack-set/__snapshots__/stack-set.test.ts.snap
+++ b/src/constructs/stack-set/__snapshots__/stack-set.test.ts.snap
@@ -1,0 +1,237 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuStackSet construct should correctly provision a stack with a stack set resource 1`] = `
+Object {
+  "Resources": Object {
+    "StackSet": Object {
+      "Properties": Object {
+        "AutoDeployment": Object {
+          "Enabled": true,
+          "RetainStacksOnAccountRemoval": false,
+        },
+        "Description": "this stack set provisions some common infrastructure",
+        "Parameters": Array [],
+        "PermissionModel": "SERVICE_MANAGED",
+        "StackInstancesGroup": Array [
+          Object {
+            "DeploymentTargets": Object {
+              "OrganizationalUnitIds": Array [
+                "o-12345abcde",
+              ],
+            },
+            "Regions": Array [
+              Object {
+                "Ref": "AWS::Region",
+              },
+            ],
+          },
+        ],
+        "StackSetName": "my-stack-set",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+        "TemplateBody": "{
+  \\"Resources\\": {
+    \\"accountloggingstreamB8733874\\": {
+      \\"Type\\": \\"AWS::Kinesis::Stream\\",
+      \\"Properties\\": {
+        \\"ShardCount\\": 1,
+        \\"RetentionPeriodHours\\": 24,
+        \\"StreamEncryption\\": {
+          \\"Fn::If\\": [
+            \\"AwsCdkKinesisEncryptedStreamsUnsupportedRegions\\",
+            {
+              \\"Ref\\": \\"AWS::NoValue\\"
+            },
+            {
+              \\"EncryptionType\\": \\"KMS\\",
+              \\"KeyId\\": \\"alias/aws/kinesis\\"
+            }
+          ]
+        },
+        \\"Tags\\": [
+          {
+            \\"Key\\": \\"gu:cdk:version\\",
+            \\"Value\\": \\"TEST\\"
+          },
+          {
+            \\"Key\\": \\"gu:repo\\",
+            \\"Value\\": \\"guardian/cdk\\"
+          },
+          {
+            \\"Key\\": \\"Stack\\",
+            \\"Value\\": \\"test\\"
+          },
+          {
+            \\"Key\\": \\"Stage\\",
+            \\"Value\\": \\"INFRA\\"
+          }
+        ]
+      }
+    }
+  },
+  \\"Conditions\\": {
+    \\"AwsCdkKinesisEncryptedStreamsUnsupportedRegions\\": {
+      \\"Fn::Or\\": [
+        {
+          \\"Fn::Equals\\": [
+            {
+              \\"Ref\\": \\"AWS::Region\\"
+            },
+            \\"cn-north-1\\"
+          ]
+        },
+        {
+          \\"Fn::Equals\\": [
+            {
+              \\"Ref\\": \\"AWS::Region\\"
+            },
+            \\"cn-northwest-1\\"
+          ]
+        }
+      ]
+    }
+  }
+}",
+      },
+      "Type": "AWS::CloudFormation::StackSet",
+    },
+  },
+}
+`;
+
+exports[`The GuStackSet construct should support parameters in the stack set instance 1`] = `
+Object {
+  "Resources": Object {
+    "StackSet": Object {
+      "Properties": Object {
+        "AutoDeployment": Object {
+          "Enabled": true,
+          "RetainStacksOnAccountRemoval": false,
+        },
+        "Description": "this stack set provisions some common infrastructure",
+        "Parameters": Array [
+          Object {
+            "ParameterKey": "CentralSnsTopicArn",
+            "ParameterValue": Object {
+              "Ref": "accountalertsD9982E6F",
+            },
+          },
+        ],
+        "PermissionModel": "SERVICE_MANAGED",
+        "StackInstancesGroup": Array [
+          Object {
+            "DeploymentTargets": Object {
+              "OrganizationalUnitIds": Array [
+                "o-12345abcde",
+              ],
+            },
+            "Regions": Array [
+              Object {
+                "Ref": "AWS::Region",
+              },
+            ],
+          },
+        ],
+        "StackSetName": "my-stack-set",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+        "TemplateBody": "{
+  \\"Parameters\\": {
+    \\"CentralSnsTopicArn\\": {
+      \\"Type\\": \\"String\\",
+      \\"AllowedPattern\\": \\"arn:aws:[a-z0-9]*:[a-z0-9\\\\\\\\-]*:[0-9]{12}:.*\\"
+    }
+  }
+}",
+      },
+      "Type": "AWS::CloudFormation::StackSet",
+    },
+    "accountalertsD9982E6F": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "accountalertsPolicy8E37A8FA": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sns:Publish",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "aws:PrincipalOrgID": "o-12345abcde",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Object {
+                "Ref": "accountalertsD9982E6F",
+              },
+              "Sid": "0",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Topics": Array [
+          Object {
+            "Ref": "accountalertsD9982E6F",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::TopicPolicy",
+    },
+  },
+}
+`;

--- a/src/constructs/stack-set/index.ts
+++ b/src/constructs/stack-set/index.ts
@@ -1,0 +1,1 @@
+export * from "./stack-set";

--- a/src/constructs/stack-set/stack-set.test.ts
+++ b/src/constructs/stack-set/stack-set.test.ts
@@ -1,0 +1,70 @@
+import { SynthUtils } from "@aws-cdk/assert";
+import { OrganizationPrincipal } from "@aws-cdk/aws-iam";
+import { Topic } from "@aws-cdk/aws-sns";
+import { App } from "@aws-cdk/core";
+import { RegexPattern } from "../../constants";
+import { GuStackForInfrastructure, GuStackForStackSetInstance, GuStringParameter } from "../core";
+import { GuKinesisStream } from "../kinesis";
+import { GuSnsTopic } from "../sns";
+import { GuStackSet } from "./stack-set";
+
+describe("The GuStackSet construct", () => {
+  it("should correctly provision a stack with a stack set resource", () => {
+    const theStackSetInstance = new GuStackForStackSetInstance("the-stack-set", { stack: "test" });
+    new GuKinesisStream(theStackSetInstance, "account-logging-stream");
+
+    const parentStack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+
+    new GuStackSet(parentStack, "StackSet", {
+      name: "my-stack-set",
+      description: "this stack set provisions some common infrastructure",
+      organisationUnitTargets: ["o-12345abcde"],
+      stackSetInstance: theStackSetInstance,
+    });
+
+    expect(SynthUtils.toCloudFormation(parentStack)).toMatchSnapshot();
+  });
+
+  it("should support parameters in the stack set instance", () => {
+    const theStackSetInstance = new GuStackForStackSetInstance("the-stack-set", { stack: "test" });
+    Topic.fromTopicArn(
+      theStackSetInstance,
+      "central-topic",
+      new GuStringParameter(theStackSetInstance, "CentralSnsTopicArn", { allowedPattern: RegexPattern.ARN })
+        .valueAsString
+    );
+
+    const awsOrgId = "o-12345abcde";
+    const parentStack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    const centralTopic = new GuSnsTopic(parentStack, "account-alerts");
+    centralTopic.grantPublish(new OrganizationPrincipal(awsOrgId));
+
+    new GuStackSet(parentStack, "StackSet", {
+      name: "my-stack-set",
+      description: "this stack set provisions some common infrastructure",
+      organisationUnitTargets: [awsOrgId],
+      stackSetInstance: theStackSetInstance,
+      stackSetInstanceParameters: {
+        CentralSnsTopicArn: centralTopic.topicArn,
+      },
+    });
+
+    expect(SynthUtils.toCloudFormation(parentStack)).toMatchSnapshot();
+  });
+
+  it("should error if the parent stack does not specify all parameters for the stack set instance template", () => {
+    const theStackSetInstance = new GuStackForStackSetInstance("the-stack-set", { stack: "test" });
+    new GuStringParameter(theStackSetInstance, "CentralSnsTopic", { allowedPattern: RegexPattern.ARN });
+
+    const parentStack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+
+    expect(() => {
+      new GuStackSet(parentStack, "StackSet", {
+        name: "my-stack-set",
+        description: "this stack set provisions some common infrastructure",
+        organisationUnitTargets: ["o-12345abcde"],
+        stackSetInstance: theStackSetInstance,
+      });
+    }).toThrow("There are undefined stack set parameters: CentralSnsTopic");
+  });
+});

--- a/src/constructs/stack-set/stack-set.ts
+++ b/src/constructs/stack-set/stack-set.ts
@@ -1,0 +1,173 @@
+import { CfnStackSet } from "@aws-cdk/core";
+import type { GuStackForInfrastructure, GuStackForStackSetInstance } from "../core";
+
+interface GuStackSetProps {
+  /**
+   * The contents for `TemplateBody` within a `AWS::CloudFormation::StackSet`.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html#cfn-cloudformation-stackset-templatebody
+   */
+  stackSetInstance: GuStackForStackSetInstance;
+
+  /**
+   * The name of the stack set. This will appear in the target account.
+   */
+  name: string;
+
+  /**
+   * A description of the stack set. This will appear in the target account.
+   */
+  description: string;
+
+  /**
+   * AWS Organisation Unit IDs to deploy the stack set into.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudformation-stackset-deploymenttargets.html#cfn-cloudformation-stackset-deploymenttargets-organizationalunitids
+   */
+  organisationUnitTargets: string[];
+
+  /**
+   * The contents for`Parameters` within a `AWS::CloudFormation::StackSet`.
+   *
+   * Typically, you'll only need parameters if the parent stack creates resources for use in the stack set instances.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html#cfn-cloudformation-stackset-parameters
+   */
+  stackSetInstanceParameters?: Record<string, string>;
+
+  /**
+   * Which regions to run the stack set in.
+   *
+   * @default The region of the parent stack.
+   */
+  regions?: string[];
+}
+
+/**
+ * A construct to create a `AWS::CloudFormation::StackSet`.
+ *
+ * The stack set will be configured to automatically deploy into accounts when they join an AWS Organisation Unit.
+ * It's assumed stack sets are only provisioned for infrastructure, therefore the `STAGE` value will always be `INFRA`.
+ *
+ * Usage:
+ * ```typescript
+ * // the infrastructure to create in target accounts
+ * class AccountAlertTopic extends GuStackForStackSetInstance {
+ *   constructor(id: string, props: GuStackProps) {
+ *     super(id, props);
+ *
+ *     new GuSnsTopic(this, "topic-for-alerts");
+ *   }
+ * }
+ *
+ * class ParentStack extends GuStackForInfrastructure {
+ *   constructor(scope: App, id: string, props: GuStackProps) {
+ *     super(scope, id, props);
+ *
+ *     new GuStackSet(this, `${id}StackSet`, {
+ *       stackSetInstance: new AccountAlertTopic("Alerts", { stack: props.stack }),
+ *       name: "centralised-alarms",
+ *       description: "Provisioning of standard account alerting resources",
+ *       organisationUnitTargets: [ "o-abcde12345" ]
+ *     });
+ *   }
+ * }
+ *
+ * // contents of `bin/cdk.ts`
+ * new ParentStack(new App(), "AccountAlarmResources", { stack: "alarms" })
+ * ```
+ *
+ * This will produce a CloudFormation template like this:
+ * ```yaml
+ * Resources:
+ *   AccountAlarmResourcesStackSet:
+ *     Type: AWS::CloudFormation::StackSet
+ *     Properties:
+ *       PermissionModel: SERVICE_MANAGED
+ *       StackSetName: centralised-alarms
+ *       AutoDeployment:
+ *         Enabled: true
+ *         RetainStacksOnAccountRemoval: false
+ *       Description: Provisioning of standard account alerting resources
+ *       Parameters: []
+ *       StackInstancesGroup:
+ *         - DeploymentTargets:
+ *             OrganizationalUnitIds:
+ *               - o-abcde12345
+ *           Regions:
+ *             - Ref: AWS::Region
+ *       Tags:
+ *         - Key: gu:cdk:version
+ *           Value: TEST
+ *         - Key: gu:repo
+ *           Value: guardian/cdk
+ *         - Key: Stack
+ *           Value: alarms
+ *         - Key: Stage
+ *           Value: INFRA
+ *       TemplateBody: |-
+ *         {
+ *           "Resources": {
+ *             "topicforalerts57330FBE": {
+ *               "Type": "AWS::SNS::Topic",
+ *               "Properties": {
+ *                 "Tags": [
+ *                   {
+ *                     "Key": "gu:cdk:version",
+ *                     "Value": "TEST"
+ *                   },
+ *                   {
+ *                     "Key": "gu:repo",
+ *                     "Value": "guardian/cdk"
+ *                   },
+ *                   {
+ *                     "Key": "Stack",
+ *                     "Value": "alarms"
+ *                   },
+ *                   {
+ *                     "Key": "Stage",
+ *                     "Value": "INFRA"
+ *                   }
+ *                 ]
+ *               }
+ *             }
+ *           }
+ *         }
+ * ```
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html
+ */
+export class GuStackSet extends CfnStackSet {
+  constructor(scope: GuStackForInfrastructure, id: string, props: GuStackSetProps) {
+    const stackSetInstanceParameters = props.stackSetInstanceParameters ?? {};
+
+    const params = Object.keys(stackSetInstanceParameters);
+    const undefinedStackSetParams = props.stackSetInstance.parameterKeys.filter((_) => !params.includes(_));
+
+    if (undefinedStackSetParams.length !== 0) {
+      throw new Error(`There are undefined stack set parameters: ${undefinedStackSetParams.join(", ")}`);
+    }
+
+    super(scope, id, {
+      stackSetName: props.name,
+      description: props.description,
+      permissionModel: "SERVICE_MANAGED",
+      autoDeployment: {
+        enabled: true,
+        retainStacksOnAccountRemoval: false,
+      },
+      stackInstancesGroup: [
+        {
+          regions: props.regions ?? [scope.region],
+          deploymentTargets: {
+            organizationalUnitIds: props.organisationUnitTargets,
+          },
+        },
+      ],
+      templateBody: props.stackSetInstance.cfnJson,
+      parameters: Object.entries(stackSetInstanceParameters).map(([key, value]) => {
+        return { parameterKey: key, parameterValue: value };
+      }),
+    });
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Create constructs to support the creation of `AWS::CloudFormation::StackSet` resources. Unfortunately, AWS CDK does not (yet) have a L2 construct for Stack Sets 😢 .

Usage:
```typescript
// the infrastructure to create in target accounts
class AccountAlertTopic extends GuStackForStackSetInstance {
  constructor(id: string, props: GuStackProps) {
    super(id, props);

    new GuSnsTopic(this, "topic-for-alerts");
  }
}

// the infrastructure to create in the root account
class ParentStack extends GuStackForInfrastructure {
  constructor(scope: App, id: string, props: GuStackProps) {
    super(scope, id, props);

    new GuStackSet(this, `${id}StackSet`, {
      stackSetInstance: new AccountAlertTopic("Alerts", { stack: props.stack }),
      name: "centralised-alarms",
      description: "Provisioning of standard account alerting resources",
      organisationUnitTargets: [ "o-abcde12345" ]
    });
  }
}

// contents of `bin/cdk.ts`
new ParentStack(new App(), "AccountAlarmResources", { stack: "alarms" })
```

This will produce a CloudFormation template like this:
```yaml
Resources:
  AccountAlarmResourcesStackSet:
    Type: AWS::CloudFormation::StackSet
    Properties:
      PermissionModel: SERVICE_MANAGED
      StackSetName: centralised-alarms
      AutoDeployment:
        Enabled: true
        RetainStacksOnAccountRemoval: false
      Description: Provisioning of standard account alerting resources
      Parameters: []
      StackInstancesGroup:
        - DeploymentTargets:
            OrganizationalUnitIds:
              - o-abcde12345
          Regions:
            - Ref: AWS::Region
      Tags:
        - Key: gu:cdk:version
          Value: TEST
        - Key: gu:repo
          Value: guardian/cdk
        - Key: Stack
          Value: alarms
        - Key: Stage
          Value: INFRA
      TemplateBody: |-
        {
          "Resources": {
            "topicforalerts57330FBE": {
              "Type": "AWS::SNS::Topic",
              "Properties": {
                "Tags": [
                  {
                    "Key": "gu:cdk:version",
                    "Value": "TEST"
                  },
                  {
                    "Key": "gu:repo",
                    "Value": "guardian/cdk"
                  },
                  {
                    "Key": "Stack",
                    "Value": "alarms"
                  },
                  {
                    "Key": "Stage",
                    "Value": "INFRA"
                  }
                ]
              }
            }
          }
        }
```

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html.

Note: this does not support provisioning of stack sets to specific accounts as I'm not sure why we'd ever do this.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We get a step closer to a better stack set deployment story as, by provisioning stack sets as just another resource in a CloudFormation template, we're closer to being able to deploy them via RIff-Raff like any other infrastructure.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Do the construct names make sense and are they intention revealing enough?

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
