### PR TITLE
chore: gitignore compiled code from `integration-test` project

### DIFF
--- a/tools/integration-test/.gitignore
+++ b/tools/integration-test/.gitignore
@@ -4,3 +4,6 @@ cdk.out
 # Reinstalling dependencies based on a lockfile doesn't seem to work cleanly (perhaps due to installing dependencies from file?).
 # We don't care too much about deterministic builds anyway, as this is just an integration test.
 package-lock.json
+
+# compiled code
+dist/


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Every so often the IDE decides to compile the `integration-test` project. This creates files within `tools/integration-test/dist/`, which we do not care about. Add this directory to `.gitignore`. This means we can `git add .` again!