### PR TITLE
feat!: Remove stage awareness from constructs

### DIFF
--- a/src/constructs/acm/__snapshots__/certificate.test.ts.snap
+++ b/src/constructs/acm/__snapshots__/certificate.test.ts.snap
@@ -2,16 +2,6 @@
 
 exports[`The GuCertificate class should create a new certificate (which requires manual DNS changes) if hosted zone ids are not provided 1`] = `
 Object {
-  "Mappings": Object {
-    "testing": Object {
-      "CODE": Object {
-        "domainName": "code-guardian.com",
-      },
-      "PROD": Object {
-        "domainName": "prod-guardian.com",
-      },
-    },
-  },
   "Parameters": Object {
     "Stage": Object {
       "AllowedValues": Array [
@@ -27,15 +17,7 @@ Object {
     "CertificateTesting28FCAC6D": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "DomainName": Object {
-          "Fn::FindInMap": Array [
-            "testing",
-            Object {
-              "Ref": "Stage",
-            },
-            "domainName",
-          ],
-        },
+        "DomainName": "code-guardian.com",
         "Tags": Array [
           Object {
             "Key": "App",
@@ -71,18 +53,6 @@ Object {
 
 exports[`The GuCertificate class should create a new certificate when hosted zone ids are provided 1`] = `
 Object {
-  "Mappings": Object {
-    "testing": Object {
-      "CODE": Object {
-        "domainName": "code-guardian.com",
-        "hostedZoneId": "id123",
-      },
-      "PROD": Object {
-        "domainName": "prod-guardian.com",
-        "hostedZoneId": "id124",
-      },
-    },
-  },
   "Parameters": Object {
     "Stage": Object {
       "AllowedValues": Array [
@@ -98,35 +68,11 @@ Object {
     "CertificateTesting28FCAC6D": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "DomainName": Object {
-          "Fn::FindInMap": Array [
-            "testing",
-            Object {
-              "Ref": "Stage",
-            },
-            "domainName",
-          ],
-        },
+        "DomainName": "code-guardian.com",
         "DomainValidationOptions": Array [
           Object {
-            "DomainName": Object {
-              "Fn::FindInMap": Array [
-                "testing",
-                Object {
-                  "Ref": "Stage",
-                },
-                "domainName",
-              ],
-            },
-            "HostedZoneId": Object {
-              "Fn::FindInMap": Array [
-                "testing",
-                Object {
-                  "Ref": "Stage",
-                },
-                "hostedZoneId",
-              ],
-            },
+            "DomainName": "code-guardian.com",
+            "HostedZoneId": "id123",
           },
         ],
         "Tags": Array [

--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -2,16 +2,14 @@ import { Certificate, CertificateValidation } from "@aws-cdk/aws-certificatemana
 import type { CertificateProps } from "@aws-cdk/aws-certificatemanager/lib/certificate";
 import { HostedZone } from "@aws-cdk/aws-route53";
 import { RemovalPolicy } from "@aws-cdk/core";
-import { Stage } from "../../constants";
-import type { GuDomainNameProps } from "../../types/domain-names";
-import { StageAwareValue } from "../../types/stage";
+import type { GuDomainName } from "../../types/domain-names";
 import { GuStatefulMigratableConstruct } from "../../utils/mixin";
 import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { GuStack } from "../core";
 import { AppIdentity } from "../core/identity";
 import type { GuMigratingResource } from "../core/migrating";
 
-export type GuCertificatePropsWithApp = GuDomainNameProps & AppIdentity & GuMigratingResource;
+export type GuCertificatePropsWithApp = GuDomainName & AppIdentity & GuMigratingResource;
 
 /**
  * Construct which creates a DNS-validated ACM Certificate.
@@ -57,43 +55,17 @@ export type GuCertificatePropsWithApp = GuDomainNameProps & AppIdentity & GuMigr
  */
 export class GuCertificate extends GuStatefulMigratableConstruct(GuAppAwareConstruct(Certificate)) {
   constructor(scope: GuStack, props: GuCertificatePropsWithApp) {
-    const hasHostedZoneId: boolean = StageAwareValue.isStageValue(props)
-      ? !!props.CODE.hostedZoneId && !!props.PROD.hostedZoneId
-      : !!props.INFRA.hostedZoneId;
+    const { app, domainName, existingLogicalId, hostedZoneId } = props;
 
-    const maybeHostedZone = !hasHostedZoneId
-      ? undefined
-      : HostedZone.fromHostedZoneId(
-          scope,
-          /* eslint-disable @typescript-eslint/no-non-null-assertion -- `hasHostedZoneId` is true, so we know `hostedZoneId` is present here */
-          AppIdentity.suffixText({ app: props.app }, "HostedZone"),
-          StageAwareValue.isStageValue(props)
-            ? scope.withStageDependentValue({
-                app: props.app,
-                variableName: "hostedZoneId",
-                stageValues: {
-                  [Stage.CODE]: props.CODE.hostedZoneId!,
-                  [Stage.PROD]: props.PROD.hostedZoneId!,
-                },
-              })
-            : props.INFRA.hostedZoneId!
-          /* eslint-enable @typescript-eslint/no-non-null-assertion */
-        );
+    const maybeHostedZone = hostedZoneId
+      ? HostedZone.fromHostedZoneId(scope, AppIdentity.suffixText({ app }, "HostedZone"), hostedZoneId)
+      : undefined;
 
     const awsCertificateProps: CertificateProps & GuMigratingResource & AppIdentity = {
-      domainName: StageAwareValue.isStageValue(props)
-        ? scope.withStageDependentValue({
-            app: props.app,
-            variableName: "domainName",
-            stageValues: {
-              [Stage.CODE]: props.CODE.domainName,
-              [Stage.PROD]: props.PROD.domainName,
-            },
-          })
-        : props.INFRA.domainName,
+      domainName,
       validation: CertificateValidation.fromDns(maybeHostedZone),
-      existingLogicalId: props.existingLogicalId,
-      app: props.app,
+      existingLogicalId,
+      app,
     };
     super(scope, "Certificate", awsCertificateProps);
     this.applyRemovalPolicy(RemovalPolicy.RETAIN);

--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -21,36 +21,22 @@ export type GuCertificatePropsWithApp = GuDomainName & AppIdentity & GuMigrating
  * operation which adds this construct will pause until the relevant DNS record has been added manually.
  *
  * Example usage for creating a new certificate:
- *
  * ```typescript
  * new GuCertificate(stack, "TestCertificate", {
- *    app: "testing",
- *    [Stage.CODE]: {
- *      domainName: "code-guardian.com",
- *      hostedZoneId: "id123",
- *    },
- *    [Stage.PROD]: {
- *      domainName: "prod-guardian.com",
- *      hostedZoneId: "id124",
- *    },
- *  });
+ *   app: "testing",
+ *   domainName: "code-guardian.com",
+ *   hostedZoneId: "id123",
+ * });
  *```
  *
  * Example usage for inheriting a certificate which was created via CloudFormation:
- *
  * ```typescript
  * new GuCertificate(stack, "TestCertificate", {
- *    app: "testing",
- *    existingLogicalId: "MyCloudFormedCertificate",
- *    [Stage.CODE]: {
- *      domainName: "code-guardian.com",
- *      hostedZoneId: "id123",
- *    },
- *    [Stage.PROD]: {
- *      domainName: "prod-guardian.com",
- *      hostedZoneId: "id124",
- *    },
- *  });
+ *   app: "testing",
+ *   existingLogicalId: "MyCloudFormedCertificate",
+ *   domainName: "code-guardian.com",
+ *   hostedZoneId: "id123",
+ * });
  *```
  */
 export class GuCertificate extends GuStatefulMigratableConstruct(GuAppAwareConstruct(Certificate)) {

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -1,7 +1,7 @@
 import { AutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import type { AutoScalingGroupProps, CfnAutoScalingGroup } from "@aws-cdk/aws-autoscaling";
 import { OperatingSystemType, UserData } from "@aws-cdk/aws-ec2";
-import type { ISecurityGroup, MachineImage, MachineImageConfig } from "@aws-cdk/aws-ec2";
+import type { ISecurityGroup, MachineImageConfig } from "@aws-cdk/aws-ec2";
 import type { ApplicationTargetGroup } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stage } from "../../constants";
 import { StageAwareValue } from "../../types/stage";
@@ -33,7 +33,6 @@ export interface GuAutoScalingGroupProps
     GuMigratingResource {
   stageDependentProps?: GuStageDependentAsgProps;
   imageId?: GuAmiParameter;
-  machineImage?: MachineImage;
   userData: UserData | string;
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;

--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -1,7 +1,6 @@
 import "@aws-cdk/assert/jest";
 import { InstanceClass, InstanceSize, InstanceType, Vpc } from "@aws-cdk/aws-ec2";
 import { Stack } from "@aws-cdk/core";
-import { Stage } from "../../constants";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuPrivateConfigBucketParameter } from "../core";
 import { GuAutoScalingGroup } from "./asg";
@@ -33,14 +32,7 @@ describe("GuUserData", () => {
       vpc,
       userData,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      stageDependentProps: {
-        [Stage.CODE]: {
-          minimumInstances: 1,
-        },
-        [Stage.PROD]: {
-          minimumInstances: 3,
-        },
-      },
+      minimumInstances: 1,
       app: "testing",
     });
 
@@ -88,14 +80,7 @@ describe("GuUserData", () => {
       vpc,
       userData,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      stageDependentProps: {
-        [Stage.CODE]: {
-          minimumInstances: 1,
-        },
-        [Stage.PROD]: {
-          minimumInstances: 3,
-        },
-      },
+      minimumInstances: 1,
       app: "testing",
     });
 

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -2,16 +2,6 @@
 
 exports[`The Gu5xxPercentageAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
-  "Mappings": Object {
-    "testing": Object {
-      "CODE": Object {
-        "alarmActionsEnabled": false,
-      },
-      "PROD": Object {
-        "alarmActionsEnabled": true,
-      },
-    },
-  },
   "Outputs": Object {
     "ApplicationLoadBalancerTestingDnsName": Object {
       "Description": "DNS entry for ApplicationLoadBalancerTesting",
@@ -125,15 +115,7 @@ Object {
     },
     "High5xxPercentageAlarmTesting9E960B0F": Object {
       "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "testing",
-            Object {
-              "Ref": "Stage",
-            },
-            "alarmActionsEnabled",
-          ],
-        },
+        "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
             "Fn::Join": Array [
@@ -253,16 +235,6 @@ Object {
 
 exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
-  "Mappings": Object {
-    "testing": Object {
-      "CODE": Object {
-        "alarmActionsEnabled": false,
-      },
-      "PROD": Object {
-        "alarmActionsEnabled": true,
-      },
-    },
-  },
   "Outputs": Object {
     "ApplicationLoadBalancerTestingDnsName": Object {
       "Description": "DNS entry for ApplicationLoadBalancerTesting",
@@ -451,15 +423,7 @@ Object {
     },
     "UnhealthyInstancesAlarmTestingD3AE50F4": Object {
       "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "testing",
-            Object {
-              "Ref": "Stage",
-            },
-            "alarmActionsEnabled",
-          ],
-        },
+        "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
             "Fn::Join": Array [

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -2,16 +2,6 @@
 
 exports[`GuLambdaThrottlingAlarm construct should match snapshot 1`] = `
 Object {
-  "Mappings": Object {
-    "testing": Object {
-      "CODE": Object {
-        "alarmActionsEnabled": false,
-      },
-      "PROD": Object {
-        "alarmActionsEnabled": true,
-      },
-    },
-  },
   "Parameters": Object {
     "DistributionBucketName": Object {
       "Default": "/account/services/artifact.bucket",
@@ -263,15 +253,7 @@ Object {
     },
     "lambdaThrottlingAlarmForLambda2146DC08": Object {
       "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "testing",
-            Object {
-              "Ref": "Stage",
-            },
-            "alarmActionsEnabled",
-          ],
-        },
+        "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
             "Fn::Join": Array [
@@ -332,16 +314,6 @@ Object {
 
 exports[`The GuLambdaErrorPercentageAlarm construct should create the correct alarm resource with minimal config 1`] = `
 Object {
-  "Mappings": Object {
-    "testing": Object {
-      "CODE": Object {
-        "alarmActionsEnabled": false,
-      },
-      "PROD": Object {
-        "alarmActionsEnabled": true,
-      },
-    },
-  },
   "Parameters": Object {
     "DistributionBucketName": Object {
       "Default": "/account/services/artifact.bucket",
@@ -593,15 +565,7 @@ Object {
     },
     "mylambdafunction8D341B54": Object {
       "Properties": Object {
-        "ActionsEnabled": Object {
-          "Fn::FindInMap": Array [
-            "testing",
-            Object {
-              "Ref": "Stage",
-            },
-            "alarmActionsEnabled",
-          ],
-        },
+        "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
             "Fn::Join": Array [

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -13,8 +13,22 @@ export interface GuAlarmProps extends AlarmProps, AppIdentity {
 /**
  * Creates a CloudWatch alarm which sends notifications to the specified SNS topic.
  *
- * By default, alarm notifications will be silenced in the `CODE` environment. In order to override this behaviour
- * (e.g. for testing purposes whilst configuring a new alarm), set the `actionsEnabledInCode` prop to `true`.
+ * Alarm actions are enabled by default.
+ *
+ * To silence alarm actions in `CODE`, provide a Mapping:
+ * ```typescript
+ * new GuAlarm(stack, "alarm", {
+ *   // other required props
+ *   actionsEnabled: stack.withStageDependentValue({
+ *     app: "my-app",
+ *     variableName: "alarmActionsEnabled",
+ *     stageValues: {
+ *       [Stage.CODE]: false,
+ *       [Stage.PROD]: true,
+ *     },
+ *   }),
+ * });
+ * ```
  *
  * This library provides an implementation of some commonly used alarms, which require less boilerplate than this construct,
  * for example [[`Gu5xxPercentageAlarm`]]. Prefer using these more specific implementations where possible.

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -20,7 +20,7 @@ interface Gu5xxPercentageAlarmProps extends Pick<GuAlarmProps, "snsTopicName">, 
   loadBalancer: GuApplicationLoadBalancer;
 }
 
-interface GuUnhealthyInstancesAlarmProps extends Pick<GuAlarmProps, "snsTopicName">, AppIdentity {
+interface GuUnhealthyInstancesAlarmProps extends Pick<GuAlarmProps, "snsTopicName" | "actionsEnabled">, AppIdentity {
   targetGroup: GuApplicationTargetGroup;
 }
 

--- a/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
+++ b/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
@@ -2,16 +2,6 @@
 
 exports[`The GuCname construct should create the correct resources with minimal config 1`] = `
 Object {
-  "Mappings": Object {
-    "mytestapp": Object {
-      "CODE": Object {
-        "domainName": "xyz.code-guardian.com",
-      },
-      "PROD": Object {
-        "domainName": "xyz.prod-guardian.com",
-      },
-    },
-  },
   "Parameters": Object {
     "Stage": Object {
       "AllowedValues": Array [
@@ -26,15 +16,7 @@ Object {
   "Resources": Object {
     "TestRecord": Object {
       "Properties": Object {
-        "Name": Object {
-          "Fn::FindInMap": Array [
-            "mytestapp",
-            Object {
-              "Ref": "Stage",
-            },
-            "domainName",
-          ],
-        },
+        "Name": "xyz.code-guardian.com",
         "RecordType": "CNAME",
         "ResourceRecords": Array [
           "apple.example.com",

--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -2,9 +2,7 @@ import "@aws-cdk/assert/jest";
 import "../../utils/test/jest";
 import { SynthUtils } from "@aws-cdk/assert";
 import { Duration } from "@aws-cdk/core";
-import { Stage, StageForInfrastructure } from "../../constants";
-import type { SynthedStack } from "../../utils/test";
-import { simpleGuStackForTesting, simpleInfraStackForTesting } from "../../utils/test";
+import { simpleGuStackForTesting } from "../../utils/test";
 import { GuCname, GuDnsRecordSet, RecordType } from "./dns-records";
 
 describe("The GuDnsRecordSet construct", () => {
@@ -49,41 +47,11 @@ describe("The GuCname construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
     new GuCname(stack, "TestRecord", {
-      domainNameProps: {
-        [Stage.CODE]: { domainName: "xyz.code-guardian.com" },
-        [Stage.PROD]: { domainName: "xyz.prod-guardian.com" },
-      },
+      domainName: "xyz.code-guardian.com",
       app: "my-test-app",
       resourceRecord: "apple.example.com",
       ttl: Duration.hours(1),
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
-  });
-
-  it("should not create a CloudFormation Mapping when used in a GuStackForInfrastructure", () => {
-    const stack = simpleGuStackForTesting();
-    new GuCname(stack, "TestRecord", {
-      domainNameProps: {
-        [Stage.CODE]: { domainName: "xyz.code-guardian.com" },
-        [Stage.PROD]: { domainName: "xyz.prod-guardian.com" },
-      },
-      app: "my-test-app",
-      resourceRecord: "apple.example.com",
-      ttl: Duration.hours(1),
-    });
-    const json = SynthUtils.toCloudFormation(stack) as SynthedStack;
-    expect(json.Mappings).toBeDefined();
-
-    const infraStack = simpleInfraStackForTesting();
-    new GuCname(infraStack, "TestRecord", {
-      domainNameProps: {
-        [StageForInfrastructure]: { domainName: "xyz.infra-guardian.com" },
-      },
-      app: "my-test-app",
-      resourceRecord: "apple.example.com",
-      ttl: Duration.hours(1),
-    });
-    const infraJson = SynthUtils.toCloudFormation(infraStack) as SynthedStack;
-    expect(infraJson.Mappings).toBeUndefined();
   });
 });

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -70,12 +70,6 @@ export interface GuCnameProps extends GuDomainName, AppIdentity {
 /**
  * Construct for creating CNAME records in NS1.
  *
- * This is designed to create an appropriate CNAME for your CODE and PROD stages, for example when creating a CNAME
- * for your load balancer.
- *
- * If you need something more unusual (e.g. you only need a CNAME for a standalone INFRA stage) you should use the
- * lower-level [[`GuDnsRecordSet`]] class.
- *
  * See [[`GuCnameProps`]] for configuration options.
  */
 export class GuCname extends GuDnsRecordSet {

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,8 +1,6 @@
 import type { Duration } from "@aws-cdk/core";
 import { CfnResource } from "@aws-cdk/core";
-import { Stage } from "../../constants";
-import type { GuDomainNameProps } from "../../types/domain-names";
-import { StageAwareValue } from "../../types/stage";
+import type { GuDomainName } from "../../types/domain-names";
 import type { GuStack } from "../core";
 import type { AppIdentity } from "../core/identity";
 
@@ -62,16 +60,7 @@ export class GuDnsRecordSet {
   }
 }
 
-export interface GuCnameProps extends AppIdentity {
-  /** The name of the records for CODE and PROD stages, for example:
-   * ```typescript
-   * {
-   *   [Stage.CODE]: { domainName: "xyz.code-guardian.com" },
-   *   [Stage.PROD]: { domainName: "xyz.prod-guardian.com" },
-   * }
-   * ```
-   */
-  domainNameProps: GuDomainNameProps;
+export interface GuCnameProps extends GuDomainName, AppIdentity {
   /** The record your CNAME should point to, for example your Load Balancer DNS name */
   resourceRecord: string;
   /** The time to live for the DNS record */
@@ -91,21 +80,13 @@ export interface GuCnameProps extends AppIdentity {
  */
 export class GuCname extends GuDnsRecordSet {
   constructor(scope: GuStack, id: string, props: GuCnameProps) {
-    const domainName = StageAwareValue.isStageValue(props.domainNameProps)
-      ? scope.withStageDependentValue({
-          app: props.app,
-          variableName: "domainName",
-          stageValues: {
-            [Stage.CODE]: props.domainNameProps.CODE.domainName,
-            [Stage.PROD]: props.domainNameProps.PROD.domainName,
-          },
-        })
-      : props.domainNameProps.INFRA.domainName;
+    const { domainName: name, resourceRecord, ttl } = props;
+
     super(scope, id, {
-      name: domainName,
+      name,
       recordType: RecordType.CNAME,
-      resourceRecords: [props.resourceRecord],
-      ttl: props.ttl,
+      resourceRecords: [resourceRecord],
+      ttl,
     });
   }
 }

--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -3,7 +3,6 @@ import "../../../utils/test/jest";
 import { Vpc } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol, ListenerAction } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stack } from "@aws-cdk/core";
-import { Stage } from "../../../constants";
 import { simpleGuStackForTesting } from "../../../utils/test";
 import { GuCertificate } from "../../acm";
 import type { GuStack } from "../../core";
@@ -27,12 +26,7 @@ const getLoadBalancer = (stack: GuStack): GuApplicationLoadBalancer => {
 const getCertificate = (stack: GuStack): GuCertificate => {
   return new GuCertificate(stack, {
     ...app,
-    [Stage.CODE]: {
-      domainName: "code-guardian.com",
-    },
-    [Stage.PROD]: {
-      domainName: "prod-guardian.com",
-    },
+    domainName: "code-guardian.com",
   });
 };
 

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -5,17 +5,17 @@ import { InstanceClass, InstanceSize, InstanceType, Peer, Port, Vpc } from "@aws
 import type { CfnLoadBalancer } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stage } from "../constants";
 import { TagKeys } from "../constants/tag-keys";
-import type { GuStack } from "../constructs/core";
 import { GuPrivateConfigBucketParameter } from "../constructs/core";
 import { GuSecurityGroup } from "../constructs/ec2/security-groups";
 import { GuDynamoDBWritePolicy } from "../constructs/iam";
+import type { GuDomainName } from "../types/domain-names";
+import type { StageValue } from "../types/stage";
 import type { SynthedStack } from "../utils/test";
 import { simpleGuStackForTesting } from "../utils/test";
 import "../utils/test/jest";
-import type { GuEc2AppProps } from "./ec2-app";
 import { AccessScope, GuApplicationPorts, GuEc2App, GuNodeApp, GuPlayApp } from "./ec2-app";
 
-const getCertificateProps = () => ({
+const getCertificateProps = (): StageValue<GuDomainName> => ({
   [Stage.CODE]: {
     domainName: "code-guardian.com",
     hostedZoneId: "id123",
@@ -25,22 +25,6 @@ const getCertificateProps = () => ({
     hostedZoneId: "id124",
   },
 });
-
-function simpleEc2AppForTesting(stack: GuStack, app: string, props: Partial<GuEc2AppProps>) {
-  return new GuEc2App(stack, {
-    applicationPort: GuApplicationPorts.Node,
-    app: app,
-    access: { scope: AccessScope.PUBLIC },
-    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-    certificateProps: {
-      [Stage.CODE]: { domainName: "code-guardian.com", hostedZoneId: "id123" },
-      [Stage.PROD]: { domainName: "prod-guardian.com", hostedZoneId: "id124" },
-    },
-    monitoringConfiguration: { noMonitoring: true },
-    userData: "UserData from pattern declaration",
-    ...props,
-  });
-}
 
 describe("the GuEC2App pattern", function () {
   it("should produce a functional EC2 app with minimal arguments", function () {
@@ -53,6 +37,10 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
@@ -67,6 +55,10 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
@@ -81,6 +73,10 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
     });
     expect(stack).toHaveResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
       Scheme: "internal",
@@ -99,6 +95,10 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: {
         distributable: {
@@ -159,6 +159,10 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: {
         snsTopicName: "test-topic",
         http5xxAlarm: {
@@ -181,6 +185,10 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: {
         snsTopicName: "test-topic",
         http5xxAlarm: false,
@@ -201,6 +209,10 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: {
         snsTopicName: "test-topic",
         http5xxAlarm: false,
@@ -221,6 +233,10 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [Peer.ipv4("192.168.1.1/32"), Peer.ipv4("8.8.8.8/32")] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
     });
@@ -278,6 +294,10 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
     });
@@ -306,6 +326,10 @@ describe("the GuEC2App pattern", function () {
           app: app,
           instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
           certificateProps: getCertificateProps(),
+          scaling: {
+            [Stage.CODE]: { minimumInstances: 1 },
+            [Stage.PROD]: { minimumInstances: 3 },
+          },
           monitoringConfiguration: { noMonitoring: true },
           userData: "",
         })
@@ -323,6 +347,10 @@ describe("the GuEC2App pattern", function () {
           app: app,
           instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
           certificateProps: getCertificateProps(),
+          scaling: {
+            [Stage.CODE]: { minimumInstances: 1 },
+            [Stage.PROD]: { minimumInstances: 3 },
+          },
           monitoringConfiguration: { noMonitoring: true },
           userData: "",
         })
@@ -337,12 +365,12 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       app: app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      certificateProps: getCertificateProps(),
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
+      certificateProps: getCertificateProps(),
       scaling: {
-        CODE: { minimumInstances: 3 },
-        PROD: { minimumInstances: 5, maximumInstances: 12 },
+        [Stage.CODE]: { minimumInstances: 3 },
+        [Stage.PROD]: { minimumInstances: 5, maximumInstances: 12 },
       },
     });
 
@@ -375,6 +403,10 @@ describe("the GuEC2App pattern", function () {
       app: app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
       roleConfiguration: {
@@ -449,9 +481,10 @@ describe("the GuEC2App pattern", function () {
       app: app,
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      certificateProps: {
-        [Stage.CODE]: { domainName: "code-guardian.com", hostedZoneId: "id123" },
-        [Stage.PROD]: { domainName: "prod-guardian.com", hostedZoneId: "id124" },
+      certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
       },
       monitoringConfiguration: { noMonitoring: true },
       userData: "UserData from pattern declaration",
@@ -469,7 +502,18 @@ describe("the GuEC2App pattern", function () {
   it("users can optionally configure block devices", function () {
     const stack = simpleGuStackForTesting();
     const app = "test-gu-ec2-app";
-    simpleEc2AppForTesting(stack, app, {
+    new GuEc2App(stack, {
+      applicationPort: GuApplicationPorts.Node,
+      app: app,
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "UserData from pattern declaration",
       blockDevices: [
         {
           deviceName: "/dev/sda1",
@@ -501,9 +545,10 @@ describe("the GuEC2App pattern", function () {
       app,
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      certificateProps: {
-        [Stage.CODE]: { domainName: "code-guardian.com", hostedZoneId: "id123" },
-        [Stage.PROD]: { domainName: "prod-guardian.com", hostedZoneId: "id124" },
+      certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
       },
       monitoringConfiguration: { noMonitoring: true },
       userData: "UserData from pattern declaration",
@@ -555,8 +600,8 @@ describe("the GuEC2App pattern", function () {
         },
       },
       scaling: {
-        CODE: { minimumInstances: 0 },
-        PROD: { minimumInstances: 1 },
+        [Stage.CODE]: { minimumInstances: 0 },
+        [Stage.PROD]: { minimumInstances: 1 },
       },
     });
 
@@ -576,8 +621,8 @@ describe("the GuEC2App pattern", function () {
         },
       },
       scaling: {
-        CODE: { minimumInstances: 1 },
-        PROD: { minimumInstances: 3 },
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
       },
     });
 
@@ -638,6 +683,10 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
       accessLogging: { enabled: true, prefix: "access-logging-prefix" },
@@ -662,6 +711,10 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
       accessLogging: { enabled: false },
@@ -690,6 +743,10 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: getCertificateProps(),
+      scaling: {
+        [Stage.CODE]: { minimumInstances: 1 },
+        [Stage.PROD]: { minimumInstances: 3 },
+      },
       monitoringConfiguration: { noMonitoring: true },
       userData: "",
       accessLogging: { enabled: false },
@@ -714,15 +771,10 @@ describe("the GuEC2App pattern", function () {
         instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
         monitoringConfiguration: { noMonitoring: true },
         userData: "#!/bin/dev foobarbaz",
-        certificateProps: {
-          [Stage.CODE]: {
-            domainName: "code-guardian.com",
-            hostedZoneId: "id123",
-          },
-          [Stage.PROD]: {
-            domainName: "prod-guardian.com",
-            hostedZoneId: "id124",
-          },
+        certificateProps: getCertificateProps(),
+        scaling: {
+          [Stage.CODE]: { minimumInstances: 1 },
+          [Stage.PROD]: { minimumInstances: 3 },
         },
       });
 
@@ -741,15 +793,10 @@ describe("the GuEC2App pattern", function () {
         instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
         monitoringConfiguration: { noMonitoring: true },
         userData: "#!/bin/dev foobarbaz",
-        certificateProps: {
-          [Stage.CODE]: {
-            domainName: "code-guardian.com",
-            hostedZoneId: "id123",
-          },
-          [Stage.PROD]: {
-            domainName: "prod-guardian.com",
-            hostedZoneId: "id124",
-          },
+        certificateProps: getCertificateProps(),
+        scaling: {
+          [Stage.CODE]: { minimumInstances: 1 },
+          [Stage.PROD]: { minimumInstances: 3 },
         },
       });
 

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -5,11 +5,11 @@ import { Port } from "@aws-cdk/aws-ec2";
 import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration, Tags } from "@aws-cdk/core";
-import type { Stage } from "../constants";
+import { Stage } from "../constants";
 import { SSM_PARAMETER_PATHS } from "../constants/ssm-parameter-paths";
 import { TagKeys } from "../constants/tag-keys";
 import { GuCertificate } from "../constructs/acm";
-import type { GuAsgCapacityProps, GuUserDataProps } from "../constructs/autoscaling";
+import type { GuUserDataProps } from "../constructs/autoscaling";
 import { GuAutoScalingGroup, GuUserData } from "../constructs/autoscaling";
 import type { Http5xxAlarmProps, NoMonitoring } from "../constructs/cloudwatch";
 import { Gu5xxPercentageAlarm, GuUnhealthyInstancesAlarm } from "../constructs/cloudwatch";
@@ -24,7 +24,9 @@ import {
   GuApplicationTargetGroup,
   GuHttpsApplicationListener,
 } from "../constructs/loadbalancing";
-import type { GuDomainNameProps } from "../types/domain-names";
+import type { GuAsgCapacity } from "../types/asg";
+import type { GuDomainName } from "../types/domain-names";
+import { StageAwareValue } from "../types/stage";
 
 export enum AccessScope {
   PUBLIC = "Public",
@@ -98,6 +100,7 @@ export interface Alarms {
   http5xxAlarm: false | Http5xxAlarmProps;
   unhealthyInstancesAlarm: boolean;
   noMonitoring?: false;
+  actionsEnabledInCode?: boolean;
 }
 
 /**
@@ -170,16 +173,13 @@ export interface GuEc2AppProps extends AppIdentity {
   userData: GuUserDataProps | string;
   access: AppAccess;
   applicationPort: number;
-  certificateProps: GuDomainNameProps;
   roleConfiguration?: GuInstanceRoleProps;
   monitoringConfiguration: Alarms | NoMonitoring;
   instanceType: InstanceType;
-  scaling?: {
-    [Stage.CODE]?: GuAsgCapacityProps;
-    [Stage.PROD]?: GuAsgCapacityProps;
-  };
   accessLogging?: AccessLoggingProps;
   blockDevices?: BlockDevice[];
+  scaling: StageAwareValue<GuAsgCapacity>;
+  certificateProps: StageAwareValue<GuDomainName>;
 }
 
 interface GuMaybePortProps extends Omit<GuEc2AppProps, "applicationPort"> {
@@ -365,9 +365,42 @@ export class GuEc2App {
     if (access.scope === AccessScope.RESTRICTED) validateRestrictedCidrRanges(access);
     if (access.scope === AccessScope.INTERNAL) validateInternalCidrRanges(access);
 
+    const hostedZone = (): undefined | string => {
+      const hasHostedZoneId: boolean = StageAwareValue.isStageValue(certificateProps)
+        ? !!certificateProps.CODE.hostedZoneId && !!certificateProps.PROD.hostedZoneId
+        : !!certificateProps.INFRA.hostedZoneId;
+
+      if (!hasHostedZoneId) {
+        return;
+      }
+
+      /* eslint-disable @typescript-eslint/no-non-null-assertion -- `hasHostedZoneId` is true, so we know `hostedZoneId` is present here */
+      return StageAwareValue.isStageValue(certificateProps)
+        ? scope.withStageDependentValue({
+            app,
+            variableName: "hostedZoneId",
+            stageValues: {
+              [Stage.CODE]: certificateProps.CODE.hostedZoneId!,
+              [Stage.PROD]: certificateProps.PROD.hostedZoneId!,
+            },
+          })
+        : certificateProps.INFRA.hostedZoneId!;
+      /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    };
+
     const certificate = new GuCertificate(scope, {
       app,
-      ...certificateProps,
+      domainName: StageAwareValue.isStageValue(certificateProps)
+        ? scope.withStageDependentValue({
+            app,
+            variableName: "domainName",
+            stageValues: {
+              [Stage.CODE]: certificateProps.CODE.domainName,
+              [Stage.PROD]: certificateProps.PROD.domainName,
+            },
+          })
+        : certificateProps.INFRA.domainName,
+      hostedZoneId: hostedZone(),
     });
 
     const maybePrivateConfigPolicy =
@@ -384,16 +417,26 @@ export class GuEc2App {
       app,
       vpc,
       instanceType,
-      stageDependentProps: {
-        CODE: {
-          minimumInstances: scaling?.CODE?.minimumInstances ?? 1,
-          maximumInstances: scaling?.CODE?.maximumInstances,
-        },
-        PROD: {
-          minimumInstances: scaling?.PROD?.minimumInstances ?? 3,
-          maximumInstances: scaling?.PROD?.maximumInstances,
-        },
-      },
+      minimumInstances: StageAwareValue.isStageValue(scaling)
+        ? scope.withStageDependentValue({
+            app,
+            variableName: "minInstances",
+            stageValues: {
+              [Stage.CODE]: scaling.CODE.minimumInstances,
+              [Stage.PROD]: scaling.PROD.minimumInstances,
+            },
+          })
+        : scaling.INFRA.minimumInstances,
+      maximumInstances: StageAwareValue.isStageValue(scaling)
+        ? scope.withStageDependentValue({
+            app,
+            variableName: "maxInstances",
+            stageValues: {
+              [Stage.CODE]: scaling.CODE.maximumInstances ?? scaling.CODE.minimumInstances * 2,
+              [Stage.PROD]: scaling.PROD.maximumInstances ?? scaling.PROD.minimumInstances * 2,
+            },
+          })
+        : scaling.INFRA.maximumInstances ?? scaling.INFRA.minimumInstances * 2,
       role: new GuInstanceRole(scope, { app, ...mergedRoleConfiguration }),
       healthCheck: HealthCheck.elb({ grace: Duration.minutes(2) }), // should this be defaulted at pattern or construct level?
       userData: typeof userData !== "string" ? new GuUserData(scope, { app, ...userData }).userData : userData,
@@ -468,19 +511,39 @@ export class GuEc2App {
     }
 
     if (!monitoringConfiguration.noMonitoring) {
-      if (monitoringConfiguration.http5xxAlarm) {
+      const {
+        http5xxAlarm,
+        snsTopicName,
+        unhealthyInstancesAlarm,
+        actionsEnabledInCode = false,
+      } = monitoringConfiguration;
+
+      const actionsEnabled: boolean = StageAwareValue.isStageValue(certificateProps)
+        ? scope.withStageDependentValue({
+            app,
+            variableName: "alarmActionsEnabled",
+            stageValues: {
+              [Stage.CODE]: actionsEnabledInCode,
+              [Stage.PROD]: true,
+            },
+          })
+        : true;
+
+      if (http5xxAlarm) {
         new Gu5xxPercentageAlarm(scope, {
           app,
           loadBalancer,
-          snsTopicName: monitoringConfiguration.snsTopicName,
-          ...monitoringConfiguration.http5xxAlarm,
+          snsTopicName,
+          ...http5xxAlarm,
+          actionsEnabled,
         });
       }
-      if (monitoringConfiguration.unhealthyInstancesAlarm) {
+      if (unhealthyInstancesAlarm) {
         new GuUnhealthyInstancesAlarm(scope, {
           app,
           targetGroup,
-          snsTopicName: monitoringConfiguration.snsTopicName,
+          snsTopicName,
+          actionsEnabled,
         });
       }
     }

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -100,6 +100,12 @@ export interface Alarms {
   http5xxAlarm: false | Http5xxAlarmProps;
   unhealthyInstancesAlarm: boolean;
   noMonitoring?: false;
+
+  /**
+   * Whether alarm actions are enabled on the `CODE` stage.
+   *
+   * @default false
+   */
   actionsEnabledInCode?: boolean;
 }
 

--- a/src/types/asg.ts
+++ b/src/types/asg.ts
@@ -1,0 +1,19 @@
+export interface GuAsgCapacity {
+  /**
+   * The number of EC2 instances running under normal circumstances,
+   * i.e. when there are no deployment or scaling events in progress.
+   */
+  minimumInstances: number;
+
+  /**
+   * The maximum number of EC2 instances.
+   * If omitted, this will be set to `minimumInstances * 2`.
+   * This allows us to support Riff-Raff's autoscaling deployment type by default.
+   *
+   * Should only be set if you need to scale beyond the default limit (e.g. due to heavy traffic),
+   * or restrict scaling for a specific reason.
+   *
+   * Note: If `minimumInstances` is defined with a Mapping `maximumInstances` must also be defined as a Mapping.
+   */
+  maximumInstances?: number;
+}

--- a/src/types/domain-names.ts
+++ b/src/types/domain-names.ts
@@ -1,8 +1,4 @@
-import type { StageAwareValue } from "./stage";
-
 export interface GuDomainName {
   domainName: string;
   hostedZoneId?: string;
 }
-
-export type GuDomainNameProps = StageAwareValue<GuDomainName>;

--- a/src/types/domain-names.ts
+++ b/src/types/domain-names.ts
@@ -1,4 +1,15 @@
 export interface GuDomainName {
+  /**
+   * The Fully Qualified Domain Name.
+   *
+   * @example "riff-raff.gutools.co.uk"
+   */
   domainName: string;
+
+  /**
+   * Route53 Zone ID.
+   *
+   * To be provided only if the zone for `domainName` is managed by Route53.
+   */
   hostedZoneId?: string;
 }


### PR DESCRIPTION
This is a fairly big change. It is possibly easier to review commit by commit. Happy to discuss ways to break it down - I'd be keen for the changes to yield a single new release.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following discussions in #1049, #1048 and IRL, this PR moves to simplify the codebase by removing explicit stage awareness from these constructs:
  - `GuAutoScalingGroup`
  - `GuCertificate`
  - `GuCname`
  - `GuAlarm`

These constructs can still be made stage aware, however it is now the decision of the caller.

This change impacts the `Ec2App` pattern too, but thankfully not in a dramatic way. The prop `certificateProps` has been renamed to `domain`; this is because it is more explicit.

~❓ https://github.com/guardian/cdk-playground/pull/161 demonstrates this branch on a simple stack. If we didn't rename `certificateProps` to `domain` this change would be a no-op. Shall we _not_ rename the prop to increase backwards compatibility?~ reverted.

### Breaking changes
BREAKING CHANGE: The props to `GuAutoScalingGroup` has changed.

Scaling props in `GuAutoScalingGroup` are now of type `number` and no longer need to be decorated with stage details. The caller can optionally provide a Mapping (via `withStageDependentValue`) if necessary. `GuCertificate`, `GuCname`, and `GuAlarm` see a similar change.

From:

```ts
new GuAutoScalingGroup(stack, "AutoscalingGroup", {
   // other required props
  stageDependentProps: {
    [Stage.CODE]: { minimumInstances: 2 },
    [Stage.PROD]: { minimumInstances: 5 },
  },
});
```

To:

```ts
// Stage agnostic
new GuAutoScalingGroup(stack, "AutoscalingGroup", {
   // other required props
  minimumInstances: 2,
  maximumInstances: 11,
});

// Stage aware
const app = "TestApp";

new GuAutoScalingGroup(stack, "AutoScalingGroup", {
   // other required props
  minimumInstances: stack.withStageDependentValue<number>({
    app,
    variableName: "minInstances",
    stageValues: { [Stage.CODE]: 1, [Stage.PROD]: 3 },
  }),
  maximumInstances: stack.withStageDependentValue<number>({
    app,
    variableName: "maxInstances",
    stageValues: { [Stage.CODE]: 2, [Stage.PROD]: 6 },
  }),
});
```

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See changes to unit tests.

Also see https://github.com/guardian/cdk-playground/pull/161 which tests this branch.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

A simpler codebase!

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Is the API being presented actually clearer?

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]
  - ℹ️  NOTE: The `GuEc2App` could benefit from a refactor, namely documenting the props more explicitly. This is out of scope for this PR, however.

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
