### PR TITLE
docs: remove references to @aws-cdk/cloudformation-include dependency

### DIFF
--- a/docs/migration-guide-ec2.md
+++ b/docs/migration-guide-ec2.md
@@ -182,8 +182,7 @@ in your original CFN template._
 3. Remove the redundant resources from your original CFN template.
 
    In simple cases it may be possible to remove the whole file. If so, you
-   should also be able to remove the CfnInclude block and the associated
-   dependency
+   should also be able to remove the CfnInclude block.
 
 4. Remove the gu:riffraff:new-asg tag from your new ASG.
 

--- a/docs/migration-guide-scheduled-lambda.md
+++ b/docs/migration-guide-scheduled-lambda.md
@@ -29,8 +29,7 @@ need to adapt these steps slightly.
 2. Remove the CloudFormation YAML file from your repository.
 
   In simple cases it may be possible to remove the whole file. If so, you
-  should also be able to remove the `CfnInclude` block and the
-  `@aws-cdk/cloudformation-include` dependency.
+  should also be able to remove the `CfnInclude` block.
 
   Note that AWS will provision the new version of the Lambda function before
   the old one is removed, so the two Lambdas (and their schedules) will coexist


### PR DESCRIPTION
## What does this change?

References to this dependency are irrelevant/confusing as we have now upgraded to v2, which uses a monolithic package: https://github.com/guardian/cdk/pull/1174.
