### PR TITLE
feat: Add warning for stateful resources when migrating to GuCDK

### DIFF
--- a/src/constructs/core/__data__/cfn.yaml
+++ b/src/constructs/core/__data__/cfn.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A CloudFormation template for testing purposes
+Parameters:
+  BucketName:
+    Type: String
+Resources:
+  ImportantBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -1,8 +1,10 @@
-import { App } from "aws-cdk-lib";
+import { join } from "path";
+import { Annotations, App } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { Queue } from "aws-cdk-lib/aws-sqs";
-import { ContextKeys, TagKeys } from "../../constants";
+import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
+import { ContextKeys, LibraryInfo, TagKeys } from "../../constants";
 import { GuTemplate } from "../../utils/test";
 import { GuParameter } from "./parameters";
 import type { GuStackProps } from "./stack";
@@ -86,5 +88,17 @@ describe("The GuStack construct", () => {
 
     const stack = new MigratingStack(new App(), "Test", { stack: "test", stage: "TEST" });
     GuTemplate.fromStack(stack).hasResourceWithLogicalId("AWS::SQS::Queue", "Notifications");
+  });
+
+  it("prompts to use GuStack.overrideLogicalId", () => {
+    const warning = jest.spyOn(Annotations.prototype, "addWarning");
+
+    const app = new App();
+    const stack = new GuStack(app, "Test", { stack: "test", stage: "TEST" });
+    new CfnInclude(stack, "Template", { templateFile: join(__dirname, "__data__", "cfn.yaml") });
+    app.synth();
+    expect(warning).toHaveBeenCalledWith(
+      `As you're migrating a YAML/JSON template to ${LibraryInfo.NAME}, be sure to check for any stateful resources! See https://github.com/guardian/cdk/blob/main/docs/stateful-resources.md.`
+    );
   });
 });


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

A `CfnInclude` construct is added to a stack when [migrating from a YAML/JSON template](https://docs.aws.amazon.com/cdk/v2/guide/use_cfn_template.html).

In this change, we produce a warning to take care over any stateful resources, and suggest use of the `overrideLogicalId` function to ensure such resources are not removed unintentionally.

This becomes useful for the proposed changes in #1278 which seeks to drop our [current messaging](https://github.com/guardian/cdk/blob/abc237fff54a0efbffa5a3733182c1cb738fff4a/src/constructs/core/migrating.ts#L35-L73). This change feels useful in isolation of #1278, hence it being it's own PR.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

This has been beta released to 43.4.0-beta.2, so to test:
  - Use GuCDK at version 43.4.0-beta.2 in a project that has a `CfnInclude` construct
  - Synth the stack and observe the output on the console

I've done this on [RIff-Raff](https://github.com/guardian/deploy-tools-platform/blob/abcd7c6049e2f5870c7910266a4aeb008aca6b21/cdk/lib/riff-raff.ts) and the result is seen in yellow below:

![image](https://user-images.githubusercontent.com/836140/169284616-eeb0ab9a-d208-40f2-a0e5-0d806ed6c3c5.png)

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More warnings to take care of stateful resources.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Is the warning visible/obvious enough to be seen?

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
