### PR TITLE
fix: Move `AccessScope` onto it's own path

### DIFF
--- a/src/constants/access.ts
+++ b/src/constants/access.ts
@@ -1,0 +1,19 @@
+/**
+ * An enum representing different types of application access.
+ */
+export enum AccessScope {
+  /**
+   * For when you want your application to be accessible to the world (0.0.0.0/0).
+   */
+  PUBLIC = "Public",
+
+  /**
+   * For when you want to restrict your application's access to a list of CIDR ranges.
+   */
+  RESTRICTED = "Restricted",
+
+  /**
+   * For when you want to restrict your application's access to the VPC.
+   */
+  INTERNAL = "Internal",
+}

--- a/src/patterns/ec2-app.test.ts
+++ b/src/patterns/ec2-app.test.ts
@@ -4,6 +4,7 @@ import { BlockDeviceVolume, EbsDeviceVolumeType } from "@aws-cdk/aws-autoscaling
 import { InstanceClass, InstanceSize, InstanceType, Peer, Port, Vpc } from "@aws-cdk/aws-ec2";
 import type { CfnLoadBalancer } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Stage } from "../constants";
+import { AccessScope } from "../constants/access";
 import { TagKeys } from "../constants/tag-keys";
 import { GuPrivateConfigBucketParameter } from "../constructs/core";
 import { GuSecurityGroup } from "../constructs/ec2/security-groups";
@@ -13,7 +14,7 @@ import type { StageValue } from "../types/stage";
 import type { SynthedStack } from "../utils/test";
 import { simpleGuStackForTesting } from "../utils/test";
 import "../utils/test/jest";
-import { AccessScope, GuApplicationPorts, GuEc2App, GuNodeApp, GuPlayApp } from "./ec2-app";
+import { GuApplicationPorts, GuEc2App, GuNodeApp, GuPlayApp } from "./ec2-app";
 
 const getCertificateProps = (): StageValue<GuDomainName> => ({
   [Stage.CODE]: {

--- a/src/patterns/ec2-app.ts
+++ b/src/patterns/ec2-app.ts
@@ -6,6 +6,7 @@ import { ApplicationProtocol } from "@aws-cdk/aws-elasticloadbalancingv2";
 import { Bucket } from "@aws-cdk/aws-s3";
 import { Duration, Tags, Token } from "@aws-cdk/core";
 import { Stage } from "../constants";
+import { AccessScope } from "../constants/access";
 import { SSM_PARAMETER_PATHS } from "../constants/ssm-parameter-paths";
 import { TagKeys } from "../constants/tag-keys";
 import { GuCertificate } from "../constructs/acm";
@@ -24,71 +25,10 @@ import {
   GuApplicationTargetGroup,
   GuHttpsApplicationListener,
 } from "../constructs/loadbalancing";
+import type { AppAccess, InternalAccess, RestrictedAccess } from "../types/access";
 import type { GuAsgCapacity } from "../types/asg";
 import type { GuDomainName } from "../types/domain-names";
 import { StageAwareValue } from "../types/stage";
-
-export enum AccessScope {
-  PUBLIC = "Public",
-  RESTRICTED = "Restricted",
-  INTERNAL = "Internal",
-}
-
-export interface Access {
-  scope: AccessScope;
-}
-
-/**
- * For when you want your application to be accessible to the world (0.0.0.0/0).
- * Your application load balancer will have a public IP address that can be reached by anyone,
- * so only use if you are aware and happy with the consequences!
- *
- * Example usage:
- * ```typescript
- * { scope: AccessScope.PUBLIC }
- * ```
- */
-export interface PublicAccess extends Access {
-  scope: AccessScope.PUBLIC;
-}
-
-/**
- * For when you want to restrict your application's access to a list of CIDR ranges. For example,
- * if you want limit access to users connecting from Guardian offices only.
- *
- * Example usage:
- * ```typescript
- * {
- *   scope: AccessScope.RESTRICTED,
- *   cidrRanges: [Peer.ipv4("192.168.1.1/32"), Peer.ipv4("8.8.8.8/32")]
- * }
- * ```
- */
-export interface RestrictedAccess extends Access {
-  scope: AccessScope.RESTRICTED;
-  cidrRanges: IPeer[];
-}
-
-/**
- * For when you want to restrict your application's access to services running inside your VPC.
- *
- * Note that if your account uses Direct Connect or VPC Peering, then incoming traffic from these sources
- * can also be allowed.
- *
- * Example usage:
- * ```typescript
- * {
- *   scope: AccessScope.INTERNAL,
- *   cidrRanges: [Peer.ipv4("10.0.0.0/8")]
- * }
- * ```
- */
-export interface InternalAccess extends Access {
-  scope: AccessScope.INTERNAL;
-  cidrRanges: IPeer[];
-}
-
-export type AppAccess = PublicAccess | RestrictedAccess | InternalAccess;
 
 export interface AccessLoggingProps {
   enabled: boolean;

--- a/src/types/access.ts
+++ b/src/types/access.ts
@@ -1,0 +1,58 @@
+import type { IPeer } from "@aws-cdk/aws-ec2";
+import type { AccessScope } from "../constants/access";
+
+export interface Access {
+  scope: AccessScope;
+}
+
+/**
+ * For when you want your application to be accessible to the world (0.0.0.0/0).
+ * Your application load balancer will have a public IP address that can be reached by anyone,
+ * so only use if you are aware and happy with the consequences!
+ *
+ * Example usage:
+ * ```typescript
+ * { scope: AccessScope.PUBLIC }
+ * ```
+ */
+export interface PublicAccess extends Access {
+  scope: AccessScope.PUBLIC;
+}
+
+/**
+ * For when you want to restrict your application's access to a list of CIDR ranges. For example,
+ * if you want limit access to users connecting from Guardian offices only.
+ *
+ * Example usage:
+ * ```typescript
+ * {
+ *   scope: AccessScope.RESTRICTED,
+ *   cidrRanges: [Peer.ipv4("192.168.1.1/32"), Peer.ipv4("8.8.8.8/32")]
+ * }
+ * ```
+ */
+export interface RestrictedAccess extends Access {
+  scope: AccessScope.RESTRICTED;
+  cidrRanges: IPeer[];
+}
+
+/**
+ * For when you want to restrict your application's access to services running inside your VPC.
+ *
+ * Note that if your account uses Direct Connect or VPC Peering, then incoming traffic from these sources
+ * can also be allowed.
+ *
+ * Example usage:
+ * ```typescript
+ * {
+ *   scope: AccessScope.INTERNAL,
+ *   cidrRanges: [Peer.ipv4("10.0.0.0/8")]
+ * }
+ * ```
+ */
+export interface InternalAccess extends Access {
+  scope: AccessScope.INTERNAL;
+  cidrRanges: IPeer[];
+}
+
+export type AppAccess = PublicAccess | RestrictedAccess | InternalAccess;


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Move from:

```
import { AccessScope } from "@guardian/cdk/lib/patterns/ec2-app";
```

To:

```
import { AccessScope } from "@guardian/cdk/lib/constants/access";
```

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Giving `AccessScope` a more logical home.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
