### PR TITLE
feat: Return created LambdaRestApis when creating a GuApiLambda

### DIFF
--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -1,5 +1,1238 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The GuApiLambda pattern should allow us to link a domain name to a LambdaRestApi 1`] = `
+Object {
+  "Outputs": Object {
+    "lambdaapi2Endpoint9DFE39DE": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "lambdaapi239350ECC",
+            },
+            ".execute-api.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "lambdaapi2DeploymentStageprodCC9E3016",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+    "lambdaapiEndpoint3B6C471A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "lambdaapiC1812993",
+            },
+            ".execute-api.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "lambdaapiDeploymentStageprod9598BC2F",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "Stage": Object {
+      "AllowedValues": Array [
+        "CODE",
+        "PROD",
+      ],
+      "Default": "CODE",
+      "Description": "Stage name",
+      "Type": "String",
+    },
+  },
+  "Resources": Object {
+    "CertificateTesting28FCAC6D": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": "code.theguardian.com",
+        "DomainValidationOptions": Array [
+          Object {
+            "DomainName": "code.theguardian.com",
+            "HostedZoneId": "id123",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DNS": Object {
+      "Properties": Object {
+        "Name": "code.theguardian.com",
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "lambdaapidomain77C40062",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "Stage": Object {
+          "Ref": "Stage",
+        },
+        "TTL": 86400,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "lambda8B5974B5": Object {
+      "DependsOn": Array [
+        "lambdaServiceRoleDefaultPolicyBF6FA5E7",
+        "lambdaServiceRole494E4CA6",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "test-stack/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/testing/my-app.zip",
+              ],
+            ],
+          },
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": Object {
+              "Ref": "Stage",
+            },
+          },
+        },
+        "Handler": "handler.ts",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "lambdaServiceRole494E4CA6",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "lambdaServiceRole494E4CA6": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "lambdaServiceRoleDefaultPolicyBF6FA5E7": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/test-stack/testing/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "lambdaServiceRoleDefaultPolicyBF6FA5E7",
+        "Roles": Array [
+          Object {
+            "Ref": "lambdaServiceRole494E4CA6",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "lambdaapi239350ECC": Object {
+      "Properties": Object {
+        "Description": "this is a test2",
+        "Name": "api2",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "lambdaapi2ANYApiPermissionTestTestlambdaapi29FEAC710ANYB2B37DB0": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapi239350ECC",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapi2ANYApiPermissionTestlambdaapi29FEAC710ANY878BC567": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapi239350ECC",
+              },
+              "/",
+              Object {
+                "Ref": "lambdaapi2DeploymentStageprodCC9E3016",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapi2ANYFE9D5EA6": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "lambda8B5974B5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "lambdaapi239350ECC",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapi239350ECC",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdaapi2AccountFAF30ECB": Object {
+      "DependsOn": Array [
+        "lambdaapi239350ECC",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "lambdaapi2CloudWatchRole72740AA5",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "lambdaapi2CloudWatchRole72740AA5": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "lambdaapi2Deployment4ECB93733f2a465bd3376b026a790d1cda259491": Object {
+      "DependsOn": Array [
+        "lambdaapi2proxyANY3F8E1D36",
+        "lambdaapi2proxyE68FDFBC",
+        "lambdaapi2ANYFE9D5EA6",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "lambdaapi239350ECC",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "lambdaapi2DeploymentStageprodCC9E3016": Object {
+      "DependsOn": Array [
+        "lambdaapi2AccountFAF30ECB",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "lambdaapi2Deployment4ECB93733f2a465bd3376b026a790d1cda259491",
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapi239350ECC",
+        },
+        "StageName": "prod",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "lambdaapi2proxyANY3F8E1D36": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "lambda8B5974B5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "lambdaapi2proxyE68FDFBC",
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapi239350ECC",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdaapi2proxyANYApiPermissionTestTestlambdaapi29FEAC710ANYproxy20D9E3C9": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapi239350ECC",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapi2proxyANYApiPermissionTestlambdaapi29FEAC710ANYproxy33429FF8": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapi239350ECC",
+              },
+              "/",
+              Object {
+                "Ref": "lambdaapi2DeploymentStageprodCC9E3016",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapi2proxyE68FDFBC": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "lambdaapi239350ECC",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "lambdaapi239350ECC",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "lambdaapiANY4EBCADD1": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "lambda8B5974B5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "lambdaapiC1812993",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapiC1812993",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdaapiANYApiPermissionTestTestlambdaapi0E958EEBANY3DF279D1": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapiC1812993",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapiANYApiPermissionTestlambdaapi0E958EEBANYA0BDE5E2": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapiC1812993",
+              },
+              "/",
+              Object {
+                "Ref": "lambdaapiDeploymentStageprod9598BC2F",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapiAccountAF0DCB01": Object {
+      "DependsOn": Array [
+        "lambdaapiC1812993",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "lambdaapiCloudWatchRole7E36513A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "lambdaapiC1812993": Object {
+      "Properties": Object {
+        "Description": "this is a test",
+        "Name": "api",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "lambdaapiCloudWatchRole7E36513A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "lambdaapiDeployment8E95B585280b2dd8620eae880b6845467e6ee11e": Object {
+      "DependsOn": Array [
+        "lambdaapiproxyANYA94E968A",
+        "lambdaapiproxyB573C729",
+        "lambdaapiANY4EBCADD1",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "lambdaapiC1812993",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "lambdaapiDeploymentStageprod9598BC2F": Object {
+      "DependsOn": Array [
+        "lambdaapiAccountAF0DCB01",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "lambdaapiDeployment8E95B585280b2dd8620eae880b6845467e6ee11e",
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapiC1812993",
+        },
+        "StageName": "prod",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "lambdaapidomain77C40062": Object {
+      "Properties": Object {
+        "DomainName": "code.theguardian.com",
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": Object {
+          "Ref": "CertificateTesting28FCAC6D",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "testing",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "lambdaapidomainMapTestlambdaapi0E958EEBADCBFBAA": Object {
+      "Properties": Object {
+        "DomainName": Object {
+          "Ref": "lambdaapidomain77C40062",
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapiC1812993",
+        },
+        "Stage": Object {
+          "Ref": "lambdaapiDeploymentStageprod9598BC2F",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "lambdaapiproxyANYA94E968A": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "lambda8B5974B5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "lambdaapiproxyB573C729",
+        },
+        "RestApiId": Object {
+          "Ref": "lambdaapiC1812993",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdaapiproxyANYApiPermissionTestTestlambdaapi0E958EEBANYproxy716A4EB4": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapiC1812993",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapiproxyANYApiPermissionTestlambdaapi0E958EEBANYproxy81BB250D": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "lambdaapiC1812993",
+              },
+              "/",
+              Object {
+                "Ref": "lambdaapiDeploymentStageprod9598BC2F",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdaapiproxyB573C729": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "lambdaapiC1812993",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "lambdaapiC1812993",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+  },
+}
+`;
+
 exports[`The GuApiLambda pattern should create the correct resources with minimal config 1`] = `
 Object {
   "Outputs": Object {

--- a/src/patterns/api-lambda.test.ts
+++ b/src/patterns/api-lambda.test.ts
@@ -1,6 +1,5 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
-import { DomainName } from "@aws-cdk/aws-apigateway/lib/domain-name";
 import { Runtime } from "@aws-cdk/aws-lambda";
 import { Duration } from "@aws-cdk/core";
 import { GuCertificate } from "../constructs/acm";
@@ -80,6 +79,7 @@ describe("The GuApiLambda pattern", () => {
     });
     const api = apiLambda.apis.get("api");
     expect(api).toBeDefined();
+    /* eslint-disable @typescript-eslint/no-non-null-assertion -- We expect api to be defined beyond this point */
     api!.addDomainName("domain", {
       domainName: "code.theguardian.com",
       certificate: new GuCertificate(stack, {
@@ -96,5 +96,6 @@ describe("The GuApiLambda pattern", () => {
       resourceRecord: api!.domainName!.domainNameAliasDomainName,
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
   });
 });

--- a/src/patterns/api-lambda.test.ts
+++ b/src/patterns/api-lambda.test.ts
@@ -77,10 +77,11 @@ describe("The GuApiLambda pattern", () => {
         },
       ],
     });
-    const api = apiLambda.apis.get("api");
-    expect(api).toBeDefined();
-    /* eslint-disable @typescript-eslint/no-non-null-assertion -- We expect api to be defined beyond this point */
-    api!.addDomainName("domain", {
+    const maybeApi = apiLambda.apis.get("api");
+    expect(maybeApi).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- We expect api to be defined beyond this line
+    const api = maybeApi!;
+    const domain = api.addDomainName("domain", {
       domainName: "code.theguardian.com",
       certificate: new GuCertificate(stack, {
         app: "testing",
@@ -93,9 +94,8 @@ describe("The GuApiLambda pattern", () => {
       app: "testing",
       ttl: Duration.days(1),
       domainName: "code.theguardian.com",
-      resourceRecord: api!.domainName!.domainNameAliasDomainName,
+      resourceRecord: domain.domainNameAliasDomainName,
     });
     expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
   });
 });

--- a/src/patterns/api-lambda.test.ts
+++ b/src/patterns/api-lambda.test.ts
@@ -1,7 +1,11 @@
 import "@aws-cdk/assert/jest";
 import { SynthUtils } from "@aws-cdk/assert";
+import { DomainName } from "@aws-cdk/aws-apigateway/lib/domain-name";
 import { Runtime } from "@aws-cdk/aws-lambda";
+import { Duration } from "@aws-cdk/core";
+import { GuCertificate } from "../constructs/acm";
 import type { NoMonitoring } from "../constructs/cloudwatch";
+import { GuCname } from "../constructs/dns";
 import { simpleGuStackForTesting } from "../utils/test";
 import { GuApiLambda } from "./api-lambda";
 
@@ -52,5 +56,45 @@ describe("The GuApiLambda pattern", () => {
       ],
     });
     expect(stack).toHaveResource("AWS::CloudWatch::Alarm");
+  });
+
+  it("should allow us to link a domain name to a LambdaRestApi", () => {
+    const stack = simpleGuStackForTesting();
+    const noMonitoring: NoMonitoring = { noMonitoring: true };
+    const apiLambda = new GuApiLambda(stack, "lambda", {
+      fileName: "my-app.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_12_X,
+      monitoringConfiguration: noMonitoring,
+      app: "testing",
+      apis: [
+        {
+          id: "api",
+          description: "this is a test",
+        },
+        {
+          id: "api2",
+          description: "this is a test2",
+        },
+      ],
+    });
+    const api = apiLambda.apis.get("api");
+    expect(api).toBeDefined();
+    api!.addDomainName("domain", {
+      domainName: "code.theguardian.com",
+      certificate: new GuCertificate(stack, {
+        app: "testing",
+        domainName: "code.theguardian.com",
+        hostedZoneId: "id123",
+      }),
+    });
+
+    new GuCname(stack, "DNS", {
+      app: "testing",
+      ttl: Duration.days(1),
+      domainName: "code.theguardian.com",
+      resourceRecord: api!.domainName!.domainNameAliasDomainName,
+    });
+    expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
   });
 });

--- a/src/patterns/api-lambda.ts
+++ b/src/patterns/api-lambda.ts
@@ -40,17 +40,24 @@ interface GuApiLambdaProps extends Omit<GuFunctionProps, "errorPercentageMonitor
  * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-with-lambda-integration.html
  */
 export class GuApiLambda extends GuLambdaFunction {
+  public readonly apis: Map<string, LambdaRestApi>;
+
   constructor(scope: GuStack, id: string, props: GuApiLambdaProps) {
     super(scope, id, {
       ...props,
       errorPercentageMonitoring: props.monitoringConfiguration.noMonitoring ? undefined : props.monitoringConfiguration,
     });
 
-    props.apis.forEach((api) => {
-      new LambdaRestApi(this, api.id, {
-        handler: this,
-        ...api,
-      });
-    });
+    this.apis = new Map<string, LambdaRestApi>();
+
+    for (const api of props.apis) {
+      this.apis.set(
+        api.id,
+        new LambdaRestApi(this, api.id, {
+          handler: this,
+          ...api,
+        })
+      );
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

* Returns the created `LambdaRestApi`s to the caller
* Tests adding a domain name to a `LambdaRestApi` and a `GuCname`

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
