### PR TITLE
chore: export GuApiLambda correctly

### DIFF
--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -1,3 +1,4 @@
+export * from "./api-lambda";
 export * from "./scheduled-lambda";
 export * from "./sns-lambda";
 export * from "./kinesis-lambda";


### PR DESCRIPTION
I noticed that the `GuApiLambda` pattern was not being exported correctly. This caused two small problems: 

1. The pattern was not listed via the [TypeDocs](https://guardian.github.io/cdk/modules/index.html). 
2. The pattern had to be imported via it's full path e.g. `import { GuApiLambda } from "@guardian/cdk/lib/patterns/api-lambda";`, which is not [what users expect for patterns](https://github.com/guardian/cdk#patterns-and-constructs).
