### PR TITLE
test: run project generation after every release

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,3 +32,8 @@ jobs:
           # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           github-token: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
           npm-lockfile-version: 2
+
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        name: run-project-generation
+        # This ensures that the newly released version of the library can still be used to generate a new project from scratch
+        run: npx @guardian/cdk@latest new --stack my-stack --app my-app


### PR DESCRIPTION
## What does this change?

In the past, the project generation tooling (which previously lived in https://github.com/guardian/cdk-cli) frequently became out of date. We recently migrated this code into the same repository as the constructs/patterns (see https://github.com/guardian/cdk/pull/962 and https://github.com/guardian/cdk/pull/971) and started automatically using the latest `cdk` libraries in all newly generated projects (https://github.com/guardian/cdk/pull/1028).

This PR checks that the project generation tooling still works after every release. 

## How to test

I've confirmed that this command will run successfully in GitHub Actions (via a [workflow run](https://github.com/jacobwinch/post-release-testing/runs/4726003628?check_suite_focus=true) in another repository).

## How can we measure success?

By running this command after every release we should notice more quickly if the project generation tooling is broken by changes to the constructs/patterns that it uses.

## Have we considered potential risks?

We will only catch failures related to project generation tooling _after_ the library has been released, so we'll need to be ready to rollback/fix forwards in case of problems. 

If this ends up happening regularly, we may want to consider completing the work to perform this check at CI time (i.e. before release) instead. I've avoided this for now as the work is more complex and it will have an impact on CI performance for every PR.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1] N/A
- [x] I have updated the documentation as required for the described changes [^2] N/A

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
