### PR TITLE
fix!: Make S3 buckets follow best practices

### DIFF
--- a/src/constructs/s3/__snapshots__/index.test.ts.snap
+++ b/src/constructs/s3/__snapshots__/index.test.ts.snap
@@ -18,6 +18,12 @@ Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketName": "super-important-stuff",
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
         "Tags": Array [
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/s3/__snapshots__/index.test.ts.snap
+++ b/src/constructs/s3/__snapshots__/index.test.ts.snap
@@ -14,7 +14,7 @@ Object {
     },
   },
   "Resources": Object {
-    "MyBucketF68F3FF0": Object {
+    "MyBucketTest262E966E": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "BucketName": "super-important-stuff",
@@ -25,6 +25,10 @@ Object {
           "RestrictPublicBuckets": true,
         },
         "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "test",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/constructs/s3/index.test.ts
+++ b/src/constructs/s3/index.test.ts
@@ -1,3 +1,4 @@
+import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuS3Bucket } from "./index";
@@ -8,10 +9,40 @@ describe("The GuS3Bucket construct", () => {
 
     new GuS3Bucket(stack, "MyBucket", {
       bucketName: "super-important-stuff",
+      app: "test",
     });
 
     // The policies are siblings of Properties.
     // The `.toHaveResource` matcher cannot be used as it only looks at Properties.
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  });
+
+  it("should be possible to override the logical id", () => {
+    const stack = simpleGuStackForTesting({ migratedFromCloudFormation: true });
+
+    new GuS3Bucket(stack, "MyBucket", {
+      bucketName: "data-bucket",
+      app: "test",
+      existingLogicalId: {
+        logicalId: "DataBucket",
+        reason: "Unit tests",
+      },
+    });
+
+    expect(stack).toHaveResourceOfTypeAndLogicalId("AWS::S3::Bucket", "DataBucket");
+  });
+
+  it("should receive the correct set of tags", () => {
+    const stack = simpleGuStackForTesting();
+    const app = "test";
+
+    new GuS3Bucket(stack, "MyBucket", {
+      bucketName: "super-important-stuff",
+      app,
+    });
+
+    expect(stack).toHaveGuTaggedResource("AWS::S3::Bucket", {
+      appIdentity: { app },
+    });
   });
 });

--- a/src/constructs/s3/index.ts
+++ b/src/constructs/s3/index.ts
@@ -2,16 +2,18 @@ import type { BucketProps } from "@aws-cdk/aws-s3";
 import { BlockPublicAccess, Bucket } from "@aws-cdk/aws-s3";
 import { RemovalPolicy } from "@aws-cdk/core";
 import { GuMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
+import type { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-export interface GuS3BucketProps extends GuMigratingResource, Omit<BucketProps, "removalPolicy"> {}
+export interface GuS3BucketProps extends GuMigratingResource, Omit<BucketProps, "removalPolicy">, AppIdentity {}
 
 /**
  * A construct to create a bucket with a "retain" policy to prevent it from being deleted. It will be orphaned instead.
  */
-export class GuS3Bucket extends GuMigratableConstruct(Bucket) {
-  constructor(scope: GuStack, id: string, props?: GuS3BucketProps) {
+export class GuS3Bucket extends GuMigratableConstruct(GuAppAwareConstruct(Bucket)) {
+  constructor(scope: GuStack, id: string, props: GuS3BucketProps) {
     super(scope, id, {
       removalPolicy: RemovalPolicy.RETAIN,
       publicReadAccess: false,

--- a/src/constructs/s3/index.ts
+++ b/src/constructs/s3/index.ts
@@ -1,5 +1,5 @@
 import type { BucketProps } from "@aws-cdk/aws-s3";
-import { Bucket } from "@aws-cdk/aws-s3";
+import { BlockPublicAccess, Bucket } from "@aws-cdk/aws-s3";
 import { RemovalPolicy } from "@aws-cdk/core";
 import { GuMigratableConstruct } from "../../utils/mixin";
 import type { GuStack } from "../core";
@@ -11,7 +11,12 @@ export interface GuS3BucketProps extends GuMigratingResource, Omit<BucketProps, 
  * A construct to create a bucket with a "retain" policy to prevent it from being deleted. It will be orphaned instead.
  */
 export class GuS3Bucket extends GuMigratableConstruct(Bucket) {
-  constructor(scope: GuStack, id: string, props: GuS3BucketProps) {
-    super(scope, id, { ...props, removalPolicy: RemovalPolicy.RETAIN });
+  constructor(scope: GuStack, id: string, props?: GuS3BucketProps) {
+    super(scope, id, {
+      removalPolicy: RemovalPolicy.RETAIN,
+      publicReadAccess: false,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      ...props,
+    });
   }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Updates `GuS3Bucket` to be private by default and also become app aware, which results in the bucket receiving the `App` tag.

BREAKING CHANGE: The `app` prop for a `GuS3Bucket` is now required.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added tests.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Buckets follow best practice by default.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

By becoming app aware, the auto generated logical id changes. This results in resource replacement 😱 ! [Usage](https://github.com/search?q=org%3Aguardian+GuS3Bucket&type=code) of this construct isn't very big and those stacks that are using it are also preserving a logical id from a previously YAML defined stack.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
