### PR TITLE
fix: include template for project generation tooling when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:custom-lint-rule": "eslint tools/eslint/rules/valid-constructors.test.ts",
     "test:dev": "jest --detectOpenHandles --runInBand --watch",
     "prepare": "tsc",
+    "prepack": "cp -r src/bin/commands/template lib/bin/commands/template",
     "release": "semantic-release",
     "release:docs": "rm -rf target && typedoc && gh-pages -d target -u \"github-actions-bot <support+actions@github.com>\"",
     "serve:docs": "rm -rf target && typedoc && serve target",


### PR DESCRIPTION
## What does this change?

I noticed a problem when testing https://github.com/guardian/cdk/pull/971 after it was released; the template files were omitted from the published `npm` package, which causes the `new` command to fail. This PR ensures that the necessary template files are included.

I've taken a similar approach to https://github.com/guardian/cdk-cli/pull/48, but I think using `cp` will be fine for our purposes.

## How to test

Create a temporary directory and run `npx @guardian/cdk@beta new --stack my-stack --app my-app`.

## How can we measure success?

The `new` command works correctly!

## Have we considered potential risks?

N/A

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1] N/A
- [x] I have updated the documentation as required for the described changes [^2] N/A

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
