### PR TITLE
fix: Align UnhealthyInstance alarm period with underlying metric period

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -495,7 +495,7 @@ Object {
           ],
         },
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
-        "DatapointsToAlarm": 6,
+        "DatapointsToAlarm": 30,
         "Dimensions": Array [
           Object {
             "Name": "LoadBalancer",
@@ -558,10 +558,10 @@ Object {
             },
           },
         ],
-        "EvaluationPeriods": 12,
+        "EvaluationPeriods": 60,
         "MetricName": "UnHealthyHostCount",
         "Namespace": "AWS/ApplicationELB",
-        "Period": 300,
+        "Period": 60,
         "Statistic": "Maximum",
         "Threshold": 1,
         "TreatMissingData": "notBreaching",

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -63,8 +63,8 @@ export class GuUnhealthyInstancesAlarm extends GuAlarm {
   constructor(scope: GuStack, props: GuUnhealthyInstancesAlarmProps) {
     const alarmName = `Unhealthy instances for ${props.app} in ${scope.stage}`;
 
-    const period = Duration.minutes(5);
-    const evaluationPeriods = 12;
+    const period = Duration.minutes(1);
+    const evaluationPeriods = 60;
     const evaluationInterval = Duration.minutes(period.toMinutes() * evaluationPeriods).toHumanString();
 
     const alarmDescription = `${props.app}'s instances have failed healthchecks several times over the last ${evaluationInterval}.
@@ -80,7 +80,7 @@ export class GuUnhealthyInstancesAlarm extends GuAlarm {
       treatMissingData: TreatMissingData.NOT_BREACHING,
       threshold: 1,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      datapointsToAlarm: 6,
+      datapointsToAlarm: 30,
       evaluationPeriods,
     };
     super(scope, AppIdentity.suffixText(props, "UnhealthyInstancesAlarm"), alarmProps);


### PR DESCRIPTION
`GuUnhealthyInstancesAlarm` is built on top of the `UnHealthyHostCount` metric, which is measured by the Load Balancer and posted in 60-second intervals. The alarm however, has a period of 5 minutes, which can have unintended consequences.

Let's consider an example data set, where the number of unhealthy instances is always zero except at `10:07` and `10:08`

```
___________
|10:00 | 0 |
|10:01 | 0 |
|10:02 | 0 |
|10:03 | 0 |
|10:04 | 0 |
|10:05 | 0 |
|10:06 | 0 |
|10:07 | 1 |
|10:08 | 1 |
|10:09 | 0 |
(etc.)
-----------
```

`GuUnhealthyInstancesAlarm` has a period of 5 minutes and evaluates 12 datapoints, which means it looks back at the past hour of data and aggregates it into 12 equally spaced buckets. When the alarm is evaluated at `11:02`, the resulting set of datapoints is

```
___________
|10:02 | 0 |
|10:07 | 1 |
|10:12 | 0 |
|10:17 | 0 |
(etc.)
-----------
```
Where only 1 datapoint is above 0. The two values of 1 fell into the same bucket. However, when it is evaluates at `11:03`, the result is

```
___________
|10:03 | 1 |
|10:08 | 1 |
|10:12 | 0 |
|10:17 | 0 |
(etc.)
-----------
```

Where now 2 datapoints are above 0. The two values of 1 fell into different buckets.

The rolling window nature of the evaluation makes the results of this aggregation operation unstable. Out in the field, the behaviour is that an alarm can go into the ALARM state one minute, only to then go into an OK state the next even though it hasn't really recovered yet.

![Untitled_document_-_Google_Docs](https://user-images.githubusercontent.com/1672034/151413091-6aa533c5-6c55-4cba-852d-92c3f47cb637.png)


 This is such counter intuitive behaviour, AWS added a little question mark to this UI that explains this

![Untitled_document_-_Google_Docs](https://user-images.githubusercontent.com/1672034/151413376-d9683cce-1165-4390-b572-274c3426444d.png)

## What does this change?
This changes the period of `GuUnhealthyInstancesAlarm` to be one minute instead. This aligns the alarm with the metric, and creates more deterministic alarm conditions. The number of datapoints above or below the threshold is always the same from the point it it first enters the system, until it leaves the time window considered by the alarm.

![CloudWatch_Management_Console](https://user-images.githubusercontent.com/1672034/151414549-35dfcc7d-c379-40af-b6ad-d61d2bc04370.png)

This does however change the alarm condition substantially. The direct mathematical equivalent is 30 datapoints out of 60, which means 30 minutes of unhealthy instances in an hour. With the period of 5 minutes, 6 minutes of unhealthy instances if spread out right could be sufficient to trigger an alarm.

@jacobwinch this alarm was introduced in #594, can you see a sensible alarm threshold based on a 1 minute period? I'm not sure what to propose here, I'm lacking the sensibility for what an episode of instances cycling looks like. I was able to trigger the alarm before by deploying prism 4 or 5 times in a row, now it needs to be like 9 or 10.

## How to test
I've been testing these alarm parameters in prism CODE.


## How can we measure success?
No more false alarms and false alarm recoveries!

## Have we considered potential risks?
Cloudwatch alarms are very easy to get wrong and might have unintended consequences. The alarm can arrive/earlier later than expected, generate noise or false alarms.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
