### PR TITLE
Add stage refactoring POC

### DIFF
--- a/src/constructs/core/stage.test.ts
+++ b/src/constructs/core/stage.test.ts
@@ -1,0 +1,101 @@
+import "@aws-cdk/assert/jest";
+
+import "../../utils/test/jest";
+import { SynthUtils } from "@aws-cdk/assert";
+import { App, CfnMapping } from "@aws-cdk/core";
+import { GuStack } from "./stack";
+import type { Stage } from "./stage";
+import { GuCertificateExample, NewStageMapping } from "./stage";
+
+describe("Stage refactor (POC)", () => {
+  it("should output a mapping as expected", () => {
+    const stack = new GuStack(new App(), "Test", { stack: "test" });
+
+    const mappings = NewStageMapping(new CfnMapping(stack, "foo"));
+    const domainName = mappings.set("domainName", stack.stage as Stage, {
+      CODE: "foo.example.com",
+      PROD: "prod.example.com",
+    });
+
+    new GuCertificateExample(stack, {
+      app: "foo",
+      domainName: domainName,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- ignore
+    const json = SynthUtils.toCloudFormation(stack);
+
+    console.log(JSON.stringify(json, null, 4));
+
+    /** Yields...
+
+    {
+        "Parameters": {
+            "Stage": {
+                "Type": "String",
+                "Default": "CODE",
+                "AllowedValues": [
+                    "CODE",
+                    "PROD"
+                ],
+                "Description": "Stage name"
+            }
+        },
+        "Mappings": {
+            "foo": {
+                "CODE": {
+                    "domainName": "foo.example.com"
+                },
+                "PROD": {
+                    "domainName": "prod.example.com"
+                }
+            }
+        },
+        "Resources": {
+            "CertificateFoo8CD0D22E": {
+                "Type": "AWS::CertificateManager::Certificate",
+                "Properties": {
+                    "DomainName": {
+                        "Fn::FindInMap": [
+                            "foo",
+                            {
+                                "Ref": "Stage"
+                            },
+                            "domainName"
+                        ]
+                    },
+                    "Tags": [
+                        {
+                            "Key": "App",
+                            "Value": "foo"
+                        },
+                        {
+                            "Key": "gu:cdk:version",
+                            "Value": "TEST"
+                        },
+                        {
+                            "Key": "gu:repo",
+                            "Value": "guardian/cdk"
+                        },
+                        {
+                            "Key": "Stack",
+                            "Value": "test"
+                        },
+                        {
+                            "Key": "Stage",
+                            "Value": {
+                                "Ref": "Stage"
+                            }
+                        }
+                    ],
+                    "ValidationMethod": "DNS"
+                },
+                "UpdateReplacePolicy": "Retain",
+                "DeletionPolicy": "Retain"
+            }
+        }
+    }
+
+     */
+  });
+});

--- a/src/constructs/core/stage.ts
+++ b/src/constructs/core/stage.ts
@@ -1,0 +1,70 @@
+import { Certificate, CertificateValidation } from "@aws-cdk/aws-certificatemanager";
+import type { CertificateProps } from "@aws-cdk/aws-certificatemanager/lib/certificate";
+import { HostedZone } from "@aws-cdk/aws-route53";
+import type { CfnMapping } from "@aws-cdk/core";
+import { RemovalPolicy } from "@aws-cdk/core";
+import { GuStatefulMigratableConstruct } from "../../utils/mixin";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
+import type { GuStack } from "../core";
+import { AppIdentity } from "../core/identity";
+import type { GuMigratingResource } from "../core/migrating";
+
+export type Stage = "CODE" | "PROD";
+
+type StageProp<A> = {
+  CODE: A;
+  PROD: A;
+};
+
+type GuStageMapping = {
+  set<A>(name: string, currentStage: Stage, values: StageProp<A>): string;
+};
+
+/**
+ * NewStageMapping is a wrapper for a Cloudformation mapping
+ *
+ * Use this to parameterise values by stage. Note, this assumes that you only
+ * have two stages, 'CODE' and 'PROD'. Create your own mapping logic if you have
+ * special requirements.
+ */
+export const NewStageMapping = (mapping: CfnMapping): GuStageMapping => {
+  return {
+    set<A>(name: string, currentStage: Stage, values: StageProp<A>): string {
+      for (const [stage, value] of Object.entries(values)) {
+        mapping.setValue(stage, name, value);
+      }
+
+      return mapping.findInMap(currentStage, name);
+    },
+  };
+};
+
+// -------- Example stack + construct below...
+
+export interface GuDomainNameProps {
+  domainName: string;
+  hostedZoneId?: string;
+}
+
+type GuCertificatePropsWithApp = GuDomainNameProps & AppIdentity & GuMigratingResource;
+
+export class GuCertificateExample extends GuStatefulMigratableConstruct(GuAppAwareConstruct(Certificate)) {
+  constructor(scope: GuStack, props: GuCertificatePropsWithApp) {
+    const maybeHostedZone = !props.hostedZoneId
+      ? undefined
+      : HostedZone.fromHostedZoneId(
+          scope,
+          AppIdentity.suffixText({ app: props.app }, "HostedZone"),
+          props.hostedZoneId
+        );
+
+    const awsCertificateProps: CertificateProps & GuMigratingResource & AppIdentity = {
+      domainName: props.domainName,
+      validation: CertificateValidation.fromDns(maybeHostedZone),
+      existingLogicalId: props.existingLogicalId,
+      app: props.app,
+    };
+    super(scope, "Certificate", awsCertificateProps);
+    this.applyRemovalPolicy(RemovalPolicy.RETAIN);
+  }
+}


### PR DESCRIPTION
(Re. discussion https://github.com/guardian/cdk/pull/1048 and also in chat.)

POC of a new approach to stage-handling for props. To illustrate I have added some basic helper code and an example test stack (with output). The GuCertificate construct was duplicated. You can see the existing construct [here](https://github.com/guardian/cdk/blob/ce51d80e5f294c1df70acc81ca1cb537bbb44666/src/constructs/acm/certificate.ts) though and note, in particular, the stage handling, which is quite verbose and complicated. E.g. things like:

```
    const maybeHostedZone = !hasHostedZoneId
      ? undefined
      : HostedZone.fromHostedZoneId(
          scope,
          /* eslint-disable @typescript-eslint/no-non-null-assertion -- `hasHostedZoneId` is true, so we know `hostedZoneId` is present here */
          AppIdentity.suffixText({ app: props.app }, "HostedZone"),
          StageAwareValue.isStageValue(props)
            ? scope.withStageDependentValue({
                app: props.app,
                variableName: "hostedZoneId",
                stageValues: {
                  [Stage.CODE]: props.CODE.hostedZoneId!,
                  [Stage.PROD]: props.PROD.hostedZoneId!,
                },
              })
            : props.INFRA.hostedZoneId!
          /* eslint-enable @typescript-eslint/no-non-null-assertion */
        );
```

which now becomes simply:

```
    const maybeHostedZone = !props.hostedZoneId
      ? undefined
      : HostedZone.fromHostedZoneId(
          scope,
          AppIdentity.suffixText({ app: props.app }, "HostedZone"),
          props.hostedZoneId
        );
```

(Certificate has just 2 of these kinds of stage-aware props, but you can imagine that our more complicated constructs have several.)

For rationale see below. 

---

The main aim was to make constructs and patterns ignorant of stages. This achieves a few things:

* keeps them simple (LOC and also readability/complexity)
* ensures our codebase can handle unusual stage requirements  without significant refactoring
* simplifies the INFRA case (it requires no special code at all)
* makes it easier to e.g. use `cdk deploy` in the future

The downside is that constructs become less opinionated on which props should be stage-specific. Generally, I think this is fine, but there might be cases where e.g. if one prop is customised by stage we would like to ensure another (related) prop is too.

