### PR TITLE
chore(deps): Configure Dependabot to ignore `constructs`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: "chore(deps): "
+
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -18,9 +19,16 @@ updates:
       prefix: "chore(deps): "
     # force the lockfile and package.json to be updated
     versioning-strategy: increase
-    # We update AWS CDK libraries ourselves (via `script/update-aws-cdk`) as this is a breaking change for users, and it results in a new major version being released
+
+    # Users of `@guardian/cdk` must be on the exact version of these dependencies.
+    # Any update to them in `package.json` should create a new major version of `@guardian/cdk`.
+    # New versions of these dependencies are published quite often. In the case of `constructs`, see https://github.com/aws/constructs/issues/970.
+    # In order to reduce the frequency of new major versions of `@guardian/cdk`, we'll manage these dependencies ourselves via `script/update-aws-cdk`.
     ignore:
+      - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"
+
   - package-ecosystem: 'npm'
     directory: '/tools/integration-test'
     schedule:
@@ -34,3 +42,4 @@ updates:
     ignore:
       - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"
+      - dependency-name: "constructs"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "release": "semantic-release",
     "release:docs": "rm -rf target && typedoc && gh-pages -d target -u \"github-actions-bot <support+actions@github.com>\"",
     "serve:docs": "rm -rf target && typedoc && serve target",
-    "update-aws-cdk": "ncu \"aws-cdk-lib\" \"aws-cdk\" --upgrade --deep --target minor",
+    "update-aws-cdk": "ncu \"aws-cdk-lib\" \"aws-cdk\" \"constructs\" --upgrade --deep --target minor",
     "cli:dev": "ts-node src/bin/index.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Users of `@guardian/cdk` must be on the exact version of the `aws-cdk` and `construct` dependencies,
else they see issues like this in CI (source https://github.com/guardian/cdk-playground/pull/192):

```console
    lib/cdk-playground.ts:17:52 - error TS2345: Argument of type 'this' is not assignable to parameter of type 'IConstruct'.
      Type 'CdkPlayground' is not assignable to type 'IConstruct'.
        Types of property 'node' are incompatible.
          Type 'import("/home/runner/work/cdk-playground/cdk-playground/cdk/node_modules/constructs/lib/construct").Node' is not assignable to type 'import("/home/runner/work/cdk-playground/cdk-playground/cdk/node_modules/@guardian/cdk/node_modules/constructs/lib/construct").Node'.
            Types have separate declarations of a private property 'host'.

    17     AppIdentity.taggedConstruct(CdkPlayground.app, this);
```

This has meant we're unable to merge what should be (according to semver) a safe, non-breaking change, without manual intervention, which dilutes the utility of having Dependabot configured on a repository.

The above was caused by merging https://github.com/guardian/cdk/pull/1195 w/out creating a new major version release, and it consequently being included in the 41.0.1 patch.

In this change, we remove management of `constructs` from Dependabot in favour of bumping the version ourselves (and creating a new major release when doing so).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

PRs raised by Dependabot to bump `@guardian/cdk` in downstream repositories should become more mergeable w/out manual intervention.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

The release notes for changes produced by [`./script/update-aws-cdk`](https://github.com/guardian/cdk/blob/main/script/update-aws-cdk) will only list the version change to `aws-lib-cdk` - we'd be relying on users observing messages about [`peerDependencies`](https://github.com/guardian/cdk/blob/8adb88bdb4a568acc0269b7d984ff45a454a94b2/package.json#L70-L74) to ensure they're on the correct `constructs` version.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
