### PR TITLE
fix: Only create a CFN Mapping when necessary

### DIFF
--- a/src/constructs/acm/certificate.test.ts
+++ b/src/constructs/acm/certificate.test.ts
@@ -54,22 +54,6 @@ describe("The GuCertificate class", () => {
   });
 
   it("should not create a CloudFormation Mapping when used in a GuStackForInfrastructure", () => {
-    const stack = simpleGuStackForTesting();
-    new GuCertificate(stack, {
-      app: "testing",
-      [Stage.CODE]: {
-        domainName: "code-guardian.com",
-        hostedZoneId: "id123",
-      },
-      [Stage.PROD]: {
-        domainName: "prod-guardian.com",
-        hostedZoneId: "id124",
-      },
-    });
-
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(json.Mappings).toBeDefined();
-
     const infraStack = simpleInfraStackForTesting();
     new GuCertificate(infraStack, {
       app: "testing",

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -2,25 +2,28 @@ import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { ComparisonOperator } from "@aws-cdk/aws-cloudwatch";
 import { Runtime } from "@aws-cdk/aws-lambda";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { simpleGuStackForTesting, simpleInfraStackForTesting } from "../../utils/test";
 import type { SynthedStack } from "../../utils/test";
+import type { GuStack } from "../core";
 import { GuLambdaFunction } from "../lambda";
 import { GuAlarm } from "./alarm";
 
 describe("The GuAlarm class", () => {
-  it("should create a CloudWatch alarm", () => {
-    const stack = simpleGuStackForTesting();
-    const lambda = new GuLambdaFunction(stack, "lambda", {
+  const lambda = (stack: GuStack) =>
+    new GuLambdaFunction(stack, "lambda", {
       fileName: "lambda.zip",
       handler: "handler.ts",
       runtime: Runtime.NODEJS_12_X,
       app: "testing",
     });
+
+  it("should create a CloudWatch alarm", () => {
+    const stack = simpleGuStackForTesting();
     new GuAlarm(stack, "alarm", {
       app: "testing",
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
-      metric: lambda.metricErrors(),
+      metric: lambda(stack).metricErrors(),
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       threshold: 1,
       evaluationPeriods: 1,
@@ -31,17 +34,11 @@ describe("The GuAlarm class", () => {
 
   it("should send alerts to the provided SNS Topic", () => {
     const stack = simpleGuStackForTesting();
-    const lambda = new GuLambdaFunction(stack, "lambda", {
-      fileName: "lambda.zip",
-      handler: "handler.ts",
-      runtime: Runtime.NODEJS_12_X,
-      app: "testing",
-    });
     new GuAlarm(stack, "alarm", {
       app: "testing",
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
-      metric: lambda.metricErrors(),
+      metric: lambda(stack).metricErrors(),
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       threshold: 1,
       evaluationPeriods: 1,
@@ -71,17 +68,11 @@ describe("The GuAlarm class", () => {
 
   it("should enable alarm actions in PROD and disable them in CODE, by default", () => {
     const stack = simpleGuStackForTesting();
-    const lambda = new GuLambdaFunction(stack, "lambda", {
-      fileName: "lambda.zip",
-      handler: "handler.ts",
-      runtime: Runtime.NODEJS_12_X,
-      app: "testing",
-    });
     new GuAlarm(stack, "alarm", {
       app: "testing",
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
-      metric: lambda.metricErrors(),
+      metric: lambda(stack).metricErrors(),
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       threshold: 1,
       evaluationPeriods: 1,
@@ -102,18 +93,12 @@ describe("The GuAlarm class", () => {
 
   it("should allow users to manually enable alarm notifications in CODE", () => {
     const stack = simpleGuStackForTesting();
-    const lambda = new GuLambdaFunction(stack, "lambda", {
-      fileName: "lambda.zip",
-      handler: "handler.ts",
-      runtime: Runtime.NODEJS_12_X,
-      app: "testing",
-    });
     new GuAlarm(stack, "alarm", {
       app: "testing",
       actionsEnabledInCode: true,
       alarmName: `Alarm in ${stack.stage}`,
       alarmDescription: "It's broken",
-      metric: lambda.metricErrors(),
+      metric: lambda(stack).metricErrors(),
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       threshold: 1,
       evaluationPeriods: 1,
@@ -130,5 +115,29 @@ describe("The GuAlarm class", () => {
         },
       },
     });
+  });
+
+  it("should not create a CloudFormation Mapping when used in a GuStackForInfrastructure", () => {
+    const addAlarmToStack = (stack: GuStack) =>
+      new GuAlarm(stack, "alarm", {
+        app: "testing",
+        alarmName: `Alarm in ${stack.stage}`,
+        alarmDescription: "It's broken",
+        metric: lambda(stack).metricErrors(),
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        threshold: 1,
+        evaluationPeriods: 1,
+        snsTopicName: "alerts-topic",
+      });
+
+    const stack = simpleGuStackForTesting();
+    addAlarmToStack(stack);
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Mappings).toBeDefined();
+
+    const infraStack = simpleInfraStackForTesting();
+    addAlarmToStack(infraStack);
+    const infraJson = SynthUtils.toCloudFormation(infraStack) as SynthedStack;
+    expect(infraJson.Mappings).toBeUndefined();
   });
 });

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -25,17 +25,16 @@ export class GuAlarm extends Alarm {
   constructor(scope: GuStack, id: string, props: GuAlarmProps) {
     super(scope, id, {
       ...props,
-      actionsEnabled: scope.withStageDependentValue({
-        app: props.app,
-        variableName: "alarmActionsEnabled",
-        stageValues:
-          scope.stage === StageForInfrastructure
-            ? { [StageForInfrastructure]: true }
-            : {
-                [Stage.CODE]: props.actionsEnabledInCode ?? false,
-                [Stage.PROD]: true,
-              },
-      }),
+      actionsEnabled:
+        scope.stage === StageForInfrastructure ||
+        scope.withStageDependentValue({
+          app: props.app,
+          variableName: "alarmActionsEnabled",
+          stageValues: {
+            [Stage.CODE]: props.actionsEnabledInCode ?? false,
+            [Stage.PROD]: true,
+          },
+        }),
     });
     const topicArn: string = `arn:aws:sns:${scope.region}:${scope.account}:${props.snsTopicName}`;
     const snsTopic: ITopic = Topic.fromTopicArn(scope, `SnsTopicFor${id}`, topicArn);

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -7,10 +7,10 @@ import { Annotations, App } from "@aws-cdk/core";
 import { Stage, StageForInfrastructure, Stages } from "../../constants";
 import { ContextKeys } from "../../constants/context-keys";
 import { TagKeys } from "../../constants/tag-keys";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { simpleGuStackForTesting, simpleInfraStackForTesting } from "../../utils/test";
 import type { SynthedStack } from "../../utils/test";
 import { GuParameter } from "./parameters";
-import { GuStack, GuStackForInfrastructure } from "./stack";
+import { GuStack } from "./stack";
 
 describe("The GuStack construct", () => {
   const warn = jest.spyOn(Annotations.prototype, "addWarning");
@@ -113,12 +113,12 @@ describe("The GuStack construct", () => {
 
 describe("The GuStackForInfrastructure construct", () => {
   it("should have a stage of INFRA", () => {
-    const stack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    const stack = simpleInfraStackForTesting({ stack: "test" });
     expect(stack.stage).toBe("INFRA");
   });
 
   it("should throw when calling withStageDependentValue with a non-INFRA stage", () => {
-    const stack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    const stack = simpleInfraStackForTesting({ stack: "test" });
 
     expect(() => {
       stack.withStageDependentValue({

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -191,7 +191,20 @@ export class GuStackForInfrastructure extends GuStack {
    * A helper function to switch between different values depending on the Stage being CloudFormed.
    *
    * As GuInfrastructureStack has a single stage (INFRA), calling withStageDependentValue is unnecessary complexity.
-   * Consider using a standard variable in code instead.
+   * Consider using a standard variable in code instead with [[`StageAwareValue`]]
+   *
+   * ```typescript
+   * const name = StageAwareValue.isStageValue(props)
+   *   ? scope.withStageDependentValue({
+   *       app: props.app,
+   *       variableName: "name",
+   *       stageValues: {
+   *         [Stage.CODE]: "CODE value",
+   *         [Stage.PROD]: "PROD value"
+   *       }
+   *     })
+   *   : "INFRA value";
+   * ```
    *
    * Note: Specifying a stage other than `INFRA` will raise an exception.
    */

--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -2,8 +2,9 @@ import "@aws-cdk/assert/jest";
 import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Duration } from "@aws-cdk/core";
-import { Stage } from "../../constants";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { Stage, StageForInfrastructure } from "../../constants";
+import type { SynthedStack } from "../../utils/test";
+import { simpleGuStackForTesting, simpleInfraStackForTesting } from "../../utils/test";
 import { GuCname, GuDnsRecordSet, RecordType } from "./dns-records";
 
 describe("The GuDnsRecordSet construct", () => {
@@ -42,5 +43,32 @@ describe("The GuCname construct", () => {
       ttl: Duration.hours(1),
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+
+  it("should not create a CloudFormation Mapping when used in a GuStackForInfrastructure", () => {
+    const stack = simpleGuStackForTesting();
+    new GuCname(stack, "TestRecord", {
+      domainNameProps: {
+        [Stage.CODE]: { domainName: "xyz.code-guardian.com" },
+        [Stage.PROD]: { domainName: "xyz.prod-guardian.com" },
+      },
+      app: "my-test-app",
+      resourceRecord: "apple.example.com",
+      ttl: Duration.hours(1),
+    });
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Mappings).toBeDefined();
+
+    const infraStack = simpleInfraStackForTesting();
+    new GuCname(infraStack, "TestRecord", {
+      domainNameProps: {
+        [StageForInfrastructure]: { domainName: "xyz.infra-guardian.com" },
+      },
+      app: "my-test-app",
+      resourceRecord: "apple.example.com",
+      ttl: Duration.hours(1),
+    });
+    const infraJson = SynthUtils.toCloudFormation(infraStack) as SynthedStack;
+    expect(infraJson.Mappings).toBeUndefined();
   });
 });

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,6 +1,6 @@
 import type { Duration } from "@aws-cdk/core";
 import { CfnResource } from "@aws-cdk/core";
-import { Stage, StageForInfrastructure } from "../../constants";
+import { Stage } from "../../constants";
 import type { GuDomainNameProps } from "../../types/domain-names";
 import { StageAwareValue } from "../../types/stage";
 import type { GuStack } from "../core";
@@ -70,18 +70,16 @@ export interface GuCnameProps extends AppIdentity {
  */
 export class GuCname extends GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuCnameProps) {
-    const domainName = scope.withStageDependentValue({
-      app: props.app,
-      variableName: "domainName",
-      stageValues: StageAwareValue.isStageValue(props.domainNameProps)
-        ? {
+    const domainName = StageAwareValue.isStageValue(props.domainNameProps)
+      ? scope.withStageDependentValue({
+          app: props.app,
+          variableName: "domainName",
+          stageValues: {
             [Stage.CODE]: props.domainNameProps.CODE.domainName,
             [Stage.PROD]: props.domainNameProps.PROD.domainName,
-          }
-        : {
-            [StageForInfrastructure]: props.domainNameProps.INFRA.domainName,
           },
-    });
+        })
+      : props.domainNameProps.INFRA.domainName;
     super(scope, id, {
       name: domainName,
       recordType: RecordType.CNAME,

--- a/src/constructs/s3/__snapshots__/index.test.ts.snap
+++ b/src/constructs/s3/__snapshots__/index.test.ts.snap
@@ -14,11 +14,21 @@ Object {
     },
   },
   "Resources": Object {
-    "MyBucketF68F3FF0": Object {
+    "MyBucketTest262E966E": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketName": "super-important-stuff",
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "test",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/constructs/s3/index.test.ts
+++ b/src/constructs/s3/index.test.ts
@@ -1,3 +1,4 @@
+import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuS3Bucket } from "./index";
@@ -8,10 +9,40 @@ describe("The GuS3Bucket construct", () => {
 
     new GuS3Bucket(stack, "MyBucket", {
       bucketName: "super-important-stuff",
+      app: "test",
     });
 
     // The policies are siblings of Properties.
     // The `.toHaveResource` matcher cannot be used as it only looks at Properties.
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+
+  it("should be possible to override the logical id", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+
+    new GuS3Bucket(stack, "MyBucket", {
+      bucketName: "data-bucket",
+      app: "test",
+      existingLogicalId: {
+        logicalId: "DataBucket",
+        reason: "Unit tests",
+      },
+    });
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::S3::Bucket", "DataBucket");
+  });
+
+  it("should receive the correct set of tags", () => {
+    const stack = simpleGuStackForTesting();
+    const app = "test";
+
+    new GuS3Bucket(stack, "MyBucket", {
+      bucketName: "super-important-stuff",
+      app,
+    });
+
+    expect(stack).toHaveGuTaggedResource("AWS::S3::Bucket", {
+      appIdentity: { app },
+    });
   });
 });

--- a/src/constructs/s3/index.ts
+++ b/src/constructs/s3/index.ts
@@ -1,17 +1,24 @@
 import type { BucketProps } from "@aws-cdk/aws-s3";
-import { Bucket } from "@aws-cdk/aws-s3";
+import { BlockPublicAccess, Bucket } from "@aws-cdk/aws-s3";
 import { RemovalPolicy } from "@aws-cdk/core";
 import { GuMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
+import type { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-export interface GuS3BucketProps extends GuMigratingResource, Omit<BucketProps, "removalPolicy"> {}
+export interface GuS3BucketProps extends GuMigratingResource, Omit<BucketProps, "removalPolicy">, AppIdentity {}
 
 /**
  * A construct to create a bucket with a "retain" policy to prevent it from being deleted. It will be orphaned instead.
  */
-export class GuS3Bucket extends GuMigratableConstruct(Bucket) {
+export class GuS3Bucket extends GuMigratableConstruct(GuAppAwareConstruct(Bucket)) {
   constructor(scope: GuStack, id: string, props: GuS3BucketProps) {
-    super(scope, id, { ...props, removalPolicy: RemovalPolicy.RETAIN });
+    super(scope, id, {
+      removalPolicy: RemovalPolicy.RETAIN,
+      publicReadAccess: false,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      ...props,
+    });
   }
 }

--- a/src/constructs/stack-set/stack-set.test.ts
+++ b/src/constructs/stack-set/stack-set.test.ts
@@ -1,9 +1,9 @@
 import { SynthUtils } from "@aws-cdk/assert";
 import { OrganizationPrincipal } from "@aws-cdk/aws-iam";
 import { Topic } from "@aws-cdk/aws-sns";
-import { App } from "@aws-cdk/core";
 import { RegexPattern } from "../../constants";
-import { GuStackForInfrastructure, GuStackForStackSetInstance, GuStringParameter } from "../core";
+import { simpleInfraStackForTesting } from "../../utils/test";
+import { GuStackForStackSetInstance, GuStringParameter } from "../core";
 import { GuKinesisStream } from "../kinesis";
 import { GuSnsTopic } from "../sns";
 import { GuStackSet } from "./stack-set";
@@ -13,7 +13,7 @@ describe("The GuStackSet construct", () => {
     const theStackSetInstance = new GuStackForStackSetInstance("the-stack-set", { stack: "test" });
     new GuKinesisStream(theStackSetInstance, "account-logging-stream");
 
-    const parentStack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    const parentStack = simpleInfraStackForTesting({ stack: "test" });
 
     new GuStackSet(parentStack, "StackSet", {
       name: "my-stack-set",
@@ -35,7 +35,7 @@ describe("The GuStackSet construct", () => {
     );
 
     const awsOrgId = "o-12345abcde";
-    const parentStack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    const parentStack = simpleInfraStackForTesting({ stack: "test" });
     const centralTopic = new GuSnsTopic(parentStack, "account-alerts");
     centralTopic.grantPublish(new OrganizationPrincipal(awsOrgId));
 
@@ -56,7 +56,7 @@ describe("The GuStackSet construct", () => {
     const theStackSetInstance = new GuStackForStackSetInstance("the-stack-set", { stack: "test" });
     new GuStringParameter(theStackSetInstance, "CentralSnsTopic", { allowedPattern: RegexPattern.ARN });
 
-    const parentStack = new GuStackForInfrastructure(new App(), "Test", { stack: "test" });
+    const parentStack = simpleInfraStackForTesting({ stack: "test" });
 
     expect(() => {
       new GuStackSet(parentStack, "StackSet", {

--- a/src/constructs/vpc/vpc.test.ts
+++ b/src/constructs/vpc/vpc.test.ts
@@ -1,25 +1,18 @@
 import "@aws-cdk/assert/jest";
 import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
-import { App } from "@aws-cdk/core";
-import { GuStackForInfrastructure } from "../core";
+import { simpleInfraStackForTesting } from "../../utils/test";
 import { GuVpc } from "./vpc";
 
 describe("The GuVpc construct", () => {
-  const simpleInfraStack = () => {
-    return new GuStackForInfrastructure(new App(), "Test", {
-      stack: "test-stack",
-    });
-  };
-
   it("should match snapshot", () => {
-    const stack = simpleInfraStack();
+    const stack = simpleInfraStackForTesting({ stack: "test-stack" });
     new GuVpc(stack, "MyVpc");
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 
   it("should create VPC SSM parameters by default", () => {
-    const stack = simpleInfraStack();
+    const stack = simpleInfraStackForTesting({ stack: "test-stack" });
     new GuVpc(stack, "MyVpc", { ssmParameters: true });
     expect(stack).toHaveResourceLike("AWS::SSM::Parameter", {
       Name: "/account/vpc/primary/id",
@@ -35,7 +28,7 @@ describe("The GuVpc construct", () => {
   });
 
   it("should not create VPC SSM parameters if set to false", () => {
-    const stack = simpleInfraStack();
+    const stack = simpleInfraStackForTesting({ stack: "test-stack" });
     new GuVpc(stack, "MyVpc", { ssmParameters: false });
 
     expect(stack).toCountResources("AWS::SSM::Parameter", 0);

--- a/src/types/stage.test.ts
+++ b/src/types/stage.test.ts
@@ -1,0 +1,32 @@
+import { Stage, StageForInfrastructure } from "../constants";
+import { StageAwareValue } from "./stage";
+
+describe("StageAwareValue user defined type guards", () => {
+  it("should correctly identify input", () => {
+    expect(
+      StageAwareValue.isStageValue({
+        [Stage.CODE]: "some value for CODE",
+        [Stage.PROD]: "some value for PROD",
+      })
+    ).toBeTruthy();
+
+    expect(
+      StageAwareValue.isStageValue({
+        [StageForInfrastructure]: "some value",
+      })
+    ).toBeFalsy();
+
+    expect(
+      StageAwareValue.isStageForInfrastructureValue({
+        [Stage.CODE]: "some value for CODE",
+        [Stage.PROD]: "some value for PROD",
+      })
+    ).toBeFalsy();
+
+    expect(
+      StageAwareValue.isStageForInfrastructureValue({
+        [StageForInfrastructure]: "some value",
+      })
+    ).toBeTruthy();
+  });
+});

--- a/src/utils/test/simple-gu-stack.ts
+++ b/src/utils/test/simple-gu-stack.ts
@@ -1,6 +1,6 @@
 import { App } from "@aws-cdk/core";
 import type { Environment } from "@aws-cdk/core";
-import { GuStack } from "../../constructs/core";
+import { GuStack, GuStackForInfrastructure } from "../../constructs/core";
 import type { GuStackProps } from "../../constructs/core";
 
 // Some stacks (such as ones using access logging on load balancers) require specifying a region
@@ -10,6 +10,12 @@ interface SimpleGuStackProps extends Partial<GuStackProps> {
 
 export const simpleGuStackForTesting: (props?: SimpleGuStackProps) => GuStack = (props?: SimpleGuStackProps) =>
   new GuStack(new App(), "Test", {
+    stack: props?.stack ?? "test-stack",
+    ...props,
+  });
+
+export const simpleInfraStackForTesting: (props?: SimpleGuStackProps) => GuStack = (props?: SimpleGuStackProps) =>
+  new GuStackForInfrastructure(new App(), "Test", {
     stack: props?.stack ?? "test-stack",
     ...props,
   });


### PR DESCRIPTION
Might be easier to review commit by commit.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The `withStageDependentValue` function on a `GuStack` can be used to add a [CloudFormation Mapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/mappings-section-structure.html) to the template where a value is dependant on the stage the template is being run in.

This makes sense for a `GuStack` where `stage` is either CODE or PROD. However creating a mapping for a `GuStackForInfrastructure` where `stage` is always INFRA is redundant.

In this change we only create the CloudFormation Mapping where necessary; if stage is INFRA we return a value directly, rather than via a Mapping.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See the additional tests where we assert that Mappings for `GuStackForInfrastructure` is `undefined`.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A shorter and simpler synthesised CloudFormation template.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
