### PR TITLE
feat: Add support for a static site hosted by S3 and fronted by CloudFront w/custom domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-cdk/assert": "1.140.0",
         "@aws-cdk/aws-apigateway": "1.140.0",
         "@aws-cdk/aws-autoscaling": "1.140.0",
+        "@aws-cdk/aws-cloudfront": "1.140.0",
         "@aws-cdk/aws-cloudwatch-actions": "1.140.0",
         "@aws-cdk/aws-ec2": "1.140.0",
         "@aws-cdk/aws-ecr": "1.140.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@aws-cdk/assert": "1.140.0",
     "@aws-cdk/aws-apigateway": "1.140.0",
     "@aws-cdk/aws-autoscaling": "1.140.0",
+    "@aws-cdk/aws-cloudfront": "1.140.0",
     "@aws-cdk/aws-cloudwatch-actions": "1.140.0",
     "@aws-cdk/aws-ec2": "1.140.0",
     "@aws-cdk/aws-ecr": "1.140.0",

--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -56,6 +56,8 @@ export type GuCertificatePropsWithApp = GuDomainNameProps & AppIdentity & GuMigr
  *```
  */
 export class GuCertificate extends GuStatefulMigratableConstruct(GuAppAwareConstruct(Certificate)) {
+  static mappingVariableName: string = "domainName";
+
   constructor(scope: GuStack, props: GuCertificatePropsWithApp) {
     const hasHostedZoneId: boolean = StageAwareValue.isStageValue(props)
       ? !!props.CODE.hostedZoneId && !!props.PROD.hostedZoneId
@@ -84,7 +86,7 @@ export class GuCertificate extends GuStatefulMigratableConstruct(GuAppAwareConst
       domainName: StageAwareValue.isStageValue(props)
         ? scope.withStageDependentValue({
             app: props.app,
-            variableName: "domainName",
+            variableName: GuCertificate.mappingVariableName,
             stageValues: {
               [Stage.CODE]: props.CODE.domainName,
               [Stage.PROD]: props.PROD.domainName,

--- a/src/constructs/static-site/__snapshots__/static-site.test.ts.snap
+++ b/src/constructs/static-site/__snapshots__/static-site.test.ts.snap
@@ -1,0 +1,932 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuStaticSite pattern should be possible to define multiple in a single stack 1`] = `
+Object {
+  "Mappings": Object {
+    "Site2": Object {
+      "CODE": Object {
+        "domainName": "site2.dev-gutools.co.uk",
+      },
+      "PROD": Object {
+        "domainName": "site2.gutools.co.uk",
+      },
+    },
+    "myapp": Object {
+      "CODE": Object {
+        "domainName": "my-app.dev-gutools.co.uk",
+      },
+      "PROD": Object {
+        "domainName": "my-app.gutools.co.uk",
+      },
+    },
+  },
+  "Outputs": Object {
+    "CloudFrontOAISite2": Object {
+      "Description": "Canonical user ID used by CloudFront distribution. This should be granted 's3:GetObject' access to S3 bucket 'site2-origin'.",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "CloudFrontOriginAccessIdentitySite23746234B",
+          "S3CanonicalUserId",
+        ],
+      },
+    },
+    "OriginBucketNameMyapp": Object {
+      "Description": "S3 bucket origin for CloudFront.",
+      "Value": Object {
+        "Ref": "OriginBucketMyapp924B0FC3",
+      },
+    },
+  },
+  "Parameters": Object {
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "CertificateMyappA1452439": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": Object {
+          "Fn::FindInMap": Array [
+            "myapp",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CertificateSite2260E1692": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": Object {
+          "Fn::FindInMap": Array [
+            "Site2",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "Site2",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudFrontOriginAccessIdentityMyapp936D2403": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "Origin Access Identity for my-app ",
+                Object {
+                  "Ref": "Stage",
+                },
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "CloudFrontOriginAccessIdentitySite23746234B": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "Origin Access Identity for Site2 ",
+                Object {
+                  "Ref": "Stage",
+                },
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "DnsRecordMyapp": Object {
+      "Properties": Object {
+        "Name": Object {
+          "Fn::FindInMap": Array [
+            "myapp",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "Site1MyappCFDistribution297F4C3E",
+              "DomainName",
+            ],
+          },
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "DnsRecordSite2": Object {
+      "Properties": Object {
+        "Name": Object {
+          "Fn::FindInMap": Array [
+            "Site2",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "Site2Site2CFDistribution8AFAF8EA",
+              "DomainName",
+            ],
+          },
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "OriginBucketMyapp924B0FC3": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "OriginBucketMyappPolicyD18AACC9": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "OriginBucketMyapp924B0FC3",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "CloudFrontOriginAccessIdentityMyapp936D2403",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "OriginBucketMyapp924B0FC3",
+                        "Arn",
+                      ],
+                    },
+                    "/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/my-app/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "CloudFrontOriginAccessIdentityMyapp936D2403",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "OriginBucketMyapp924B0FC3",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "Site1MyappCFDistribution297F4C3E": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "Aliases": Array [
+            Object {
+              "Fn::FindInMap": Array [
+                "myapp",
+                Object {
+                  "Ref": "Stage",
+                },
+                "domainName",
+              ],
+            },
+          ],
+          "Comment": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "CloudFront distribution for my-app ",
+                Object {
+                  "Ref": "Stage",
+                },
+              ],
+            ],
+          },
+          "DefaultCacheBehavior": Object {
+            "AllowedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "CachedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "Compress": true,
+            "ForwardedValues": Object {
+              "Cookies": Object {
+                "Forward": "none",
+              },
+              "QueryString": false,
+            },
+            "TargetOriginId": "origin1",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "ConnectionAttempts": 3,
+              "ConnectionTimeout": 10,
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "OriginBucketMyapp924B0FC3",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "origin1",
+              "OriginPath": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/my-app",
+                  ],
+                ],
+              },
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "CloudFrontOriginAccessIdentityMyapp936D2403",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_100",
+          "ViewerCertificate": Object {
+            "AcmCertificateArn": Object {
+              "Ref": "CertificateMyappA1452439",
+            },
+            "SslSupportMethod": "sni-only",
+          },
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "Site2Site2CFDistribution8AFAF8EA": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "Aliases": Array [
+            Object {
+              "Fn::FindInMap": Array [
+                "Site2",
+                Object {
+                  "Ref": "Stage",
+                },
+                "domainName",
+              ],
+            },
+          ],
+          "Comment": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "CloudFront distribution for Site2 ",
+                Object {
+                  "Ref": "Stage",
+                },
+              ],
+            ],
+          },
+          "DefaultCacheBehavior": Object {
+            "AllowedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "CachedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "Compress": true,
+            "ForwardedValues": Object {
+              "Cookies": Object {
+                "Forward": "none",
+              },
+              "QueryString": false,
+            },
+            "TargetOriginId": "origin1",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "ConnectionAttempts": 3,
+              "ConnectionTimeout": 10,
+              "DomainName": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "site2-origin.s3.",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ".",
+                    Object {
+                      "Ref": "AWS::URLSuffix",
+                    },
+                  ],
+                ],
+              },
+              "Id": "origin1",
+              "OriginPath": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/Site2",
+                  ],
+                ],
+              },
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "CloudFrontOriginAccessIdentitySite23746234B",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_100",
+          "ViewerCertificate": Object {
+            "AcmCertificateArn": Object {
+              "Ref": "CertificateSite2260E1692",
+            },
+            "SslSupportMethod": "sni-only",
+          },
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "Site2",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+  },
+}
+`;
+
+exports[`The GuStaticSite pattern should create the correct resources with minimal config 1`] = `
+Object {
+  "Mappings": Object {
+    "myapp": Object {
+      "CODE": Object {
+        "domainName": "my-app.dev-gutools.co.uk",
+      },
+      "PROD": Object {
+        "domainName": "my-app.gutools.co.uk",
+      },
+    },
+  },
+  "Outputs": Object {
+    "OriginBucketNameMyapp": Object {
+      "Description": "S3 bucket origin for CloudFront.",
+      "Value": Object {
+        "Ref": "OriginBucketMyapp924B0FC3",
+      },
+    },
+  },
+  "Parameters": Object {
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "CertificateMyappA1452439": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": Object {
+          "Fn::FindInMap": Array [
+            "myapp",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudFrontOriginAccessIdentityMyapp936D2403": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "Origin Access Identity for my-app ",
+                Object {
+                  "Ref": "Stage",
+                },
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "DnsRecordMyapp": Object {
+      "Properties": Object {
+        "Name": Object {
+          "Fn::FindInMap": Array [
+            "myapp",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "StaticSiteMyappCFDistribution3080CEE2",
+              "DomainName",
+            ],
+          },
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "OriginBucketMyapp924B0FC3": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "OriginBucketMyappPolicyD18AACC9": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "OriginBucketMyapp924B0FC3",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "CloudFrontOriginAccessIdentityMyapp936D2403",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "OriginBucketMyapp924B0FC3",
+                        "Arn",
+                      ],
+                    },
+                    "/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/my-app/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "CloudFrontOriginAccessIdentityMyapp936D2403",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "OriginBucketMyapp924B0FC3",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "StaticSiteMyappCFDistribution3080CEE2": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "Aliases": Array [
+            Object {
+              "Fn::FindInMap": Array [
+                "myapp",
+                Object {
+                  "Ref": "Stage",
+                },
+                "domainName",
+              ],
+            },
+          ],
+          "Comment": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "CloudFront distribution for my-app ",
+                Object {
+                  "Ref": "Stage",
+                },
+              ],
+            ],
+          },
+          "DefaultCacheBehavior": Object {
+            "AllowedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "CachedMethods": Array [
+              "GET",
+              "HEAD",
+            ],
+            "Compress": true,
+            "ForwardedValues": Object {
+              "Cookies": Object {
+                "Forward": "none",
+              },
+              "QueryString": false,
+            },
+            "TargetOriginId": "origin1",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "ConnectionAttempts": 3,
+              "ConnectionTimeout": 10,
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "OriginBucketMyapp924B0FC3",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "origin1",
+              "OriginPath": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/my-app",
+                  ],
+                ],
+              },
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "CloudFrontOriginAccessIdentityMyapp936D2403",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "PriceClass": "PriceClass_100",
+          "ViewerCertificate": Object {
+            "AcmCertificateArn": Object {
+              "Ref": "CertificateMyappA1452439",
+            },
+            "SslSupportMethod": "sni-only",
+          },
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "my-app",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+  },
+}
+`;

