### PR TITLE
revert: "chore: Forgo keeping `version` in `package.json` up to date"

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,3 +18,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./script/cd
+
+      # Only performed if `main` is updated
+      # See https://docs.github.com/en/actions/reference/environment-variables#determining-when-to-use-default-environment-variables-or-contexts
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        name: post-release
+        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
+        with:
+          # This action will raise a PR to edit package.json.
+          # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI,
+          # so we need to provide a different token.
+          # This is a PAT for the guardian-ci user.
+          # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+          github-token: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
+          npm-lockfile-version: 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,12 @@ jobs:
         with:
           cache: npm
       - run: ./script/ci
+  approve-and-merge:
+    runs-on: ubuntu-latest
+    needs: [CI]
+    steps:
+      - name: Validate, approve and merge release PRs
+        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-lockfile-version: 2

--- a/README.md
+++ b/README.md
@@ -136,10 +136,8 @@ To release a new version:
 1. Once reviewed and approved, merge your PR.
 1. Wait for the robots to:
    - Use your structured commit to automatically determine the next version number (following [semantic versioning][sem-ver]).
-   - Release a new version to [npm].
+   - Release a new version to npm and update `package.json`.
 1. Enjoy a comment on your PR to inform you that your change has been released.
-
-Note: The version number in `package.json` is static. Refer to [npm] or [releases] for the latest version number.
 
 For more information, see the docs on [testing][docs-testing].
 
@@ -163,7 +161,5 @@ For more information, see the docs on [testing][docs-testing].
 [github-scripts]: https://github.com/github/scripts-to-rule-them-all
 [guardian/actions-merge-release-changes-to-protected-branch]: https://github.com/guardian/actions-merge-release-changes-to-protected-branch
 [karma-commits]: http://karma-runner.github.io/6.1/dev/git-commit-msg.html
-[npm]: https://www.npmjs.com/package/@guardian/cdk
-[releases]: https://github.com/guardian/cdk/releases
 [semantic-release]: https://github.com/semantic-release/semantic-release
 [sem-ver]: https://semver.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/cdk",
-  "version": "32.1.0",
+  "version": "33.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/cdk",
-      "version": "32.1.0",
+      "version": "33.0.0",
       "dependencies": {
         "@aws-cdk/assert": "1.137.0",
         "@aws-cdk/aws-apigateway": "1.137.0",
@@ -18097,6 +18097,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -31403,7 +31404,8 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yargs": {
       "version": "17.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/cdk",
-  "version": "0.0.0",
+  "version": "32.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/cdk",
-      "version": "0.0.0",
+      "version": "32.1.0",
       "dependencies": {
         "@aws-cdk/assert": "1.137.0",
         "@aws-cdk/aws-apigateway": "1.137.0",
@@ -18097,7 +18097,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -31404,8 +31403,7 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/cdk",
   "description": "Generic Guardian flavoured AWS CDK components",
-  "version": "32.1.0",
+  "version": "33.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/cdk",
   "description": "Generic Guardian flavoured AWS CDK components",
-  "version": "0.0.0",
+  "version": "32.1.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
This PR reverts https://github.com/guardian/cdk/pull/1006. Although we don't need the version number in `package.json` for releasing, it is [used by `LibraryInfo`](https://github.com/guardian/cdk/blob/a33a14bd05528a202c47208b1a6d930e95a36f0f/src/constants/library-info.ts#L8-L31), so I think it's worth reinstating this.
