### PR TITLE
chore(linter rule): Fix valid constructor linting rule

### DIFF
--- a/tools/eslint/rules/valid-constructors.js
+++ b/tools/eslint/rules/valid-constructors.js
@@ -3,7 +3,7 @@ RULES
 1. Private constructors don't get linted
 2. Must be 1, 2 or 3 parameters
 3. First parameter must be called scope
-4. First parameter must be of type GuStack or GuStackForInfrastructure
+4. First parameter must be of type GuStack
 5. If 2 parameters:
    - The second parameter must be called props
    - The second parameter must be a custom type
@@ -77,7 +77,7 @@ const lintParameter = (param, node, context, { name, type, allowOptional, allowD
 
 const scopeParamSpec = {
   name: "scope",
-  type: new RegExp("^(GuStackForInfrastructure|GuStack)$"),
+  type: "GuStack",
   allowOptional: false,
   allowDefault: false,
   position: "first",

--- a/tools/eslint/rules/valid-constructors.test.ts
+++ b/tools/eslint/rules/valid-constructors.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars -- testing file */
 
-import type { GuStack, GuStackForInfrastructure } from "../../../src/constructs/core";
+import type { GuStack } from "../../../src/constructs/core";
 
 interface MyProps {
   name: string;
@@ -48,11 +48,5 @@ class YetAnotherThreeParamConstructor {
 class PrivateConstructor {
   private constructor(number: number) {
     console.log(number);
-  }
-}
-
-class InfraConstructor {
-  constructor(scope: GuStackForInfrastructure) {
-    console.log(scope);
   }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Since #1134 `GuStackForInfrastructure` no longer exists. Update the custom linting rule accordingly.

Slightly confused as to why CI didn't pick this up... possibly due to how `tsc` is ran? i.e. we never explicitly use [`tsconfig.eslint.json`](https://github.com/guardian/cdk/blob/5ccb3c10dad5447ea014fa48ad58c743aab23c8a/tsconfig.eslint.json#L5).