--- a/src/constructs/static-site/__snapshots__/static-site.test.ts.snap
+++ b/src/constructs/static-site/__snapshots__/static-site.test.ts.snap
@@ -21,19 +21,16 @@ Object {
     },
   },
   "Outputs": Object {
-    "CloudFrontOAISite2": Object {
-      "Description": "Canonical user ID used by CloudFront distribution. This should be granted 's3:GetObject' access to S3 bucket 'site2-origin'.",
-      "Value": Object {
-        "Fn::GetAtt": Array [
-          "CloudFrontOriginAccessIdentitySite23746234B",
-          "S3CanonicalUserId",
-        ],
-      },
-    },
     "OriginBucketNameMyapp": Object {
       "Description": "S3 bucket origin for CloudFront.",
       "Value": Object {
         "Ref": "OriginBucketMyapp924B0FC3",
+      },
+    },
+    "OriginBucketNameSite2": Object {
+      "Description": "S3 bucket origin for CloudFront.",
+      "Value": Object {
+        "Ref": "OriginBucketSite255F13D42",
       },
     },
   },
@@ -327,6 +324,112 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
+    "OriginBucketSite255F13D42": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "Site2",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "OriginBucketSite2Policy507D57A2": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "OriginBucketSite255F13D42",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "CloudFrontOriginAccessIdentitySite23746234B",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "OriginBucketSite255F13D42",
+                        "Arn",
+                      ],
+                    },
+                    "/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/Site2/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "CloudFrontOriginAccessIdentitySite23746234B",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "OriginBucketSite255F13D42",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "Site1MyappCFDistribution297F4C3E": Object {
       "Properties": Object {
         "DistributionConfig": Object {
@@ -501,18 +604,9 @@ Object {
               "ConnectionAttempts": 3,
               "ConnectionTimeout": 10,
               "DomainName": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "site2-origin.s3.",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ".",
-                    Object {
-                      "Ref": "AWS::URLSuffix",
-                    },
-                  ],
+                "Fn::GetAtt": Array [
+                  "OriginBucketSite255F13D42",
+                  "RegionalDomainName",
                 ],
               },
               "Id": "origin1",

--- a/src/constructs/static-site/index.ts
+++ b/src/constructs/static-site/index.ts
@@ -1,0 +1,1 @@
+export * from "./static-site";

--- a/src/constructs/static-site/static-site.test.ts
+++ b/src/constructs/static-site/static-site.test.ts
@@ -164,53 +164,6 @@ describe("The GuStaticSite pattern", () => {
     });
   });
 
