### PR TITLE
docs: add migration docs for scheduled lambda architecture

### DIFF
--- a/docs/migration-guide-lambda.md
+++ b/docs/migration-guide-lambda.md
@@ -1,3 +1,0 @@
-# Migration Guide (Lambda)
-
-TODO.

--- a/docs/migration-guide-scheduled-lambda.md
+++ b/docs/migration-guide-scheduled-lambda.md
@@ -32,14 +32,17 @@ need to adapt these steps slightly.
   should also be able to remove the `CfnInclude` block and the
   `@aws-cdk/cloudformation-include` dependency.
 
-  Note that AWS will provision the new version of the lambda function before
+  Note that AWS will provision the new version of the Lambda function before
   the old one is removed, so the two Lambdas (and their schedules) will coexist
   for a short period of time.
 
 3. Deploy this change using Riff-Raff.
 
-   In `CODE` you should test this by deploying your branch. In `PROD` you can merge
-   the PR and allow Riff-Raff to deploy `main` automatically.
+  In order for this deployment to work Riff-Raff must identify your Lambda using tags, rather than function name.
+  There's an example of this [here](https://github.com/guardian/elastic-search-monitor/pull/17/commits/6cf1684fe518c7dd7e24fc20f8047866bc6e51e3).
+
+  In `CODE` you should test this by deploying your branch. In `PROD` you can merge
+  the PR and allow Riff-Raff to deploy `main` automatically.
 
 4. Confirm that your Lambda is still invoked on the correct schedule and that all behaviour works as expected.
 

