### PR TITLE
fix: provide access to GuApiGatewayWithLambdaByPath's API Gateway instance

### DIFF
--- a/src/patterns/api-multiple-lambdas.ts
+++ b/src/patterns/api-multiple-lambdas.ts
@@ -120,8 +120,10 @@ function isNoMonitoring(
  * For details on configuring the individual Lambda functions, see [[`GuLambdaFunction`]].
  */
 export class GuApiGatewayWithLambdaByPath {
+  public readonly api: RestApi;
   constructor(scope: GuStack, props: GuApiGatewayWithLambdaByPathProps) {
     const apiGateway = new RestApi(scope, "RestApi", props);
+    this.api = apiGateway;
     props.targets.map((target) => {
       const resource = apiGateway.root.resourceForPath(target.path);
       resource.addMethod(target.httpMethod, new LambdaIntegration(target.lambda));


### PR DESCRIPTION
## What does this change?

Similar to https://github.com/guardian/cdk/pull/1158 - I forgot to allow users to access the underlying API Gateway instance when I added the `GuApiGatewayWithLambdaByPath` pattern via https://github.com/guardian/cdk/pull/1250.

## How to test

I'm currently migrating an app to this pattern and installing a beta which contains this change allows me to configure DNS properly.

## How can we measure success?

Users can configure DNS for the `GuApiGatewayWithLambdaByPath` pattern.

## Have we considered potential risks?

I can't think of any risks associated with this.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
