### PR TITLE
ci: Move AWS CDK check into it's own GHA job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,11 @@ jobs:
           validateSingleCommit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check-aws-cdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./script/check-aws-cdk
   CI:
     runs-on: ubuntu-latest
     steps:

--- a/script/ci
+++ b/script/ci
@@ -7,7 +7,6 @@ ROOT_DIR=$DIR/..
 
 preamble() {
   "${DIR}"/check-yarn-lock
-  "${DIR}"/check-aws-cdk
 }
 
 runIntegrationTest() {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently CI will fail when the version of AWS CDK libraries being used are over 5 releases out of date. This forces us to keep somewhat up to date with releases, however it does introduce an odd situation:
  1. Raise PR
  2. CI passes on PR
  3. PR gets approved
  4. New AWS CDK released
  5. PR merged
  6. Semantic Release creates a new release
  7. Robot that keeps `version` in `package.json` up to date raises PR
  8. Robot PR fails CI and cannot be automatically merged

The latest example of this can be seen on:
  - #977 
  - #995 
  - #997.

Where #977 passed CI (step 2) and was merged (step 5) and #995 (step 7) is now failing it's CI checks (step 8).

When this happens we usually update the branch of the robot's PR to remove the AWS CDK check, allowing CI to pass. This isn't great as we put the check back in the next PR. This is noise.

This change moves the AWS CDK check into a discrete job in GHA. This should mean we can resolve the above solution by updating the branch protection rules, allowing the AWS CDK check to fail but still require the tests to pass.

This yields less noise in the repository.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should pass and there should be another build report.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

https://github.com/guardian/cdk/pull/995 can be merged before https://github.com/guardian/cdk/pull/997 and thus the revision history stays truthful.

More importantly though, we able to ignore the AWS CDK check a little more easily.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

???

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
