### PR TITLE
feat: Make ephemeralStorage configurable via props for ecs task

### DIFF
--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -2,100 +2,6 @@
 
 exports[`The GuEcsTask pattern should create the correct resources with lots of config 1`] = `
 Object {
-  "Mappings": Object {
-    "ServiceprincipalMap": Object {
-      "af-south-1": Object {
-        "states": "states.af-south-1.amazonaws.com",
-      },
-      "ap-east-1": Object {
-        "states": "states.ap-east-1.amazonaws.com",
-      },
-      "ap-northeast-1": Object {
-        "states": "states.ap-northeast-1.amazonaws.com",
-      },
-      "ap-northeast-2": Object {
-        "states": "states.ap-northeast-2.amazonaws.com",
-      },
-      "ap-northeast-3": Object {
-        "states": "states.ap-northeast-3.amazonaws.com",
-      },
-      "ap-south-1": Object {
-        "states": "states.ap-south-1.amazonaws.com",
-      },
-      "ap-southeast-1": Object {
-        "states": "states.ap-southeast-1.amazonaws.com",
-      },
-      "ap-southeast-2": Object {
-        "states": "states.ap-southeast-2.amazonaws.com",
-      },
-      "ap-southeast-3": Object {
-        "states": "states.ap-southeast-3.amazonaws.com",
-      },
-      "ca-central-1": Object {
-        "states": "states.ca-central-1.amazonaws.com",
-      },
-      "cn-north-1": Object {
-        "states": "states.cn-north-1.amazonaws.com",
-      },
-      "cn-northwest-1": Object {
-        "states": "states.cn-northwest-1.amazonaws.com",
-      },
-      "eu-central-1": Object {
-        "states": "states.eu-central-1.amazonaws.com",
-      },
-      "eu-north-1": Object {
-        "states": "states.eu-north-1.amazonaws.com",
-      },
-      "eu-south-1": Object {
-        "states": "states.eu-south-1.amazonaws.com",
-      },
-      "eu-south-2": Object {
-        "states": "states.eu-south-2.amazonaws.com",
-      },
-      "eu-west-1": Object {
-        "states": "states.eu-west-1.amazonaws.com",
-      },
-      "eu-west-2": Object {
-        "states": "states.eu-west-2.amazonaws.com",
-      },
-      "eu-west-3": Object {
-        "states": "states.eu-west-3.amazonaws.com",
-      },
-      "me-south-1": Object {
-        "states": "states.me-south-1.amazonaws.com",
-      },
-      "sa-east-1": Object {
-        "states": "states.sa-east-1.amazonaws.com",
-      },
-      "us-east-1": Object {
-        "states": "states.us-east-1.amazonaws.com",
-      },
-      "us-east-2": Object {
-        "states": "states.us-east-2.amazonaws.com",
-      },
-      "us-gov-east-1": Object {
-        "states": "states.us-gov-east-1.amazonaws.com",
-      },
-      "us-gov-west-1": Object {
-        "states": "states.us-gov-west-1.amazonaws.com",
-      },
-      "us-iso-east-1": Object {
-        "states": "states.amazonaws.com",
-      },
-      "us-iso-west-1": Object {
-        "states": "states.amazonaws.com",
-      },
-      "us-isob-east-1": Object {
-        "states": "states.amazonaws.com",
-      },
-      "us-west-1": Object {
-        "states": "states.us-west-1.amazonaws.com",
-      },
-      "us-west-2": Object {
-        "states": "states.us-west-2.amazonaws.com",
-      },
-    },
-  },
   "Outputs": Object {
     "testecstaskecstestStateMachineArnOutput": Object {
       "Value": Object {
@@ -329,12 +235,15 @@ Object {
               "Effect": "Allow",
               "Principal": Object {
                 "Service": Object {
-                  "Fn::FindInMap": Array [
-                    "ServiceprincipalMap",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    "states",
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "states.",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ".amazonaws.com",
+                    ],
                   ],
                 },
               },
@@ -585,6 +494,9 @@ Object {
           },
         ],
         "Cpu": "1024",
+        "EphemeralStorage": Object {
+          "SizeInGiB": 20,
+        },
         "ExecutionRoleArn": Object {
           "Fn::GetAtt": Array [
             "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
@@ -797,30 +709,6 @@ Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "RetentionInDays": 14,
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "ecs-test",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
-          },
-        ],
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -2,6 +2,100 @@
 
 exports[`The GuEcsTask pattern should create the correct resources with lots of config 1`] = `
 Object {
+  "Mappings": Object {
+    "ServiceprincipalMap": Object {
+      "af-south-1": Object {
+        "states": "states.af-south-1.amazonaws.com",
+      },
+      "ap-east-1": Object {
+        "states": "states.ap-east-1.amazonaws.com",
+      },
+      "ap-northeast-1": Object {
+        "states": "states.ap-northeast-1.amazonaws.com",
+      },
+      "ap-northeast-2": Object {
+        "states": "states.ap-northeast-2.amazonaws.com",
+      },
+      "ap-northeast-3": Object {
+        "states": "states.ap-northeast-3.amazonaws.com",
+      },
+      "ap-south-1": Object {
+        "states": "states.ap-south-1.amazonaws.com",
+      },
+      "ap-southeast-1": Object {
+        "states": "states.ap-southeast-1.amazonaws.com",
+      },
+      "ap-southeast-2": Object {
+        "states": "states.ap-southeast-2.amazonaws.com",
+      },
+      "ap-southeast-3": Object {
+        "states": "states.ap-southeast-3.amazonaws.com",
+      },
+      "ca-central-1": Object {
+        "states": "states.ca-central-1.amazonaws.com",
+      },
+      "cn-north-1": Object {
+        "states": "states.cn-north-1.amazonaws.com",
+      },
+      "cn-northwest-1": Object {
+        "states": "states.cn-northwest-1.amazonaws.com",
+      },
+      "eu-central-1": Object {
+        "states": "states.eu-central-1.amazonaws.com",
+      },
+      "eu-north-1": Object {
+        "states": "states.eu-north-1.amazonaws.com",
+      },
+      "eu-south-1": Object {
+        "states": "states.eu-south-1.amazonaws.com",
+      },
+      "eu-south-2": Object {
+        "states": "states.eu-south-2.amazonaws.com",
+      },
+      "eu-west-1": Object {
+        "states": "states.eu-west-1.amazonaws.com",
+      },
+      "eu-west-2": Object {
+        "states": "states.eu-west-2.amazonaws.com",
+      },
+      "eu-west-3": Object {
+        "states": "states.eu-west-3.amazonaws.com",
+      },
+      "me-south-1": Object {
+        "states": "states.me-south-1.amazonaws.com",
+      },
+      "sa-east-1": Object {
+        "states": "states.sa-east-1.amazonaws.com",
+      },
+      "us-east-1": Object {
+        "states": "states.us-east-1.amazonaws.com",
+      },
+      "us-east-2": Object {
+        "states": "states.us-east-2.amazonaws.com",
+      },
+      "us-gov-east-1": Object {
+        "states": "states.us-gov-east-1.amazonaws.com",
+      },
+      "us-gov-west-1": Object {
+        "states": "states.us-gov-west-1.amazonaws.com",
+      },
+      "us-iso-east-1": Object {
+        "states": "states.amazonaws.com",
+      },
+      "us-iso-west-1": Object {
+        "states": "states.amazonaws.com",
+      },
+      "us-isob-east-1": Object {
+        "states": "states.amazonaws.com",
+      },
+      "us-west-1": Object {
+        "states": "states.us-west-1.amazonaws.com",
+      },
+      "us-west-2": Object {
+        "states": "states.us-west-2.amazonaws.com",
+      },
+    },
+  },
   "Outputs": Object {
     "testecstaskecstestStateMachineArnOutput": Object {
       "Value": Object {
@@ -235,15 +329,12 @@ Object {
               "Effect": "Allow",
               "Principal": Object {
                 "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "states.",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ".amazonaws.com",
-                    ],
+                  "Fn::FindInMap": Array [
+                    "ServiceprincipalMap",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    "states",
                   ],
                 },
               },
@@ -495,7 +586,7 @@ Object {
         ],
         "Cpu": "1024",
         "EphemeralStorage": Object {
-          "SizeInGiB": 20,
+          "SizeInGiB": 30,
         },
         "ExecutionRoleArn": Object {
           "Fn::GetAtt": Array [
@@ -709,6 +800,30 @@ Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
         "RetentionInDays": 14,
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -46,6 +46,7 @@ describe("The GuEcsTask pattern", () => {
       taskTimeoutInMinutes: 60,
       cpu: 1024,
       memory: 1024,
+      storage: 30,
       monitoringConfiguration: { snsTopicArn: "arn:something:else:here:we:goalarm-topic", noMonitoring: false },
       taskCommand: `echo "yo ho row ho it's a pirates life for me"`,
       securityGroups: [securityGroup(stack, app)],

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -110,6 +110,7 @@ export interface GuEcsTaskProps extends AppIdentity {
   securityGroups?: ISecurityGroup[];
   customTaskPolicies?: PolicyStatement[];
   environmentOverrides?: TaskEnvironmentVariable[];
+  storage?: number;
 }
 
 /**
@@ -144,7 +145,7 @@ export class GuEcsTask {
       // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu for details
       cpu = 2048, // 2 cores and from 4-16GB memory
       memory = 4096, // 4GB
-
+      storage = 20, //20 GB
       containerConfiguration,
       taskCommand,
       taskTimeoutInMinutes = 15,
@@ -168,6 +169,7 @@ export class GuEcsTask {
       cpu: cpu.toString(),
       memoryMiB: memory.toString(),
       family: `${stack}-${stage}-${app}`,
+      ephemeralStorageGiB: storage,
     });
 
     const containerDefinition = taskDefinition.addContainer(`${id}-TaskContainer`, {


### PR DESCRIPTION
## What does this change?
This makes [ephemeralStorage](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-ecs.TaskDefinition.html#ephemeralstoragegib) configurable in the ECS Task construct. 

On the investigations team our ECS tasks are running out of disk space due to the amount of data they are processing. We need to configure a larger amount of disk space for the fargate containers.

## How to test
Set the storage prop, verify that it gets applied to the containers created by the task.


## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
