### PR TITLE
chore: Forgo keeping `version` in `package.json` up to date

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,17 +18,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./script/cd
-
-      # Only performed if `main` is updated
-      # See https://docs.github.com/en/actions/reference/environment-variables#determining-when-to-use-default-environment-variables-or-contexts
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        name: post-release
-        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
-        with:
-          # This action will raise a PR to edit package.json.
-          # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI,
-          # so we need to provide a different token.
-          # This is a PAT for the guardian-ci user.
-          # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
-          github-token: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
-          npm-lockfile-version: 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,12 +31,3 @@ jobs:
         with:
           cache: npm
       - run: ./script/ci
-  approve-and-merge:
-    runs-on: ubuntu-latest
-    needs: [CI]
-    steps:
-      - name: Validate, approve and merge release PRs
-        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          npm-lockfile-version: 2

--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ To release a new version:
 1. Once reviewed and approved, merge your PR.
 1. Wait for the robots to:
    - Use your structured commit to automatically determine the next version number (following [semantic versioning][sem-ver]).
-   - Release a new version to npm and update `package.json`.
+   - Release a new version to [npm].
 1. Enjoy a comment on your PR to inform you that your change has been released.
+
+Note: The version number in `package.json` is static. Refer to [npm] or [releases] for the latest version number.
 
 For more information, see the docs on [testing][docs-testing].
 
@@ -161,5 +163,7 @@ For more information, see the docs on [testing][docs-testing].
 [github-scripts]: https://github.com/github/scripts-to-rule-them-all
 [guardian/actions-merge-release-changes-to-protected-branch]: https://github.com/guardian/actions-merge-release-changes-to-protected-branch
 [karma-commits]: http://karma-runner.github.io/6.1/dev/git-commit-msg.html
+[npm]: https://www.npmjs.com/package/@guardian/cdk
+[releases]: https://github.com/guardian/cdk/releases
 [semantic-release]: https://github.com/semantic-release/semantic-release
 [sem-ver]: https://semver.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/cdk",
-  "version": "32.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/cdk",
-      "version": "32.1.0",
+      "version": "0.0.0",
       "dependencies": {
         "@aws-cdk/assert": "1.137.0",
         "@aws-cdk/aws-apigateway": "1.137.0",
@@ -18097,6 +18097,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -31403,7 +31404,8 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yargs": {
       "version": "17.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/cdk",
   "description": "Generic Guardian flavoured AWS CDK components",
-  "version": "32.1.0",
+  "version": "0.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Currently when a new release is made (via Semantic Release), a robot will raise and merge a PR to update `version` in `package.json`.

This is handy as we can browse the file to see what the latest version is.
I don't think it's necessary for the release process - Semantic Release gets the latest version number from npm.

It comes at a slight cost, however:
  - A bit of PR noise. We're not expected to interacted with the robot's PRs, but the `CODEOWNERS` rules mean we get added as reviewers.
  - An odd scenario where our CI checks don't pass and the robot's PR cannot be automatically merged. See #998.

This change moves to a simpler model of keeping `version` in `package.json` completly static between releases.
If one would like to find the number of the latest version, npm or GitHub releases can be used.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

Might be one to try on the `beta` branch?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Releasing a new version of the library produces less noise.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This should not have any impact on the release process as [Semantic Release gets the latest number from npm](https://github.com/semantic-release/npm/blob/708c29bf735d731f6855b2425ba9f12b618873dd/lib/prepare.js#L10-L17), rather than reading form the `package.json`.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
