### PR TITLE
feat: Add error annotation when a deprecated lambda runtime is used

### DIFF
--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -1,7 +1,7 @@
-import { Code, Function, RuntimeFamily } from "@aws-cdk/aws-lambda";
-import type { FunctionProps, Runtime } from "@aws-cdk/aws-lambda";
+import { Code, Function, Runtime, RuntimeFamily } from "@aws-cdk/aws-lambda";
+import type { FunctionProps } from "@aws-cdk/aws-lambda";
 import { Bucket } from "@aws-cdk/aws-s3";
-import { Duration } from "@aws-cdk/core";
+import { Annotations, Duration } from "@aws-cdk/core";
 import { GuDistributable } from "../../types/distributable";
 import { GuLambdaErrorPercentageAlarm, GuLambdaThrottlingAlarm } from "../cloudwatch";
 import type { GuLambdaErrorPercentageMonitoringProps, GuLambdaThrottlingMonitoringProps } from "../cloudwatch";
@@ -9,6 +9,14 @@ import { GuDistributionBucketParameter } from "../core";
 import type { GuStack } from "../core";
 import { AppIdentity } from "../core/identity";
 import { GuParameterStoreReadPolicyStatement } from "../iam";
+
+const DEPRECATED_RUNTIMES: Runtime[] = [
+  Runtime.NODEJS_4_3,
+  Runtime.NODEJS_6_10,
+  Runtime.NODEJS_8_10,
+  Runtime.NODEJS_10_X,
+  Runtime.NODEJS_12_X,
+];
 
 export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code">, AppIdentity {
   /**
@@ -87,6 +95,10 @@ export class GuLambdaFunction extends Function {
       timeout: timeout ?? Duration.seconds(30),
       code,
     });
+
+    if (DEPRECATED_RUNTIMES.includes(runtime)) {
+      Annotations.of(this).addError(`The runtime ${runtime.name} is deprecated or not LTS. Consider updating.`);
+    }
 
     this.app = app;
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We should never use a deprecated or non-LTS runtime for lambdas. In this change, we add an error annotation to this effect.

Note: the annotation does not prevent the stack from being synthesised, to do this, we'd want to `throw`. I'm not sure if that's desirable behaviour atm though?

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We are discouraged from using deprecated or non-LTS lambda runtimes.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We have to maintain the `DEPRECATED_RUNTIMES` list.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
