### PR TITLE
chore(deps): Update aws-cdk to 2.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript": "~4.6.4"
       },
       "peerDependencies": {
-        "aws-cdk": "2.20.0",
+        "aws-cdk": "2.23.0",
         "aws-cdk-lib": "2.23.0",
         "constructs": "10.1.5"
       }
@@ -2585,9 +2585,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.20.0.tgz",
-      "integrity": "sha512-rs9LTpvrlbsMcenZ3t7TuLDGbHhbnDocrE63Xb2PT++VptR/A8svllK8k1W7hPl77L9QS75GNK5gh+ShkEzsnw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.23.0.tgz",
+      "integrity": "sha512-sfVrFImP+mRVdqCDsJcM63inAp9/XSmmeE2hlg8Bqwf7WUblRmj22xiD53VbL2dkc1la6UN05TkfNDAGT0skow==",
       "peer": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -17436,9 +17436,9 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "aws-cdk": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.20.0.tgz",
-      "integrity": "sha512-rs9LTpvrlbsMcenZ3t7TuLDGbHhbnDocrE63Xb2PT++VptR/A8svllK8k1W7hPl77L9QS75GNK5gh+ShkEzsnw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.23.0.tgz",
+      "integrity": "sha512-sfVrFImP+mRVdqCDsJcM63inAp9/XSmmeE2hlg8Bqwf7WUblRmj22xiD53VbL2dkc1la6UN05TkfNDAGT0skow==",
       "peer": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "yargs": "^17.5.1"
   },
   "peerDependencies": {
-    "aws-cdk": "2.20.0",
+    "aws-cdk": "2.23.0",
     "aws-cdk-lib": "2.23.0",
     "constructs": "10.1.5"
   },


### PR DESCRIPTION
Small follow up to https://github.com/guardian/cdk/pull/1251.

Whilst working on https://github.com/guardian/amiable/pull/138, I copy & pasted the versions from peer dependencies without thinking about it. This mismatch leads to the following error when running `cdk synth`:

`This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.`

This PR should help others to avoid this problem.
