### PR TITLE
chore(ci): Use GH's setup-node Action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: guardian/actions-setup-node@v2.4.1
+      - uses: actions/setup-node@v2
         with:
+          node-version-file: '.nvmrc'
           cache: npm
       - name: CD
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: guardian/actions-setup-node@v2.4.1
+      - uses: actions/setup-node@v2
         with:
+          node-version-file: '.nvmrc'
           cache: npm
       - run: ./script/ci
   approve-and-merge:


### PR DESCRIPTION
Since https://github.com/actions/setup-node/pull/338, GH's setup-node Action understands `.nvmrc` files. This makes our [`guardian/actions-setup-node`](https://github.com/guardian/actions-setup-node) fork somewhat redundant now.

Move to GH's Action so we can deprecate our fork.

# How to test

CI should pass. The build log should also suggest the correct node version is used too.