### PR TITLE
chore(ci): Upgrade to minor version of aws-cdk deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release": "semantic-release",
     "release:docs": "rm -rf target && typedoc && gh-pages -d target -u \"github-actions-bot <support+actions@github.com>\"",
     "serve:docs": "rm -rf target && typedoc && serve target",
-    "update-aws-cdk": "ncu \"/^@?aws-cdk(/.*)?$/\" --upgrade --deep",
+    "update-aws-cdk": "ncu \"/^@?aws-cdk(/.*)?$/\" --upgrade --deep --target minor",
     "cli:dev": "ts-node src/bin/index.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Add the [`target` flag](https://github.com/raineorshine/npm-check-updates#how-dependency-updates-are-determined) to `ncu` to ensure we stay on v1 of aws-cdk libraries. Otherwise v2 might be used, which we're not compatible with (yet!).

This will fail the `check-aws-cdk` build step. I propose we:
  - Remove the requirement for `check-aws-cdk` to pass
  - Merge this
  - Raise and merge a PR to update aws-cdk deps
  - Enable the requirement for `check-aws-cdk` to pass
  - Rebase existing PRs