### PR TITLE
chore: add VS Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "editorconfig.editorconfig",
+        "dbaeumer.vscode-eslint",
+        "stkb.rewrap",
+    ]
+}


### PR DESCRIPTION
Automatically recommend key extensions when project is opened in VS Code.