--- a/docs/migration-guide-scheduled-lambda.md
+++ b/docs/migration-guide-scheduled-lambda.md
@@ -1,0 +1,46 @@
+# Migration Guide (Scheduled Lambda)
+
+This document assumes you have completed initial setup and other steps described
+in the [Migration Guide](./migration-guide.md).
+
+---
+
+The [GuScheduledLambda](https://guardian.github.io/cdk/classes/patterns.GuScheduledLambda.html) pattern describes
+a Lambda function that is triggered periodically by AWS.
+
+Generally speaking, this architecture is used for tasks like polling/updating a datastore (e.g. a file in S3).
+
+In most cases, it is safe for two versions of Lambdas like to this to exist/run concurrently and for simplicity
+this migration guide assumes that is the case.
+
+Some applications may not work with this approach. If it is crucial to avoid two lambdas running concurrently, you will
+need to adapt these steps slightly.
+
+## Migration Steps
+
+1. Create an instance of `GuScheduledLambda` in your stack.
+
+  Use your existing stack as a guide. For example, you will likely need to
+  create some custom IAM permissions and add them to your
+  [Lambda](https://guardian.github.io/cdk/classes/constructs_lambda.GuLambdaFunction.html).
+
+  There's an example of this [here](https://github.com/guardian/tag-janitor/blob/9e2222d7cea6b37a48e5327efecf7b543b81af15/cdk/lib/cdk-stack.ts#L57-L62).
+
+2. Remove the CloudFormation YAML file from your repository.
+
+  In simple cases it may be possible to remove the whole file. If so, you
+  should also be able to remove the `CfnInclude` block and the
+  `@aws-cdk/cloudformation-include` dependency.
+
+  Note that AWS will provision the new version of the lambda function before
+  the old one is removed, so the two Lambdas (and their schedules) will coexist
+  for a short period of time.
+
+3. Deploy this change using Riff-Raff.
+
+   In `CODE` you should test this by deploying your branch. In `PROD` you can merge
+   the PR and allow Riff-Raff to deploy `main` automatically.
+
+4. Confirm that your Lambda is still invoked on the correct schedule and that all behaviour works as expected.
+
+

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -75,4 +75,6 @@ How best to do this will depend on the details of your application. Further
 advice can be found here:
 
 - [for EC2 apps](./migration-guide-ec2.md)
-- [for Lambdas](./migration-guide-lambda.md)
+- [for Lambdas which run on a schedule/cron](./migration-guide-scheduled-lambda.md)
+
+Migration guides will be coming soon for other Lambda-based architectures. Please contact DevX if you'd like to discuss the migration of an application which uses an architecture that is not listed above.

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -51,21 +51,23 @@ function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
 /**
  * Construct which creates a Lambda function.
  *
- * This lambda relies on the code artifact residing in a standard location in S3. For more details on the bucket used,
- * see [[`GuDistributionBucketParameter`]]. By default, the path used will be `stack/stage/app/fileName`.
+ * This Lambda relies on the code artifact residing in a standard location in S3. For more details on the bucket used,
+ * see [[`GuDistributionBucketParameter`]]. By default, the path used will be `<stack>/<stage>/<app</<fileName>`.
  *
  * The default memory size of this Lambda will vary depending on the runtime chosen.
  * For Java runtimes (i.e. resource hungry Scala Lambdas!), 1024MB will be used. For all other runtimes,
  * the memory size defaults to 512MB. This can be overridden via the `memorySize` prop.
  *
- * By default, the timeout for this lambda is 30 seconds. This can be overridden via the `timeout` prop.
+ * By default, the timeout for this Lambda is 30 seconds. This can be overridden via the `timeout` prop.
  *
- * By default the Lambda is granted permission to read from the SSM parameter store subtree specific to this lambda
- * (i.e. it can read all keys under <stage>/<stack>/<app>/). The lambda has STACK/STAGE/APP environment variables
- * which can be used to determine its identity.
+ * By default the Lambda is granted permission to read from the SSM parameter store subtree specific to this Lambda
+ * (i.e. it can read all keys under `/<stage>/<stack>/<app>/`). If you need to add additional permissions, you can use
+ * [`addToRolePolicy`](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-lambda.FunctionBase.html#addwbrtowbrrolewbrpolicystatement).
  *
- * Note that this construct creates a Lambda without a trigger/event source. Depending on your use-case, you may wish to
- * consider using a pattern which instantiates a Lambda with a trigger e.g. [[`GuScheduledLambda`]].
+ * The Lambda has `STACK`, `STAGE` and `APP` environment variables which can be used to determine its identity.
+ *
+ * Note that this construct creates a Lambda without an event source. Depending on your use-case, you may wish to
+ * consider using a pattern which instantiates a Lambda with an event source e.g. [[`GuScheduledLambda`]].
  */
 export class GuLambdaFunction extends Function {
   public readonly app: string;

--- a/src/patterns/scheduled-lambda.ts
+++ b/src/patterns/scheduled-lambda.ts
@@ -19,7 +19,7 @@ import type { GuFunctionProps } from "../constructs/lambda";
  *
  * const props = {
  *   // Other props here
- *   schedule: Schedule.rate(Duration.minutes(5)),
+ *   rules: [{ schedule: Schedule.rate(Duration.minutes(5)) }],
  * }
  * ```
  *
@@ -29,7 +29,7 @@ import type { GuFunctionProps } from "../constructs/lambda";
  *
  * const props = {
  *   // Other props here
- *   schedule: Schedule.expression("cron(0 8 ? * MON-FRI *)"),
+ *   rules: [{ schedule: Schedule.expression("cron(0 8 ? * MON-FRI *)") }],
  * }
  * ```
  *


### PR DESCRIPTION
## What does this change?

This PR adds a migration guide for the scheduled Lambda pattern/architecture. Whilst working on this I noticed a couple of problems with the TypeDocs for the relevant patterns/constructs, so I've also fixed those here.

## How to test

I've tested this via https://github.com/guardian/elastic-search-monitor/pull/16 & https://github.com/guardian/elastic-search-monitor/pull/17.

## How can we measure success?

Other developers/teams should be able to follow this guide and migrate their own scheduled Lambda infrastructure.

## Have we considered potential risks?

Yes, this is low risk; it only adds documentation & the documentation has been tested/rehearsed.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1] N/A - there are no breaking changes in this PR.
- [x] I have updated the documentation as required for the described changes [^2] This PR fixes some broken docs.

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
