### PR TITLE
fix: ephemeralStorage must be > 20 when configuring

### DIFF
--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -145,7 +145,7 @@ export class GuEcsTask {
       // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu for details
       cpu = 2048, // 2 cores and from 4-16GB memory
       memory = 4096, // 4GB
-      storage = 20, //20 GB
+      storage = 21, //20 GB
       containerConfiguration,
       taskCommand,
       taskTimeoutInMinutes = 15,

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -145,7 +145,7 @@ export class GuEcsTask {
       // see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu for details
       cpu = 2048, // 2 cores and from 4-16GB memory
       memory = 4096, // 4GB
-      storage = 21, //20 GB
+      storage, // default is 20 GB when not provided in props
       containerConfiguration,
       taskCommand,
       taskTimeoutInMinutes = 15,
@@ -155,6 +155,12 @@ export class GuEcsTask {
       securityGroups = [],
       environmentOverrides,
     } = props;
+
+    if (storage && storage < 21) {
+      throw new Error(
+        "Storage must be at least 21. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-ephemeralstorage.html"
+      );
+    }
 
     const { stack, stage } = scope;
 


### PR DESCRIPTION
## What does this change?
The changes in https://github.com/guardian/cdk/pull/1075 breaks the ecs task construct because `EphemeralStorage size should be at least 21` according to cloudformation - this is suprising as the [default is apparently 20gb](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-ecs.TaskDefinition.html#ephemeralstoragegib)  I guess if you set it to anything other than the default then it expects you to actually increase the amount of storage from the default amount.

I'm not sure what the best thing to do here is - this PR currently sets the default to 21GB which I've tested solves the problem - but it could also probably be `undefined` so that the default 20gb value is used.

## How to test
I've verified that this solves the problem. 

Previously broken deploy: https://riffraff.gutools.co.uk/deployment/view/f0292e42-69f3-43c3-a2ee-08ce6cbe93ab
Fixed deploy: https://riffraff.gutools.co.uk/deployment/view/12e724bb-52af-4f3e-8fef-4b7b6088936e
