### PR TITLE
feat: allow users to opt-in to application log shipping via GuEc2App

### DIFF
--- a/src/constants/tag-keys.ts
+++ b/src/constants/tag-keys.ts
@@ -3,4 +3,5 @@ export const TagKeys = {
   REPOSITORY_NAME: "gu:repo",
   PATTERN_NAME: "gu:cdk:pattern-name",
   LOG_KINESIS_STREAM_NAME: "LogKinesisStreamName",
+  SYSTEMD_UNIT: "SystemdUnit",
 };


### PR DESCRIPTION
## What does this change?

This PR helps users to configure application log shipping via the `GuEc2App` pattern (or one of its subclasses).

**By default, application logging is switched off.** This is because the majority of users of the pattern will be migrating (or have already migrated) an app which already ships application logs via some other means. We do not want to accidentally ship duplicate logs to ELK and we do not want to increase friction by forcing users to switch their approach to logging at the point of adoption.

The downside of this is that brand new applications will not automatically pick up this sensible default (i.e. they'll need to remember to opt-in via the pattern props).

I suggest that we update the default behaviour (via a breaking change) when a significant number of apps have started using `devx-logs`.

## How to test

Unit testing should be sufficient here. Once merged, I'll upgrade and slightly [simplify Amiable's `cdk` definition](https://github.com/guardian/amiable/blob/c7062e5fdc6ad0be3aa24ee3bb92289a93877f27/cdk/lib/amiable/amiable.ts#L56).

## How can we measure success?

There's a little less effort involved in making the infrastructure changes required to ship application logs via `devx-logs`.

## Have we considered potential risks?

I think this is pretty low risk as it doesn't modify existing behaviour.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
