### PR TITLE
fix: add withoutImdvs2 to props of GuAutoScalingGroup and GuEc2App 

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -37,6 +37,7 @@ export interface GuAutoScalingGroupProps
   userData: UserData | string;
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
+  withoutImdsv2?: boolean;
 }
 
 /**
@@ -71,6 +72,7 @@ export class GuAutoScalingGroup extends GuStatefulMigratableConstruct(GuAppAware
       targetGroup,
       userData: userDataLike,
       vpc,
+      withoutImdsv2 = false,
     } = props;
 
     // Ensure min and max are defined in the same way. Throwing an `Error` when necessary. For example when min is defined via a Mapping, but max is not.
@@ -87,7 +89,7 @@ export class GuAutoScalingGroup extends GuStatefulMigratableConstruct(GuAppAware
       minCapacity: minimumInstances,
       maxCapacity: maximumInstances ?? minimumInstances * 2,
       role,
-      requireImdsv2: true,
+      requireImdsv2: !withoutImdsv2,
       machineImage: {
         getImage: (): MachineImageConfig => {
           return {

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -103,6 +103,7 @@ export interface GuEc2AppProps extends AppIdentity {
   blockDevices?: BlockDevice[];
   scaling: GuAsgCapacity;
   certificateProps: GuDomainName;
+  withoutImdsv2?: boolean;
 }
 
 function restrictedCidrRanges(ranges: IPeer[]) {
@@ -303,6 +304,7 @@ export class GuEc2App {
       roleConfiguration = { withoutLogShipping: false, additionalPolicies: [] },
       scaling: { minimumInstances, maximumInstances = minimumInstances * 2 },
       userData,
+      withoutImdsv2,
     } = props;
 
     const vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText({ app }, "VPC"));
@@ -332,6 +334,7 @@ export class GuEc2App {
       instanceType,
       minimumInstances,
       maximumInstances,
+      withoutImdsv2,
       role: new GuInstanceRole(scope, { app, ...mergedRoleConfiguration }),
       healthCheck: HealthCheck.elb({ grace: Duration.minutes(2) }), // should this be defaulted at pattern or construct level?
       userData: typeof userData !== "string" ? new GuUserData(scope, { app, ...userData }).userData : userData,


### PR DESCRIPTION
## What does this change?

We're adding this prop to allow consumers of the GuAutoScalingGroup construct and GuEc2App pattern to be able to explicitly opt out of IMDSv2. Previously, requireImdsv2 was hardcoded to true inside of GuAutoScalingGroup. It's best practice to use IMDSv2, but it's good to provide an escape hatch for applications that aren't ready to adopt it.

NB: GuAutoScalingGroup defaults the value to false, so existing consumers will be unaffected by this change.

## How to test

N/A

## How can we measure success?

support-frontend can log again!

## Have we considered potential risks?

N/A

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