-  it("should work with a pre-existing bucket", () => {
-    const stack = simpleGuStackForTesting();
-    new GuStaticSite(stack, "StaticSite", {
-      ...defaultProps,
-      preExistingOriginBucketName: "i-already-exist",
-    });
-
-    expect(stack).not.toHaveResource("AWS::S3::Bucket");
-    expect(stack).not.toHaveResource("AWS::S3::BucketPolicy");
-
-    expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
-      DistributionConfig: {
-        Origins: [
-          {
-            DomainName: {
-              "Fn::Join": [
-                "",
-                [
-                  "i-already-exist.s3.",
-                  {
-                    Ref: "AWS::Region",
-                  },
-                  ".",
-                  {
-                    Ref: "AWS::URLSuffix",
-                  },
-                ],
-              ],
-            },
-            OriginPath: {
-              "Fn::Join": [
-                "",
-                [
-                  "/",
-                  {
-                    Ref: "Stage",
-                  },
-                  "/my-app",
-                ],
-              ],
-            },
-          },
-        ],
-      },
-    });
-  });
-
   it("should not create a CloudFormation Mapping when used in a GuStackForInfrastructure", () => {
     const stack = simpleGuStackForTesting();
     new GuStaticSite(stack, "StackSite", defaultProps);
@@ -239,7 +192,6 @@ describe("The GuStaticSite pattern", () => {
           domainName: "site2.gutools.co.uk",
         },
       },
-      preExistingOriginBucketName: "site2-origin",
     });
 
     expect(stack).toHaveGuTaggedResource("AWS::CloudFront::Distribution", { appIdentity: { app: defaultProps.app } });

