### PR TITLE
docs: re-add instructions for configuring the `gu:cdk:version` mock

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -19,6 +19,45 @@ Here are some recommendations for using the Guardian CDK library:
 developing locally and in PRs. This enables us to catch things early, creating a shorter feedback loop. See the
 [AWS docs](https://docs.aws.amazon.com/cdk/v2/guide/testing.html#testing_snapshot) on snapshot testing.
 
+#### Mocking `gu:cdk:version`
+The `@guardian/cdk` library follows [Semantic Versioning](https://semver.org/).
+
+GuCDK will add the `gu:cdk:version` tag to resources to aid usage tracking.
+This number changes with every version and as a result automatic version upgrade PRs (e.g. via Dependabot) will fail their snapshot tests.
+To reduce friction, GuCDK ships a mock that can be used with Jest, resulting in snapshots having a static value for this tag.
+
+To use it, first, create `jest.setup.js` and add the global mock:
+
+```javascript
+jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+```
+
+Next, edit `jest.config.js` setting the [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array) property:
+
+```javascript
+module.exports = {
+  setupFilesAfterEnv: ["./jest.setup.js"],
+};
+```
+
+Finally, update your snapshots (`jest -u`).
+
+The `gu:cdk:version` tag should now be:
+
+```json5
+{
+  "Key": "gu:cdk:version",
+  "PropagateAtLaunch": true,
+  "Value": "TEST", // <-- would otherwise be the version number of @guardian/cdk in use
+}
+```
+
+Note:
+  - This mock only affects tests. The `gu:cdk:version` tag in the final template created from a `cdk synth` will have the correct value
+  - This mock is automatically configured when using the GuCDK project generator
+
+✨ With `gu:cdk:version` mocked, snapshot tests run during CI, you can feel confident about merging Dependabot PRs that bump `@guardian/cdk` once CI passes ✨.
+
 ### Generating the cloudformation template
 CI should generate files in the `cdk.out` directory (make sure to add this to `.gitignore`).
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds instructions for manually configuring the Jest mock of `gu:cdk:version` that were lost in #1121. See #448 (and #468) for the original reasoning.
