### PR TITLE
fix: Enforce a CNAME DNS entry has a single answer

### DIFF
--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -28,6 +28,21 @@ describe("The GuDnsRecordSet construct", () => {
     });
     expect(stack).toHaveResourceOfTypeAndLogicalId("Guardian::DNS::RecordSet", "ThisExactLogicalId");
   });
+
+  it("should throw if a CNAME is created with multiple answers", () => {
+    const stack = simpleGuStackForTesting();
+
+    expect(() => {
+      new GuDnsRecordSet(stack, "ThisExactLogicalId", {
+        name: "banana.example.com",
+        recordType: RecordType.CNAME,
+        resourceRecords: ["apple.example.com", "banana.example.com"],
+        ttl: Duration.hours(1),
+      });
+    }).toThrowError(
+      "According to RFC, a CNAME record should not return multiple answers. Doing so may cause problems during resolution."
+    );
+  });
 });
 
 describe("The GuCname construct", () => {

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -26,16 +26,37 @@ export interface GuDnsRecordSetProps {
  */
 export class GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuDnsRecordSetProps) {
+    const { name, recordType, resourceRecords, ttl } = props;
+    const { stage } = scope;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- more `RecordType`s will be added soon!
+    if (recordType === RecordType.CNAME) {
+      /*
+      If you try to create a CNAME with multiple records within NS1, you are greeted with:
+
+        According to RFC, a CNAME record should not return multiple answers.
+        Doing so may cause problems during resolution.
+        If you want to use multiple answers, you should ensure you have the correct filters in place (such as SELECT_FIRST_N 1) to limit them to a single answer at resolution time.
+
+      `Guardian::DNS::RecordSet` does not implement "correct filters", so fail fast by throwing.
+       */
+      if (resourceRecords.length !== 1) {
+        throw new Error(
+          "According to RFC, a CNAME record should not return multiple answers. Doing so may cause problems during resolution."
+        );
+      }
+    }
+
     // The spec for this private resource type can be found here:
     // https://github.com/guardian/cfn-private-resource-types/tree/main/dns/guardian-dns-record-set-type/docs#syntax
     new CfnResource(scope, id, {
       type: "Guardian::DNS::RecordSet",
       properties: {
-        Name: props.name,
-        ResourceRecords: props.resourceRecords,
-        RecordType: props.recordType,
-        TTL: props.ttl.toSeconds(),
-        Stage: scope.stage,
+        Name: name,
+        ResourceRecords: resourceRecords,
+        RecordType: recordType,
+        TTL: ttl.toSeconds(),
+        Stage: stage,
       },
     });
   }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

There are currently two ways to create `Guardian::DNS::RecordSet` resource:
  1. `GuCname`
  2. `GuDnsRecordSet`

A CNAME should not return multiple answers without "the correct filters in place (such as SELECT_FIRST_N 1) to limit them to a single answer at resolution time".

`Guardian::DNS::RecordSet` does not create any filters (and it's unlikely to).

The props of `GuCname` enforce this single answer restriction, however if you're still able to use `GuDnsRecordSet` to create a CNAME that violates this restriction.

In this change we throw if a CNAME is being created with multiple answers.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added test.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We're prevented from deploying a potentially broken DNS entry.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