--- a/src/constructs/static-site/static-site.test.ts
+++ b/src/constructs/static-site/static-site.test.ts
@@ -1,0 +1,250 @@
+import "@aws-cdk/assert/jest";
+import "../../utils/test/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { Stage, StageForInfrastructure } from "../../constants";
+import type { SynthedStack } from "../../utils/test";
+import { simpleGuStackForTesting, simpleInfraStackForTesting } from "../../utils/test";
+import type { GuStaticSiteProps } from "./static-site";
+import { GuStaticSite } from "./static-site";
+
+describe("The GuStaticSite pattern", () => {
+  const defaultProps: GuStaticSiteProps = {
+    app: "my-app",
+    domainNameProps: {
+      [Stage.CODE]: {
+        domainName: "my-app.dev-gutools.co.uk",
+      },
+      [Stage.PROD]: {
+        domainName: "my-app.gutools.co.uk",
+      },
+    },
+  };
+
+  it("should create the correct resources with minimal config", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "StaticSite", defaultProps);
+
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::S3::Bucket", /^OriginBucketMyapp.+$/);
+    expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+      DistributionConfig: {
+        Origins: [
+          {
+            DomainName: {
+              "Fn::GetAtt": ["OriginBucketMyapp924B0FC3", "RegionalDomainName"],
+            },
+            OriginPath: {
+              "Fn::Join": [
+                "",
+                [
+                  "/",
+                  {
+                    Ref: "Stage",
+                  },
+                  "/my-app",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::CertificateManager::Certificate", /^CertificateMyapp.+$/);
+    expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+      DistributionConfig: {
+        ViewerCertificate: {
+          AcmCertificateArn: {
+            Ref: "CertificateMyappA1452439",
+          },
+          SslSupportMethod: "sni-only",
+        },
+      },
+    });
+  });
+
+  it("should throw when attempting to use an ACM ARN with a hardcoded account id", () => {
+    const stack = simpleGuStackForTesting();
+
+    expect(() => {
+      new GuStaticSite(stack, "StaticSite", {
+        ...defaultProps,
+        preExistingCertificateArn: {
+          [Stage.CODE]: "arn:aws:acm:us-east-1:000000000000:certificate/abcde-01234-fghij-56789",
+          [Stage.PROD]: "arn:aws:acm:us-east-1:000000000000:certificate/01234-abcde-56789-fghij",
+        },
+      });
+    }).toThrowError(
+      "Account numbers are considered private information and should not be added to VCS. Use the `account` property on `GuStack` instead."
+    );
+  });
+
+  it("should throw when provided an ACM ARN outside of the us-east-1 region", () => {
+    const stack = simpleGuStackForTesting();
+
+    expect(() => {
+      new GuStaticSite(stack, "StaticSite", {
+        ...defaultProps,
+        preExistingCertificateArn: {
+          [Stage.CODE]: `arn:aws:acm:eu-west-1:${stack.account}:certificate/abcde-01234-fghij-56789`,
+          [Stage.PROD]: `arn:aws:acm:eu-west-1:${stack.account}:certificate/01234-abcde-56789-fghij`,
+        },
+      });
+    }).toThrowError("CloudFront requires ACM certificates from the us-east-1 region.");
+  });
+
+  it("should throw when provided an invalid ACM ARN", () => {
+    const stack = simpleInfraStackForTesting();
+
+    expect(() => {
+      new GuStaticSite(stack, "StaticSite", {
+        ...defaultProps,
+        preExistingCertificateArn: {
+          [StageForInfrastructure]: `arn:aws:acm:us-east-1:${stack.account}:tls/abcde-01234-fghij-56789`,
+        },
+      });
+    }).toThrowError("Invalid ARN for an ACM resource.");
+  });
+
+  it("should not create a new ACM certificate when a us-east-1 certificate ARN is provided", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "StaticSite", {
+      ...defaultProps,
+      preExistingCertificateArn: {
+        [Stage.CODE]: `arn:aws:acm:us-east-1:${stack.account}:certificate/abcde-01234-fghij-56789`,
+        [Stage.PROD]: `arn:aws:acm:us-east-1:${stack.account}:certificate/01234-abcde-56789-fghij`,
+      },
+    });
+
+    expect(stack).not.toHaveResource("AWS::CertificateManager::Certificate");
+
+    expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+      DistributionConfig: {
+        ViewerCertificate: {
+          AcmCertificateArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:acm:us-east-1:",
+                {
+                  Ref: "AWS::AccountId",
+                },
+                ":certificate/",
+                {
+                  "Fn::FindInMap": [
+                    "myapp",
+                    {
+                      Ref: "Stage",
+                    },
+                    "certificateResourceName",
+                  ],
+                },
+              ],
+            ],
+          },
+          SslSupportMethod: "sni-only",
+        },
+      },
+    });
+
+    const { Mappings } = SynthUtils.toCloudFormation(stack) as SynthedStack;
+
+    expect(Mappings).toMatchObject({
+      myapp: {
+        CODE: {
+          certificateResourceName: "abcde-01234-fghij-56789",
+          domainName: "my-app.dev-gutools.co.uk",
+        },
+        PROD: {
+          certificateResourceName: "01234-abcde-56789-fghij",
+          domainName: "my-app.gutools.co.uk",
+        },
+      },
+    });
+  });
+
+  it("should work with a pre-existing bucket", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "StaticSite", {
+      ...defaultProps,
+      preExistingOriginBucketName: "i-already-exist",
+    });
+
+    expect(stack).not.toHaveResource("AWS::S3::Bucket");
+    expect(stack).not.toHaveResource("AWS::S3::BucketPolicy");
+
+    expect(stack).toHaveResourceLike("AWS::CloudFront::Distribution", {
+      DistributionConfig: {
+        Origins: [
+          {
+            DomainName: {
+              "Fn::Join": [
+                "",
+                [
+                  "i-already-exist.s3.",
+                  {
+                    Ref: "AWS::Region",
+                  },
+                  ".",
+                  {
+                    Ref: "AWS::URLSuffix",
+                  },
+                ],
+              ],
+            },
+            OriginPath: {
+              "Fn::Join": [
+                "",
+                [
+                  "/",
+                  {
+                    Ref: "Stage",
+                  },
+                  "/my-app",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("should not create a CloudFormation Mapping when used in a GuStackForInfrastructure", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "StackSite", defaultProps);
+    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
+    expect(json.Mappings).toBeDefined();
+
+    const infraStack = simpleInfraStackForTesting();
+    new GuStaticSite(infraStack, "StackSite", {
+      ...defaultProps,
+      domainNameProps: { [StageForInfrastructure]: { domainName: "my-infra-app.gutools.co.uk" } },
+    });
+    const infraJson = SynthUtils.toCloudFormation(infraStack) as SynthedStack;
+    expect(infraJson.Mappings).toBeUndefined();
+  });
+
+  it("should be possible to define multiple in a single stack", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "Site1", defaultProps);
+    new GuStaticSite(stack, "Site2", {
+      app: "Site2",
+      domainNameProps: {
+        [Stage.CODE]: {
+          domainName: "site2.dev-gutools.co.uk",
+        },
+        [Stage.PROD]: {
+          domainName: "site2.gutools.co.uk",
+        },
+      },
+      preExistingOriginBucketName: "site2-origin",
+    });
+
+    expect(stack).toHaveGuTaggedResource("AWS::CloudFront::Distribution", { appIdentity: { app: defaultProps.app } });
+    expect(stack).toHaveGuTaggedResource("AWS::CloudFront::Distribution", { appIdentity: { app: "Site2" } });
+
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+});

--- a/src/constructs/static-site/static-site.test.ts
+++ b/src/constructs/static-site/static-site.test.ts
@@ -247,4 +247,10 @@ describe("The GuStaticSite pattern", () => {
 
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
+
+  it("should be possible to opt-out of DNS creation", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "Site1", { ...defaultProps, withoutDns: true });
+    expect(stack).toCountResources("Guardian::DNS::RecordSet", 0);
+  });
 });

--- a/src/constructs/static-site/static-site.test.ts
+++ b/src/constructs/static-site/static-site.test.ts
@@ -253,4 +253,12 @@ describe("The GuStaticSite pattern", () => {
     new GuStaticSite(stack, "Site1", { ...defaultProps, withoutDns: true });
     expect(stack).toCountResources("Guardian::DNS::RecordSet", 0);
   });
+
+  it("should be possible to create a deterministic bucket name", () => {
+    const stack = simpleGuStackForTesting();
+    new GuStaticSite(stack, "Site", { ...defaultProps, bucketName: "my-new-bucket" });
+    expect(stack).toHaveResourceLike("AWS::S3::Bucket", {
+      BucketName: "my-new-bucket",
+    });
+  });
 });

