### PR TITLE
chore: add aws-cdk as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "typescript": "~4.6.3"
       },
       "peerDependencies": {
+        "aws-cdk": "2.20.0",
         "aws-cdk-lib": "2.20.0",
         "constructs": "10.0.110"
       }
@@ -2581,6 +2582,21 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.20.0.tgz",
+      "integrity": "sha512-rs9LTpvrlbsMcenZ3t7TuLDGbHhbnDocrE63Xb2PT++VptR/A8svllK8k1W7hPl77L9QS75GNK5gh+ShkEzsnw==",
+      "peer": true,
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
@@ -5939,7 +5955,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17328,6 +17343,15 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "aws-cdk": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.20.0.tgz",
+      "integrity": "sha512-rs9LTpvrlbsMcenZ3t7TuLDGbHhbnDocrE63Xb2PT++VptR/A8svllK8k1W7hPl77L9QS75GNK5gh+ShkEzsnw==",
+      "peer": true,
+      "requires": {
+        "fsevents": "2.3.2"
+      }
+    },
     "aws-cdk-lib": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.20.0.tgz",
@@ -19884,7 +19908,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "yargs": "^17.4.0"
   },
   "peerDependencies": {
+    "aws-cdk": "2.20.0",
     "aws-cdk-lib": "2.20.0",
     "constructs": "10.0.110"
   },


### PR DESCRIPTION
## What does this change?

All users will need `aws-cdk` in order to synth their stacks, so I've added it as a peer dependency (as discussed [here](https://github.com/guardian/amigo/pull/719#discussion_r853192458)).

## How to test

N/A

## How can we measure success?

This helps to inform users that they'll need the `aws-cdk` dependency (and which version they'll need).

## Have we considered potential risks?

I can't think of any here.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
