### PR TITLE
docs: add guidance for viewing diff without tag noise

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -53,7 +53,11 @@ existing stack by running a Cloudformation diff:
 where `AWS stack name` is the full name of the target Cloudformation Stack in
 AWS.
 
-At this point we recommend running CDK synth as part of your CI.
+You might find that the diff contains a lot of noise due to tags that are automatically added by `@guardian/cdk`.
+Tag changes will not cause disruption to your infrastructure. 
+If desired, you can view a diff which excludes the tagging changes by temporarily [amending your stack's props](https://github.com/guardian/cdk-playground/blob/26af40f6432cb94b3e5ef34648d422a7a6ee6b33/cdk/bin/cdk.ts#L6).
+
+Once you are happy with the diff, we recommend running CDK synth as part of your CI process.
 
 ## Migrating resources
 


### PR DESCRIPTION
## What does this change?

Small documentation improvement in response to [this Trello card](https://trello.com/c/kgNzEPc7/1180-should-gucdk-project-generator-default-withouttags-to-true). 

I considered enabling this property by default for all generated projects but decided that forcing another manual step (i.e. "go and change the boolean that the project generation tooling set!") on _all_ users was undesirable. I think that developers might want to do this for their first migration, or for a high profile stack - but I don't think it's necessary to check this every time.

## How to test

N/A

## How can we measure success?

Users can gain confidence more easily (if desired) when migrating to `@guardian/cdk`.

## Have we considered potential risks?

There's a small risk that people will forget to reenable tagging - I'd expect that to be caught during code review or deployment.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