--- a/src/constructs/static-site/static-site.ts
+++ b/src/constructs/static-site/static-site.ts
@@ -67,6 +67,11 @@ export interface GuStaticSiteProps
    * This is useful if you want to control the TTL, which defaults to 1 hour.
    */
   withoutDns?: boolean;
+
+  /**
+   * Name of the bucket to create, otherwise the bucket name will be auto-generated.
+   */
+  bucketName?: string;
 }
 
 /**
@@ -208,12 +213,12 @@ export class GuStaticSite extends GuAppAwareConstruct(CloudFrontWebDistribution)
 
   private static getBucket(
     scope: GuStack,
-    { app, preExistingOriginBucketName }: GuStaticSiteProps,
+    { app, preExistingOriginBucketName, bucketName }: GuStaticSiteProps,
     { cloudFrontOriginAccessIdentityS3CanonicalUserId }: OriginAccessIdentity
   ) {
     const bucket = preExistingOriginBucketName
       ? Bucket.fromBucketName(scope, AppIdentity.suffixText({ app }, "OriginBucket"), preExistingOriginBucketName)
-      : new GuS3Bucket(scope, "OriginBucket", { app });
+      : new GuS3Bucket(scope, "OriginBucket", { app, bucketName });
 
     if (preExistingOriginBucketName) {
       /*

--- a/src/constructs/static-site/static-site.ts
+++ b/src/constructs/static-site/static-site.ts
@@ -61,6 +61,12 @@ export interface GuStaticSiteProps
    * Defaults to compress responses and redirect http to https.
    */
   behaviours?: Behavior[];
