### PR TITLE
revert: "test: run project generation after every release"

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,8 +32,3 @@ jobs:
           # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           github-token: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
           npm-lockfile-version: 2
-
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        name: run-project-generation
-        # This ensures that the newly released version of the library can still be used to generate a new project from scratch
-        run: npx @guardian/cdk@latest new --stack my-stack --app my-app


### PR DESCRIPTION
This reverts commit eca07f386fe78cd5d43dbb1398342813a9d20e91 as it is [causing the CD workflow to fail](https://github.com/guardian/cdk/runs/4761287199?check_suite_focus=true).

I'll attempt this again when I understand the problem.