### PR TITLE
Add migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,34 @@ constructs. It is an opinionated and secure-by-default way to describe and
 provision your AWS resources.
 
 - [Introduction to `@guardian/cdk`](./docs/001-general-usage.md)
-- [Migrating an existing Cloudformation template](./docs/003-migrating-existing-stacks.md)
+- [CDK demo including screencast](https://github.com/guardian/cdk-demo)
+- [Migrating an existing Cloudformation template](./docs/migration-guide.md)
 - [Creating a new EC2 or Lambda application from scratch](./docs/002-starting-a-new-project.md)
 - View the [typedocs][internal-website]
 - [Contributing](#contributing) to @guardian/cdk
 
 ## Quickstart
 
-This library can be installed from npm.
+@guardian/cdk expects certain Parameter Store values to be present - for
+example, VPC IDs, and the location of dist buckets. To check for account
+readiness and fix any issues, run:
 
-```
-npm install --save @guardian/cdk
-```
+    npx @guardian/cdk account-readiness --profile [profile]
 
-or
+Then, instantiate a new CDK app:
 
-```
-yarn add @guardian/cdk
-```
+    npx @guardian/cdk new --app [app] --stack [stack]
+
+> Tip: if you are migrating an app, see the [Migration
+> Guide](./docs/migration-guide.md) for more detail.
+
+> Tip: the [AWS CDK Developer
+> Guide](https://docs.aws.amazon.com/cdk/v2/guide/home.html) is worth a
+> read-through if you are new to CDK.
+
+### Patterns and Constructs
+
+Once you have your new app, you can start adding patterns and constructs.
 
 Patterns can be imported from the top level of the library:
 
@@ -44,18 +54,18 @@ If you need to use a construct directly, they must be imported from their constr
 import { GuAutoScalingGroup } from "@guardian/cdk/lib/constructs/autoscaling";
 ```
 
-This is intentional as the patterns ideally solve the majority of use-cases.
-If they don't, please let us know about your use-case so that we can consider supporting it via a pattern.
+Our hope is that patterns solve the majority of your use-cases. If they don't,
+please let us know about your use-case so that we can consider supporting it via
+a pattern.
 
 Alternatively, PRs are always welcome!
-
-There are more details on using the CDK library in [docs][directory-docs]
 
 ### Using the `@guardian/cdk` CLI
 
 The CLI supports various commands to ease the transition to CDK.
 
 <!-- cli -->
+
 ```
 @guardian/cdk COMMAND [args]
 
@@ -73,6 +83,7 @@ Options:
   -h, --help     Show help                                             [boolean]
 
 ```
+
 <!-- clistop -->
 
 ## Contributing

--- a/docs/migration-guide-ec2.md
+++ b/docs/migration-guide-ec2.md
@@ -1,0 +1,193 @@
+# Migration Guide (GuEc2App)
+
+This document assumes you have completed initial setup and other steps described
+in the [Migration Guide](./migration-guide.md).
+
+---
+
+The [GuEc2App](https://guardian.github.io/cdk/classes/index.GuEc2App.html)
+pattern describes a web service with instances running in an auto-scaling group
+(ASG), accessed via an Application Load Balancer (ALB).
+
+It is an appropriate CDK target for many Guardian web services.
+
+However, migrating running applications is not always straightforward. For
+example, the app may use an ELB whereas the pattern uses an ALB.
+
+For apps where avoiding downtime is critical, we recommend a _dual-stack
+migration strategy_. The idea is to duplicate the key parts of the stack using
+the pattern, test, and, once confident, switch DNS to point to the new stack.
+
+**Stage 1: dual-stack**
+
+```mermaid
+    A(example.gutools.co.uk)
+    A --> B[Legacy ELB]
+    A .-> C[GuEC2 ALB]
+```
+
+**Stage 2: switch DNS**
+
+```mermaid
+    A(example.gutools.co.uk)
+    A .-> B[Legacy ELB]
+    A --> C[GuEC2 ALB]
+```
+
+**Stage 3: cleanup**
+
+```mermaid
+    A(example.gutools.co.uk)
+    A --> C[GuEC2 ALB]
+```
+
+If you application includes a database, queues, S3 buckets, etc., you can either
+duplicate these two, or share them across the two instance groups. E.g. for the
+latter, something like:
+
+```mermaid
+graph TD
+    A(example.gutools.co.uk)
+    A --> B[Legacy ELB]
+    A .-> C[GuEC2 ALB]
+    B <--> D[(Database)]
+    C <--> D[(Database)]
+```
+
+And the continue to migrate DNS and cleanup as described above.
+
+There is no single-best solution here though; some applications may not work
+with this approach.
+
+## Stage 1: the new stack
+
+_This stage creates a new version of your EC2 app’s infrastructure, according to
+CDK’s best practices. For example, if you are currently using an ELB (old AWS
+resource type), the new version of your infrastructure will use an ALB (new AWS
+resource type). Note that some resources (e.g. Dynamo tables) will not be
+duplicated as part of the pattern._
+
+_At the end of this stage, you should have a functional copy of your
+application, which can be used for testing purposes. Riff-Raff will have been
+configured to deploy to both versions of your infrastructure, so you can operate
+in this state for as long as you need to._
+
+_We will remove the old copy of your resources in a later stage of the
+migration._
+
+1.  Create an instance of GuEc2App in your stack.
+
+    Use your existing stack as a guide. For example, you will likely need to
+    create some custom IAM permissions and pass them into the pattern.
+
+2.  Add a tag with the name gu:riffraff:new-asg and value true to your new ASG.
+
+    There’s an example of this here.
+
+3.  Update your riff-raff.yaml file to include the `asgMigrationInProgress` parameter.
+
+    There’s an example of this here.
+
+4.  Manually apply the CloudFormation update via the console.
+
+    a. Ensure that the latest version of main has been deployed to CODE/PROD
+    before making further changes
+
+    b. Populate the AMI<App> CloudFormation parameter with the AMI ID that is
+    currently being used for your application
+
+    c. Preview the change set: it should only contain Add operations, as we are
+    just provisioning new resources here.
+
+5.  Deploy this change using Riff-Raff and confirm that both ASGs are updated
+    as part of the deployment.
+
+6.  Test your app’s functionality via the new load balancer’s DNS name (this can
+    be found as an output in the CFN console).
+
+## Stage 2: switch DNS
+
+_This stage ensures that you are able to manage your own DNS record(s) via CDK and updates your DNS record(s) to point at your new load balancer(s)._
+
+_At the end of this stage, all traffic should be running via the new resources that we created in Stage 2. The equivalent old resources should still be part of your stack, but they should be redundant by the end of this stage._
+
+_The instructions here assume that your DNS record is managed via NS1. To check if you are using NS1, you can use dig - dig +nssearch +noall +answer <TLD> where TLD is the top level domain. For example dig +nssearch +noall +answer gutools.co.uk._
+
+1.  Start managing your DNS record via CDK by instantiating a GuCname construct
+
+    Use dig to check the current properties of your DNS record, for example:
+    `dig CNAME security-hq.gutools.co.uk`.
+
+    Instantiate the GuCname class, ensuring that all properties match the
+    properties in NS1. The CNAME should still point at your old load balancer’s
+    DNS name for now.
+
+    Here is an example of this change.
+
+    _N.B. if your template already includes a Guardian::DNS::RecordSet resource,
+    you will need to:_
+
+    - _Use the same logical id when instantiating the GuCname via CloudFormation_
+    - _Delete the Guardian::DNS::RecordSet resource in the same PR that the
+      GuCname is added_
+
+2.  Drop the TTL for your DNS record, to enable faster rollback if something goes wrong.
+
+    Wait for the TTL to expire before proceeding. Here is an example of this
+    change.
+
+3.  Update DNS entry for your so that it points to the new load balancer.
+
+    Here is an example of this change.
+
+4.  Run some tests to confirm that functionality still works as expected.
+
+5.  Wait for a while before proceeding with Stage 6.
+
+    If something goes wrong at this point, we can still roll back by reverting
+    the DNS change.
+
+6.  Once you are confident that the new infrastructure is working correctly, increase the TTL for your DNS record again.
+
+## Stage 3: cleanup
+
+_This stage removes all redundant resources from your original template._
+
+_At the end of this stage, the vast majority of your resources will be created
+via the CDK pattern. Some resources, such as Dynamo tables, may still be defined
+in your original CFN template._
+
+1. View request count metrics for old vs new load balancers in CloudWatch.
+
+   You should not proceed until you have confirmed that the old load balancer is
+   receiving 0 requests.
+
+2. Identify redundant resources in your original CFN template.
+
+   For example, ASGs, LoadBalancers, previous alarms, etc.
+
+3. Remove the redundant resources from your original CFN template.
+
+   In simple cases it may be possible to remove the whole file. If so, you
+   should also be able to remove the CfnInclude block and the associated
+   dependency
+
+4. Remove the gu:riffraff:new-asg tag from your new ASG.
+
+5. Remove the `asgMigrationInProgress` parameter from your riff-raff.yaml.
+
+6. Update your riff-raff.yaml to use the correct `amiParameter` (this will be AMI<Appname>)
+
+7. Preview the CloudFormation update (via ./script/diff)
+
+   It should largely comprise of resource removals. It should also modify the
+   new ASG (due to the tag removal)
+
+8. Apply the CloudFormation update manually.
+
+9. Deploy this change using Riff-Raff.
+
+   In CODE you should test this by deploying your branch. In PROD you can merge
+   the PR and allow Riff-Raff to deploy main automatically
+
+10. Confirm that your app still works as expected.

--- a/docs/migration-guide-lambda.md
+++ b/docs/migration-guide-lambda.md
@@ -1,0 +1,3 @@
+# Migration Guide (Lambda)
+
+TODO.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,0 +1,69 @@
+# Migration Guide
+
+This guide describes how to migrate an existing Cloudformation stack (and
+template) to @guardian/cdk.
+
+If you are starting from scratch, see the [new project guide](TODO).
+
+---
+
+## Account readiness
+
+`@guardian/cdk` patterns and constructs rely on parameter store values for
+things like VPC identifiers and dist buckets. To ensure AWS your account is set
+up correctly, run:
+
+    npx @guardian/cdk account-readiness --profile [profile]
+
+Then follow the instructions for any errors.
+
+## Initial setup
+
+Firstly, ensure you are running a recent version of Node and then initialise a
+new CDK app from within your repo:
+
+    npx @guardian/cdk new --app [app] --stack [stack] --yaml-template-location cfn.yaml
+
+> Tip: run `npx @guardian/cdk new -h` to find out more about the `app` and
+> `stack` flags.
+
+This will create a new CDK (Typescript) app that simply wraps your existing
+Cloudformation template.
+
+Pay attention to the output of the command as it may describe further manual
+steps at this point.
+
+Once done, we recommend running `git diff` to see the full set of changes.
+
+Finally, confirm that your new CDK stack is not materially different from your
+existing stack by running a Cloudformation diff:
+
+    cd cdk
+    ./script/diff -s [AWS stack name] -p [profile]
+
+where `AWS stack name` is the full name of the target Cloudformation Stack in
+AWS.
+
+At this point we recommend running CDK synth as part of your CI.
+
+## Migrating resources
+
+After initial setup, you have something like this:
+
+    CDK(cfn.yaml) -> cfn.yaml
+
+That is, CDK is merely wrapping an existing template. This is useful as a
+starting point. For example, to integrate with CI/CD.
+
+The end goal, though, is for CDK to do all of the work:
+
+    CDK -> cfn.yaml
+
+To get there, we need to migrate resources defined in the old cfn.yaml template
+into CDK (Typescript).
+
+How best to do this will depend on the details of your application. Further
+advice can be found here:
+
+- [for EC2 apps](./migration-guide-ec2.md)
+- [for Lambdas](./migration-guide-lambda.md)


### PR DESCRIPTION
Taken from our battle-tested Google doc!

There are some changes I think we should make alongside or as follow-ups too that I've described below.

## Remove/modify some of the old docs

Remove these:

```
001-general-usage.md
002-starting-a-new-project.md
003-migrating-existing-stacks.md
004-tips-tricks-and-gotchas.md
005-default-parameter-store-locations.md
006-testing.md
```

And replace with the following:

```
README.md <- the main README should be sufficient for getting started and general usage (this PR takes us towards that I hope)
docs/migration-guide.md <- (as in this PR) detailed starting point for migrations
docs/migration-guide-[runtime].md <- (as in this PR) e.g. lambda/ec2 migration-specific guides, mirroring our patterns
docs/contributing.md <- should be a version of the old 006-testing.md file and stuff currently in the README around contributing, with any development principles, e..g backwards-compat approaches etc., we've decided described there.
```

Part of the thinking here is to improve the output of the various CDK CLI commands (e.g. account-readiness and new) to be more useful. E.g. account-readiness should tell you exactly what you need to do to fix any errors; we shouldn't need a full markdown doc for this (which we'd also need to keep aligned with the script). Similarly, the `new` command output should include a basic overview of key scripts and files.

Leveraging the scripts more will provide a better UX for devs and avoid us repeating key bits of information or having to remember to update docs when command outputs change.

## Other simplification

Less important but, for simplicity, I recommend we back out https://github.com/guardian/cdk/pull/883 and simply say 'run `npx @guardian/cdk -h` to see available commands' in the README.md. The specific migration guides should cover any relevant commands anyway so the value of a full breakdown (and the associated code) isn't clear.