+
+  /**
+   * Flag to opt-out of automatically creating a [[ `GuCname` ]]. You'll have to create it yourself.
+   * This is useful if you want to control the TTL, which defaults to 1 hour.
+   */
+  withoutDns?: boolean;
 }
 
 /**
@@ -252,6 +258,7 @@ export class GuStaticSite extends GuAppAwareConstruct(CloudFrontWebDistribution)
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         },
       ],
+      withoutDns = false,
     } = props;
     const { stage } = scope;
 
@@ -298,11 +305,13 @@ export class GuStaticSite extends GuAppAwareConstruct(CloudFrontWebDistribution)
       ],
     });
 
-    new GuCname(scope, AppIdentity.suffixText({ app }, "DnsRecord"), {
-      app,
-      domainNameProps,
-      resourceRecord: this.distributionDomainName,
-      ttl: Duration.hours(1),
-    });
+    if (!withoutDns) {
+      new GuCname(scope, AppIdentity.suffixText({ app }, "DnsRecord"), {
+        app,
+        domainNameProps,
+        resourceRecord: this.distributionDomainName,
+        ttl: Duration.hours(1),
+      });
+    }
   }
 }

--- a/src/constructs/static-site/static-site.ts
+++ b/src/constructs/static-site/static-site.ts
@@ -1,0 +1,308 @@
+import { Certificate } from "@aws-cdk/aws-certificatemanager";
+import {
+  CloudFrontWebDistribution,
+  OriginAccessIdentity,
+  ViewerCertificate,
+  ViewerProtocolPolicy,
+} from "@aws-cdk/aws-cloudfront";
+import type { Behavior, CloudFrontWebDistributionProps } from "@aws-cdk/aws-cloudfront/lib/web-distribution";
+import { CanonicalUserPrincipal, PolicyStatement } from "@aws-cdk/aws-iam";
+import { Bucket } from "@aws-cdk/aws-s3";
+import { Annotations, Arn, ArnFormat, CfnOutput, Duration, Token } from "@aws-cdk/core";
+import { Stage } from "../../constants";
+import type { GuDomainNameProps } from "../../types/domain-names";
+import { StageAwareValue } from "../../types/stage";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
+import { GuCertificate } from "../acm";
+import type { GuStack } from "../core";
+import { AppIdentity } from "../core/identity";
+import { GuCname } from "../dns";
+import { GuS3Bucket } from "../s3";
+
+const GLOBAL_AWS_REGION = "us-east-1";
+const CLOUDFRONT_CERTIFICATE_REQUIREMENT_MESSAGE = `CloudFront requires ACM certificates from the ${GLOBAL_AWS_REGION} region.`;
+const ACM_ARN_RESOURCE = "certificate";
+
+export interface GuStaticSiteProps
+  extends Omit<CloudFrontWebDistributionProps, "originConfigs" | "comment" | "viewerCertificate">,
+    AppIdentity {
+  /**
+   * Domain the CloudFront distribution should be aliased as.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html#cfn-cloudfront-distribution-distributionconfig-aliases
+   */
+  domainNameProps: GuDomainNameProps;
+
+  /**
+   * ARN of a pre-existing ACM certificate to attach to CloudFront. It must:
+   *   - exist in the us-east-1 region
+   *   - not have a hard coded account number
+   *
+   * If not provided, a new certificate is created. Note, this means the stack must be deployed in the us-east-1 region.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-viewercertificate.html#cfn-cloudfront-distribution-viewercertificate-acmcertificatearn
+   */
+  preExistingCertificateArn?: StageAwareValue<string>;
+
+  /**
+   * Name of a pre-existing S3 bucket holding the contents of the static site.
+   *
+   * If provided, a CloudFormation Output is created for the `CanonicalUser` to grant `s3:GetObject` permissions to.
+   * If not provided, a CloudFormation Output of the bucket name is created.
+   *
+   * @see https://github.com/awsdocs/amazon-s3-userguide/blob/d9fa2605ba253b3ca6ca1a83da5fa6b0b9b6debb/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
+   *
+   */
+  preExistingOriginBucketName?: string;
+
+  /**
+   * Behaviours of the S3 bucket origin.
+   *
+   * Defaults to compress responses and redirect http to https.
+   */
+  behaviours?: Behavior[];
+}
+
+/**
+ * A construct to create a static site with an S3 bucket origin and a CloudFront distribution.
+ * A CNAME DNS record is also created.
+ *
+ * Expects a single S3 bucket to be shared by all stages. If your app is called `my-static-site`, the bucket should have the following layout:
+ *
+ * ```
+ * .
+ * ├── CODE
+ * │    └── my-static-site
+ * │        └── index.html
+ * └── PROD
+ *     └── my-static-site
+ *         └── index.html
+ * ```
+ *
+ * Or, more generally:
+ *
+ * ```
+ * .
+ * └── <STAGE>
+ *     └── <APP>
+ *         └── index.html
+ * ```
+ *
+ * Example usage, creating a new bucket:
+ *
+ * ```typescript
+ * new GuStaticSite(scope, "StaticSite", {
+ *   app: "my-static-site",
+ *   domainNameProps: {
+ *     CODE: {
+ *       domainName: "my-static-site.code.domain.co.uk",
+ *     },
+ *     PROD: {
+ *       domainName: "my-static-site.prod.domain.co.uk",
+ *     },
+ *   },
+ * });
+ * ```
+ *
+ * Example usage, using a pre-existing bucket and certificate:
+ *
+ * ```typescript
+ * new GuStaticSite(scope, "StaticSite", {
+ *   app: "my-static-site",
+ *   domainNameProps: {
+ *     CODE: {
+ *       domainName: "my-static-site.code.domain.co.uk",
+ *     },
+ *     PROD: {
+ *       domainName: "my-static-site.prod.domain.co.uk",
+ *     },
+ *   },
+ *   originBucketName: "my-static-site-origin",
+ *   certificateArn: {
+ *     CODE: `arn:aws:acm:us-east-1:${scope.account}:certificate/abcde-01234-fghij-56789`,
+ *     PROD: `arn:aws:acm:us-east-1:${scope.account}:certificate/01234-abcde-56789-fghij`,
+ *   }
+ * });
+ */
+export class GuStaticSite extends GuAppAwareConstruct(CloudFrontWebDistribution) {
+  /*
+   Validate an ACM ARN and return the resource name for later use in a CFN Mapping.
+   This is because a CFN Mapping cannot include the `AccountId` pseudo function.
+
+   @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-accountid
+   @see https://docs.aws.amazon.com/cdk/v2/guide/tokens.html
+    */
+  private static getResourceNameFromArn(certificateArn: string): string {
+    const { account, region, resource, resourceName } = Arn.split(certificateArn, ArnFormat.SLASH_RESOURCE_NAME);
+
+    if (!Token.isUnresolved(account)) {
+      throw new Error(
+        "Account numbers are considered private information and should not be added to VCS. Use the `account` property on `GuStack` instead."
+      );
+    }
+
+    if (region !== GLOBAL_AWS_REGION) {
+      throw new Error(CLOUDFRONT_CERTIFICATE_REQUIREMENT_MESSAGE);
+    }
+
+    if (resource !== ACM_ARN_RESOURCE || !resourceName) {
+      throw new Error("Invalid ARN for an ACM resource.");
+    }
+
+    return resourceName;
+  }
+
+  /*
+  CloudFront requires an ACM certificate from us-east-1 (the "global" region).
+  If a certificateArn has been provided in the props, validate it is from the global region, or throw.
+  Else, create a new certificate and show a reminder to deploy the template in the global region.
+
+  Once https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/523 ships, this dance should no longer be necessary.
+   */
+  private static getCertificate(
+    scope: GuStack,
+    { app, domainNameProps, preExistingCertificateArn }: GuStaticSiteProps
+  ) {
+    if (!preExistingCertificateArn) {
+      Annotations.of(scope).addInfo(
+        `Deploy this template in the ${GLOBAL_AWS_REGION} region as ${CLOUDFRONT_CERTIFICATE_REQUIREMENT_MESSAGE}`
+      );
+
+      return new GuCertificate(scope, {
+        app,
+        ...domainNameProps,
+      });
+    }
+
+    const resourceName = StageAwareValue.isStageValue(preExistingCertificateArn)
+      ? scope.withStageDependentValue({
+          app,
+          variableName: "certificateResourceName",
+          stageValues: {
+            [Stage.CODE]: GuStaticSite.getResourceNameFromArn(preExistingCertificateArn.CODE),
+            [Stage.PROD]: GuStaticSite.getResourceNameFromArn(preExistingCertificateArn.PROD),
+          },
+        })
+      : GuStaticSite.getResourceNameFromArn(preExistingCertificateArn.INFRA);
+
+    return Certificate.fromCertificateArn(
+      scope,
+      AppIdentity.suffixText({ app }, "Certificate"),
+      Arn.format({
+        partition: "aws",
+        service: "acm",
+        region: GLOBAL_AWS_REGION,
+        account: scope.account,
+        resource: ACM_ARN_RESOURCE,
+        resourceName,
+        arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+      })
+    );
+  }
+
+  private static getBucket(
+    scope: GuStack,
+    { app, preExistingOriginBucketName }: GuStaticSiteProps,
+    { cloudFrontOriginAccessIdentityS3CanonicalUserId }: OriginAccessIdentity
+  ) {
+    const bucket = preExistingOriginBucketName
+      ? Bucket.fromBucketName(scope, AppIdentity.suffixText({ app }, "OriginBucket"), preExistingOriginBucketName)
+      : new GuS3Bucket(scope, "OriginBucket", { app });
+
+    if (preExistingOriginBucketName) {
+      /*
+      We can only update a bucket's policy if the bucket is created in the same stack.
+      If the bucket has been created externally, produce a CloudFormation Output to ease.
+
+      @see https://github.com/awsdocs/amazon-s3-userguide/blob/d9fa2605ba253b3ca6ca1a83da5fa6b0b9b6debb/doc_source/s3-bucket-user-policy-specifying-principal-intro.md
+       */
+      new CfnOutput(scope, AppIdentity.suffixText({ app }, "CloudFrontOAI"), {
+        description: `Canonical user ID used by CloudFront distribution. This should be granted 's3:GetObject' access to S3 bucket '${preExistingOriginBucketName}'.`,
+        value: cloudFrontOriginAccessIdentityS3CanonicalUserId,
+      });
+      Annotations.of(scope).addWarning(
+        `Origin bucket not managed by this stack. Grant 's3:GetObject' permission on ${preExistingOriginBucketName} to the principal listed as an Output on this stack. See https://github.com/awsdocs/amazon-s3-userguide/blob/d9fa2605ba253b3ca6ca1a83da5fa6b0b9b6debb/doc_source/s3-bucket-user-policy-specifying-principal-intro.md.`
+      );
+    } else {
+      bucket.addToResourcePolicy(
+        new PolicyStatement({
+          actions: ["s3:GetObject"],
+          resources: [bucket.arnForObjects(`${scope.stage}/${app}/*`)],
+          principals: [new CanonicalUserPrincipal(cloudFrontOriginAccessIdentityS3CanonicalUserId)],
+        })
+      );
+
+      new CfnOutput(scope, AppIdentity.suffixText({ app }, "OriginBucketName"), {
+        description: "S3 bucket origin for CloudFront.",
+        value: bucket.bucketName,
+      });
+    }
+
+    return bucket;
+  }
+
+  constructor(scope: GuStack, id: string, props: GuStaticSiteProps) {
+    const {
+      app,
+      domainNameProps,
+      behaviours = [
+        {
+          compress: true,
+          isDefaultBehavior: true,
+          viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        },
+      ],
+    } = props;
+    const { stage } = scope;
+
+    const certificate = GuStaticSite.getCertificate(scope, props);
+
+    const domainName = StageAwareValue.isStageValue(domainNameProps)
+      ? scope.withStageDependentValue({
+          app,
+          variableName: GuCertificate.mappingVariableName,
+          stageValues: {
+            [Stage.CODE]: domainNameProps.CODE.domainName,
+            [Stage.PROD]: domainNameProps.PROD.domainName,
+          },
+        })
+      : domainNameProps.INFRA.domainName;
+
+    const viewerCertificate = ViewerCertificate.fromAcmCertificate(certificate, {
+      aliases: [domainName],
+    });
+
+    const originAccessIdentity = new OriginAccessIdentity(
+      scope,
+      AppIdentity.suffixText({ app }, "CloudFrontOriginAccessIdentity"),
+      {
+        comment: `Origin Access Identity for ${app} ${stage}`,
+      }
+    );
+
+    const s3Bucket = GuStaticSite.getBucket(scope, props, originAccessIdentity);
+
+    super(scope, id, {
+      ...props,
+      comment: `CloudFront distribution for ${app} ${stage}`,
+      viewerCertificate,
+      originConfigs: [
+        {
+          s3OriginSource: {
+            s3BucketSource: s3Bucket,
+            originAccessIdentity,
+            originPath: `/${stage}/${app}`,
+          },
+          behaviors: behaviours,
+        },
+      ],
+    });
+
+    new GuCname(scope, AppIdentity.suffixText({ app }, "DnsRecord"), {
+      app,
+      domainNameProps,
+      resourceRecord: this.distributionDomainName,
+      ttl: Duration.hours(1),
+    });
+  }
+}


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds a new construct `GuStaticSite` to produce a static site hosted by CloudFront with an S3 origin, creating the "Using a REST API endpoint as the origin, with access restricted by an OAI" layout described [here](https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-serve-static-website/).

