### PR TITLE
feat(tagging): Tag resources with build number

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -19,44 +19,39 @@ Here are some recommendations for using the Guardian CDK library:
 developing locally and in PRs. This enables us to catch things early, creating a shorter feedback loop. See the
 [AWS docs](https://docs.aws.amazon.com/cdk/v2/guide/testing.html#testing_snapshot) on snapshot testing.
 
-#### Mocking `gu:cdk:version`
-The `@guardian/cdk` library follows [Semantic Versioning](https://semver.org/).
+#### Mocking
+GuCDK will add tags to resources:
+  - `gu:cdk:version` represents the version of GuCDK being used. This helps with usage tracking.
+  - `gu:build-number` represents the build number from CI. This helps when triaging incidents.
 
-GuCDK will add the `gu:cdk:version` tag to resources to aid usage tracking.
-This number changes with every version and as a result automatic version upgrade PRs (e.g. via Dependabot) will fail their snapshot tests.
-To reduce friction, GuCDK ships a mock that can be used with Jest, resulting in snapshots having a static value for this tag.
+To reduce friction, GuCDK ships mocks that can be used with Jest to make snapshot tests simpler. To use them:
 
-To use it, first, create `jest.setup.js` and add the global mock:
+1. Create `jest.setup.js` and add the global mocks:
 
-```javascript
-jest.mock("@guardian/cdk/lib/constants/tracking-tag");
-```
+   ```javascript
+   jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+   jest.mock("@guardian/cdk/lib/constants/build-number-tag");
+   ```
 
-Next, edit `jest.config.js` setting the [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array) property:
+2. Edit `jest.config.js` setting the [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array) property:
 
-```javascript
-module.exports = {
-  setupFilesAfterEnv: ["./jest.setup.js"],
-};
-```
+   ```javascript
+   module.exports = {
+     setupFilesAfterEnv: ["./jest.setup.js"],
+   };
+   ```
 
-Finally, update your snapshots (`jest -u`).
+3. Update your snapshots:
 
-The `gu:cdk:version` tag should now be:
+   ```shell
+   jest -u
+   ```
 
-```json5
-{
-  "Key": "gu:cdk:version",
-  "PropagateAtLaunch": true,
-  "Value": "TEST", // <-- would otherwise be the version number of @guardian/cdk in use
-}
-```
+   The value of these tags within your snapshot files should now be `"TEST"`.
 
 Note:
-  - This mock only affects tests. The `gu:cdk:version` tag in the final template created from a `cdk synth` will have the correct value
-  - This mock is automatically configured when using the GuCDK project generator
-
-✨ With `gu:cdk:version` mocked, snapshot tests run during CI, you can feel confident about merging Dependabot PRs that bump `@guardian/cdk` once CI passes ✨.
+  - Mocks only affect tests. The final template created from a `cdk synth` will have the correct values.
+  - The above mocks are automatically configured when using the GuCDK project generator.
 
 ### Generating the cloudformation template
 CI should generate files in the `cdk.out` directory (make sure to add this to `.gitignore`).

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,3 @@
 jest.mock("./src/constants/tracking-tag");
 jest.mock("./src/constants/library-info");
+jest.mock("./src/constants/build-number-tag");

--- a/src/bin/commands/new-project/template/jest.setup.js
+++ b/src/bin/commands/new-project/template/jest.setup.js
@@ -1,1 +1,2 @@
 jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock("@guardian/cdk/lib/constants/build-number-tag");

--- a/src/constants/__mocks__/build-number-tag.ts
+++ b/src/constants/__mocks__/build-number-tag.ts
@@ -1,0 +1,6 @@
+import { TagKeys } from "../tag-keys";
+
+export const BuildNumberTag = {
+  Key: TagKeys.BUILD_NUMBER,
+  Value: "TEST",
+};

--- a/src/constants/build-number-tag.ts
+++ b/src/constants/build-number-tag.ts
@@ -1,0 +1,7 @@
+import { getBuildNumber } from "../utils/build-number";
+import { TagKeys } from "./tag-keys";
+
+export const BuildNumberTag = {
+  Key: TagKeys.BUILD_NUMBER,
+  Value: getBuildNumber(),
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from "./access";
+export * from "./build-number-tag";
 export * from "./context-keys";
 export * from "./library-info";
 export * from "./regex-pattern";

--- a/src/constants/tag-keys.ts
+++ b/src/constants/tag-keys.ts
@@ -2,5 +2,6 @@ export const TagKeys = {
   TRACKING_TAG: "gu:cdk:version",
   REPOSITORY_NAME: "gu:repo",
   PATTERN_NAME: "gu:cdk:pattern-name",
+  BUILD_NUMBER: "gu:build-number",
   LOG_KINESIS_STREAM_NAME: "LogKinesisStreamName",
 };

--- a/src/constructs/acm/__snapshots__/certificate.test.ts.snap
+++ b/src/constructs/acm/__snapshots__/certificate.test.ts.snap
@@ -13,6 +13,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -55,6 +59,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -40,6 +40,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -76,6 +80,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -266,6 +274,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -313,6 +325,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -346,6 +362,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -44,6 +44,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -96,6 +100,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -318,6 +326,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -370,6 +382,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -2,7 +2,7 @@ import { App, LegacyStackSynthesizer, Stack, Tags } from "aws-cdk-lib";
 import type { StackProps } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import gitUrlParse from "git-url-parse";
-import { ContextKeys, TagKeys, TrackingTag } from "../../constants";
+import { BuildNumberTag, ContextKeys, TagKeys, TrackingTag } from "../../constants";
 import type { GuMigratingStack } from "../../types";
 import { gitRemoteOriginUrl } from "../../utils/git";
 import type { StackStageIdentity } from "./identity";
@@ -137,6 +137,8 @@ export class GuStack extends Stack implements StackStageIdentity, GuMigratingSta
       this.addTag("Stage", this.stage);
 
       this.tryAddRepositoryTag();
+
+      this.addTag(BuildNumberTag.Key, BuildNumberTag.Value);
     }
   }
 

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -185,6 +185,10 @@ Object {
             "Value": "ecs-test",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -242,6 +246,10 @@ Object {
             "Value": "ecs-test",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -287,6 +295,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "ecs-test",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -545,6 +557,10 @@ Object {
             "Value": "ecs-test",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -619,6 +635,10 @@ Object {
             "Value": "ecs-test",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -656,6 +676,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "ecs-test",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -722,6 +746,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "ecs-test",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/iam/__snapshots__/fastly-logs-iam.test.ts.snap
+++ b/src/constructs/iam/__snapshots__/fastly-logs-iam.test.ts.snap
@@ -44,6 +44,10 @@ Object {
         },
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/src/constructs/iam/policies/__snapshots__/log-shipping.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/log-shipping.test.ts.snap
@@ -85,6 +85,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -132,6 +136,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
+++ b/src/constructs/iam/policies/__snapshots__/ses.test.ts.snap
@@ -80,6 +80,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/src/constructs/iam/roles/__snapshots__/github-actions.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/github-actions.test.ts.snap
@@ -69,6 +69,10 @@ Object {
         },
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -120,6 +120,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -422,6 +426,10 @@ Object {
             "Value": "my-first-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -470,6 +478,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "my-second-app",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -798,6 +810,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1013,6 +1029,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/constructs/s3/__snapshots__/index.test.ts.snap
+++ b/src/constructs/s3/__snapshots__/index.test.ts.snap
@@ -19,6 +19,10 @@ Object {
             "Value": "test",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/src/constructs/stack-set/__snapshots__/stack-set.test.ts.snap
+++ b/src/constructs/stack-set/__snapshots__/stack-set.test.ts.snap
@@ -29,6 +29,10 @@ Object {
         "StackSetName": "my-stack-set",
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -68,6 +72,10 @@ Object {
           \\"StreamMode\\": \\"PROVISIONED\\"
         },
         \\"Tags\\": [
+          {
+            \\"Key\\": \\"gu:build-number\\",
+            \\"Value\\": \\"TEST\\"
+          },
           {
             \\"Key\\": \\"gu:cdk:version\\",
             \\"Value\\": \\"TEST\\"
@@ -154,6 +162,10 @@ Object {
         "StackSetName": "my-stack-set",
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -184,6 +196,10 @@ Object {
     "accountalertsD9982E6F": Object {
       "Properties": Object {
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/constructs/vpc/__snapshots__/vpc.test.ts.snap
+++ b/src/constructs/vpc/__snapshots__/vpc.test.ts.snap
@@ -11,6 +11,10 @@ Object {
         "InstanceTenancy": "default",
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -37,6 +41,10 @@ Object {
     "MyVpcIGW5C4A4F63": Object {
       "Properties": Object {
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -99,6 +107,10 @@ Object {
       "Properties": Object {
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -147,6 +159,10 @@ Object {
             "Value": "Private",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -188,6 +204,10 @@ Object {
     "MyVpcapplicationSubnet2RouteTable1A5026C8": Object {
       "Properties": Object {
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -246,6 +266,10 @@ Object {
           Object {
             "Key": "aws-cdk:subnet-type",
             "Value": "Private",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -329,6 +353,10 @@ Object {
         "Domain": "vpc",
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -364,6 +392,10 @@ Object {
           "Ref": "MyVpcingressSubnet1Subnet05B4D133",
         },
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -402,6 +434,10 @@ Object {
     "MyVpcingressSubnet1RouteTableBD23564A": Object {
       "Properties": Object {
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -451,6 +487,10 @@ Object {
             "Value": "Public",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -497,6 +537,10 @@ Object {
         "Domain": "vpc",
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -533,6 +577,10 @@ Object {
         },
         "Tags": Array [
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -559,6 +607,10 @@ Object {
     "MyVpcingressSubnet2RouteTable17765BD0": Object {
       "Properties": Object {
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -617,6 +669,10 @@ Object {
           Object {
             "Key": "aws-cdk:subnet-type",
             "Value": "Public",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -686,6 +742,7 @@ Object {
         "Tags": Object {
           "Stack": "test-stack",
           "Stage": "TEST",
+          "gu:build-number": "TEST",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/cdk",
         },
@@ -713,6 +770,7 @@ Object {
         "Tags": Object {
           "Stack": "test-stack",
           "Stage": "TEST",
+          "gu:build-number": "TEST",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/cdk",
         },
@@ -740,6 +798,7 @@ Object {
         "Tags": Object {
           "Stack": "test-stack",
           "Stage": "TEST",
+          "gu:build-number": "TEST",
           "gu:cdk:version": "TEST",
           "gu:repo": "guardian/cdk",
         },

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -80,6 +80,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -152,6 +156,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -204,6 +212,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -333,6 +345,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -523,6 +539,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -542,7 +562,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB937315346667ee4df9c22c2d20802b9cda38": Object {
+    "lambdaapi2Deployment4ECB93739bec20c9d83b40d6b239d4b9b95b43cf": Object {
       "DependsOn": Array [
         "lambdaapi2proxyANY3F8E1D36",
         "lambdaapi2proxyE68FDFBC",
@@ -562,7 +582,7 @@ Object {
       ],
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB937315346667ee4df9c22c2d20802b9cda38",
+          "Ref": "lambdaapi2Deployment4ECB93739bec20c9d83b40d6b239d4b9b95b43cf",
         },
         "RestApiId": Object {
           "Ref": "lambdaapi239350ECC",
@@ -572,6 +592,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -871,6 +895,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -924,6 +952,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -943,7 +975,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B585116f53ab28b49c00a8893f8c0c3770d1": Object {
+    "lambdaapiDeployment8E95B58519b9084fd437980758bd29df53020bd7": Object {
       "DependsOn": Array [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -963,7 +995,7 @@ Object {
       ],
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B585116f53ab28b49c00a8893f8c0c3770d1",
+          "Ref": "lambdaapiDeployment8E95B58519b9084fd437980758bd29df53020bd7",
         },
         "RestApiId": Object {
           "Ref": "lambdaapiC1812993",
@@ -973,6 +1005,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1009,6 +1045,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1279,6 +1319,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1331,6 +1375,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1460,6 +1508,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1650,6 +1702,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1669,7 +1725,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapi2Deployment4ECB937315346667ee4df9c22c2d20802b9cda38": Object {
+    "lambdaapi2Deployment4ECB93739bec20c9d83b40d6b239d4b9b95b43cf": Object {
       "DependsOn": Array [
         "lambdaapi2proxyANY3F8E1D36",
         "lambdaapi2proxyE68FDFBC",
@@ -1689,7 +1745,7 @@ Object {
       ],
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapi2Deployment4ECB937315346667ee4df9c22c2d20802b9cda38",
+          "Ref": "lambdaapi2Deployment4ECB93739bec20c9d83b40d6b239d4b9b95b43cf",
         },
         "RestApiId": Object {
           "Ref": "lambdaapi239350ECC",
@@ -1699,6 +1755,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1998,6 +2058,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -2051,6 +2115,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -2070,7 +2138,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "lambdaapiDeployment8E95B585116f53ab28b49c00a8893f8c0c3770d1": Object {
+    "lambdaapiDeployment8E95B58519b9084fd437980758bd29df53020bd7": Object {
       "DependsOn": Array [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -2090,7 +2158,7 @@ Object {
       ],
       "Properties": Object {
         "DeploymentId": Object {
-          "Ref": "lambdaapiDeployment8E95B585116f53ab28b49c00a8893f8c0c3770d1",
+          "Ref": "lambdaapiDeployment8E95B58519b9084fd437980758bd29df53020bd7",
         },
         "RestApiId": Object {
           "Ref": "lambdaapiC1812993",
@@ -2100,6 +2168,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -27,6 +27,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -79,6 +83,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -279,6 +287,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -45,6 +45,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -197,6 +201,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -28,6 +28,10 @@ Object {
             "Value": "testing",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -80,6 +84,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -250,6 +258,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "testing",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -61,6 +61,11 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:pattern-name",
             "PropagateAtLaunch": true,
             "Value": "GuEc2App",
@@ -164,6 +169,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -259,6 +268,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -398,6 +411,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -474,6 +491,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -501,6 +522,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -623,6 +648,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -717,6 +746,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -771,6 +804,10 @@ Object {
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -857,6 +894,11 @@ Object {
             "Key": "App",
             "PropagateAtLaunch": true,
             "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:pattern-name",
@@ -962,6 +1004,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1057,6 +1103,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1175,6 +1225,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1245,6 +1299,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1281,6 +1339,10 @@ Object {
           Object {
             "Key": "App",
             "Value": "test-gu-ec2-app",
+          },
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",
@@ -1436,6 +1498,10 @@ Object {
             "Value": "test-gu-ec2-app",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -1490,6 +1556,10 @@ Object {
           },
         ],
         "Tags": Array [
+          Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
           Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/utils/build-number.test.ts
+++ b/src/utils/build-number.test.ts
@@ -1,0 +1,29 @@
+import { getBuildNumber } from "./build-number";
+
+describe("build number retrieval", () => {
+  beforeEach(() => {
+    // don't let tests pollute each other
+    delete process.env.BUILD_NUMBER;
+    delete process.env.GITHUB_RUN_NUMBER;
+  });
+
+  it("should be set to 'unknown' when env vars are not set", () => {
+    expect(getBuildNumber()).toEqual("unknown");
+  });
+
+  it("can be set from BUILD_NUMBER", () => {
+    process.env.BUILD_NUMBER = "1";
+    expect(getBuildNumber()).toEqual("1");
+  });
+
+  it("can be set from GITHUB_RUN_NUMBER", () => {
+    process.env.GITHUB_RUN_NUMBER = "2";
+    expect(getBuildNumber()).toEqual("2");
+  });
+
+  it("prefers BUILD_NUMBER when both BUILD_NUMBER and GITHUB_RUN_NUMBER are set", () => {
+    process.env.BUILD_NUMBER = "1";
+    process.env.GITHUB_RUN_NUMBER = "2";
+    expect(getBuildNumber()).toEqual("1");
+  });
+});

--- a/src/utils/build-number.ts
+++ b/src/utils/build-number.ts
@@ -1,0 +1,26 @@
+/**
+ * Attempt to find build number from environment variables, or fallback to `unknown`.
+ *
+ * @see https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
+ * @see https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+ */
+export function getBuildNumber(): string {
+  const envVars = [
+    "BUILD_NUMBER", // TeamCity
+    "GITHUB_RUN_NUMBER", // GitHub Actions
+  ];
+
+  const fallbackValue = "unknown";
+
+  const [maybeBuildNumber] = envVars.map((key) => process.env[key]).filter(Boolean);
+
+  if (maybeBuildNumber) {
+    return maybeBuildNumber;
+  } else {
+    const attemptedLocations = envVars.join(", ");
+    console.info(
+      `Unable to locate build number from environment variables (tried ${attemptedLocations}). Falling back to ${fallbackValue}.`
+    );
+    return fallbackValue;
+  }
+}

--- a/src/utils/mixin/__snapshots__/app-aware-contruct.test.ts.snap
+++ b/src/utils/mixin/__snapshots__/app-aware-contruct.test.ts.snap
@@ -12,6 +12,10 @@ Object {
             "Value": "Test",
           },
           Object {
+            "Key": "gu:build-number",
+            "Value": "TEST",
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/src/utils/test/assertions.ts
+++ b/src/utils/test/assertions.ts
@@ -1,6 +1,6 @@
 import { Template } from "aws-cdk-lib/assertions";
 import type { Resource } from "aws-cdk-lib/assertions/lib/private/template";
-import { TagKeys, TrackingTag } from "../../constants";
+import { BuildNumberTag, TagKeys, TrackingTag } from "../../constants";
 import type { AppIdentity, GuStack } from "../../constructs/core";
 
 interface Tag {
@@ -82,6 +82,7 @@ export class GuTemplate {
         Key: TagKeys.REPOSITORY_NAME,
         Value: "guardian/cdk",
       },
+      BuildNumberTag,
     ];
 
     const tagMap = new Map<string, Tag>();


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The build number is one (/the only?) way to know which version of the infrastructure definition is running, and is useful information when triaging incidents.

In this change we look up the build number from environment variables:
  - `BUILD_NUMBER` ([TeamCity](https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters))
  - `GITHUB_RUN_NUMBER` ([GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables))
  - If not found, we fall back to `"unknown"`.

The build number is then applied as a `gu:build-number` tag to all resources in the stack.

Coupled with https://github.com/guardian/devx-logs and https://github.com/guardian/cloudwatch-logs-management, this tag will get automatically added as markers to logs shipped to the ELK stack.

The project generator has been updated to configure a mock of this new tag. Existing projects would need to add `jest.mock("@guardian/cdk/lib/constants/build-number-tag");` to `jest.setup.js`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should continue to pass as tests have been updated.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More information is available when triaging incidents, reducing uncertainty.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

### Accuracy
With this change, the marker on the log lines is determined by the AWS tag. If one performs a custom deploy in Riff-Raff, excluding the cloud-formation deployment, the value of the log line marker will not be accurate:

- Deploy all from build 1
- `gu:build-number` tag is "1"
- Log lines have marker `gu:build-number` with value of "1"
- Perform an application only deploy of build 2
- `gu:build-number` tag does not change
- Log lines continue to have marker `gu:build-number` with value of "1"

Maybe a more accurate tag name is `gu:infrastructure-build-number`?

### Increased deployment times
Today, if the IaC hasn't changed between builds, the cost of a "deploy all" is just that of the autoscaling deployment as the cloud-formation task is a no-op.

With this change, every build will produce CloudFormation changes and so the cost of "deploy all" will increase. This might be of particular concern when performing rollback deployments.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
