### PR TITLE
fix: EC2 instances should use IMDSv2

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -27,6 +27,7 @@ export interface GuAutoScalingGroupProps
       | "minCapacity"
       | "maxCapacity"
       | "desiredCapacity"
+      | "requireImdsv2"
       | "securityGroup"
     >,
     AppIdentity,
@@ -83,6 +84,7 @@ export class GuAutoScalingGroup extends GuStatefulMigratableConstruct(GuAppAware
       minCapacity: minimumInstances,
       maxCapacity: maximumInstances ?? minimumInstances * 2,
       role,
+      requireImdsv2: true,
       machineImage: {
         getImage: (): MachineImageConfig => {
           return {

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -55,6 +55,9 @@ export interface GuAutoScalingGroupProps
  *
  * If additional ingress or egress rules are required, define custom security groups and pass them in via the
  * `additionalSecurityGroups` prop.
+ *
+ * All EC2 instances provisioned via this construct will use
+ * [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
  */
 export class GuAutoScalingGroup extends GuStatefulMigratableConstruct(GuAppAwareConstruct(AutoScalingGroup)) {
   constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -167,6 +167,9 @@ Object {
           "Ref": "AMITestguec2app",
         },
         "InstanceType": "t4g.medium",
+        "MetadataOptions": Object {
+          "HttpTokens": "required",
+        },
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [
@@ -1056,6 +1059,9 @@ Object {
           "Ref": "AMITestguec2app",
         },
         "InstanceType": "t4g.medium",
+        "MetadataOptions": Object {
+          "HttpTokens": "required",
+        },
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [


### PR DESCRIPTION
## What does this change?

This PR ensures that all EC2 instances provisioned via `@guardian/cdk` use [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html), encoding the security best practice described [here](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2).

## How to test

Snapshot testing should suffice here.

## How can we measure success?

Another best practice is encoded in the library; it would currently be tricky to conform to this best practice as we do not expose the ASG props at the pattern-level.

## Have we considered potential risks?

Yes, there is a risk that a team will break their application when they upgrade if they are still relying on `IMDSv1` - there is a good description of the potential impact of that [here](https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2). 

I think this risk should be relatively low as the Security team [issued this advice over a year ago](https://github.com/guardian/security-hq/blame/main/hq/markdown/guardduty-sechub-common-problems.md). I would also expect teams to detect this problem in `CODE`.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