There are few nuances with this setup, which this construct codifies:
  - An ACM certificate for a CloudFront distribution must be in the `us-east-1` region (until https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/523 ships)
  - Account numbers are considered private and should not be added to VCS
  - Riff-Raff's `aws-s3` type can only upload to a single bucket and will shard the bucket by `stage`. That is, CloudFront's origin path should not be the root of the bucket. 

The construct supports use of a pre-existing bucket and a pre-existing ACM certificate.

Example usage:

```typescript
new GuStaticSite(scope, "StaticSite", {
  app: "my-static-site",
  domainNameProps: {
    CODE: {
      domainName: "my-static-site.code.domain.co.uk",
    },
    PROD: {
      domainName: "my-static-site.prod.domain.co.uk",
    },
  },
});
```

Example usage, using a pre-existing ACM certificate:

```typescript
new GuStaticSite(scope, "StaticSite", {
  app: "my-static-site",
  domainNameProps: {
    CODE: {
      domainName: "my-static-site.code.domain.co.uk",
    },
    PROD: {
      domainName: "my-static-site.prod.domain.co.uk",
    },
  },
  certificateArn: {
    CODE: `arn:aws:acm:us-east-1:${scope.account}:certificate/abcde-01234-fghij-56789`,
    PROD: `arn:aws:acm:us-east-1:${scope.account}:certificate/01234-abcde-56789-fghij`,
  }
});
```

Example usage, using a pre-existing S3 bucket:

```typescript
new GuStaticSite(scope, "StaticSite", {
  app: "my-static-site",
  domainNameProps: {
    CODE: {
      domainName: "my-static-site.code.domain.co.uk",
    },
    PROD: {
      domainName: "my-static-site.prod.domain.co.uk",
    },
  },
  originBucketName: "my-static-site-origin",
});
```

In this instance, the bucket's policy needs to be updated separately to grant `s3:GetObject` permission to the CloudFront Origin Access Identity - the canonical user id is added as a CloudFormation Output for use like so:

```json
{
  "Effect": "Allow",
  "Action": "s3:GetObject"
  "Principal": { 
    "CanonicalUser": "64-digit-alphanumeric-value"
  },
  "Resource": "arn:aws:s3:::my-static-site-origin/*"
}
```

See also https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added tests and https://github.com/guardian/cdk-static-site/blob/main/cdk/lib/static-site.ts for a real demo.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Creation of static sites is simpler.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

This construct assumes DNS is managed outside of Route53.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
