### PR TITLE
chore: Make operations team codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/developer-experience
+* @guardian/devx-operations


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Amends the code owner of this repository to be DevX Operations specifically. If the security or CSTI folks need to be notified they can be added as reviewers manually.