### PR TITLE
feat: Add support for automatic log shipping

### DIFF
--- a/src/constants/tag-keys.ts
+++ b/src/constants/tag-keys.ts
@@ -2,4 +2,5 @@ export const TagKeys = {
   TRACKING_TAG: "gu:cdk:version",
   REPOSITORY_NAME: "gu:repo",
   PATTERN_NAME: "gu:cdk:pattern-name",
+  LOG_KINESIS_STREAM_NAME: "LogKinesisStreamName",
 };

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -12,7 +12,14 @@ import type { GuPolicy } from "../policies";
 import { GuRole } from "./roles";
 
 export interface GuInstanceRoleProps {
+  /**
+   * By default, instances are given permissions to write to Kinesis. Set to
+   * 'true' to prevent this. Note, disabling will prevent not just application
+   * logs being shipped but also anything else - for example, automatic log
+   * shipping of Cloud Init and other logs by the cdk-base role in your AMI.
+   */
   withoutLogShipping?: boolean;
+
   additionalPolicies?: GuPolicy[];
 }
 

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -76,6 +76,13 @@ Object {
             "Value": "guardian/cdk",
           },
           Object {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          Object {
             "Key": "Name",
             "PropagateAtLaunch": true,
             "Value": "Test/AutoScalingGroupTestguec2app",
@@ -865,6 +872,13 @@ Object {
             "Key": "gu:repo",
             "PropagateAtLaunch": true,
             "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "LoggingStreamName",
+            },
           },
           Object {
             "Key": "Name",

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -580,6 +580,7 @@ describe("the GuEC2App pattern", function () {
       additionalTags: [
         { Key: "Name", Value: "Test/AutoScalingGroupPlayApp" },
         { Key: TagKeys.PATTERN_NAME, Value: "GuEc2App" },
+        { Key: TagKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });
 
@@ -589,6 +590,7 @@ describe("the GuEC2App pattern", function () {
       additionalTags: [
         { Key: "Name", Value: "Test/AutoScalingGroupNodeApp" },
         { Key: TagKeys.PATTERN_NAME, Value: "GuEc2App" },
+        { Key: TagKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });
   });
@@ -676,6 +678,7 @@ describe("the GuEC2App pattern", function () {
       additionalTags: [
         { Key: "Name", Value: "Test/AutoScalingGroupApp" },
         { Key: TagKeys.PATTERN_NAME, Value: "GuEc2App" },
+        { Key: TagKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });
   });

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -12,7 +12,7 @@ import { GuAutoScalingGroup, GuUserData } from "../../constructs/autoscaling";
 import type { Http5xxAlarmProps, NoMonitoring } from "../../constructs/cloudwatch";
 import { Gu5xxPercentageAlarm, GuUnhealthyInstancesAlarm } from "../../constructs/cloudwatch";
 import type { GuStack } from "../../constructs/core";
-import { AppIdentity, GuStringParameter } from "../../constructs/core";
+import { AppIdentity, GuLoggingStreamNameParameter, GuStringParameter } from "../../constructs/core";
 import { GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
 import type { GuInstanceRoleProps } from "../../constructs/iam";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../../constructs/iam";
@@ -347,6 +347,13 @@ export class GuEc2App {
     //  but we have decided that this is sufficient for now.
     // TODO: Do we need to tag all resources with this value? What would the use-cases be?
     Tags.of(autoScalingGroup).add(TagKeys.PATTERN_NAME, this.constructor.name, { applyToLaunchedInstances: true });
+
+    // This allows automatic shipping of instance Cloud Init logs when using the
+    // `cdk-base` Amigo role on your AMI.
+    Tags.of(autoScalingGroup).add(
+      TagKeys.LOG_KINESIS_STREAM_NAME,
+      GuLoggingStreamNameParameter.getInstance(scope).valueAsString
+    );
 
     const loadBalancer = new GuApplicationLoadBalancer(scope, "LoadBalancer", {
       app,


### PR DESCRIPTION
(Applies to the Ec2App patterns.)

A LogKinesisStreamName tag is added to the ASG and nested resources (including instances). These are read to enable automatic log shipping, initially of Cloud Init Logs.

For more info see:

* https://github.com/guardian/amigo/blob/46725214bac8d4ced5f3b2df27bc49ec6c37bd20/roles/cdk-base/README.md
* https://github.com/guardian/amigo/pull/706

And also the recent Amiable PR that would have not been necessary with this change:

https://github.com/guardian/amiable/pull/122