### PR TITLE
fix: Mark `GuKinesisLambda` and `GuSnsLambda` patterns as alpha

### DIFF
--- a/src/patterns/kinesis-lambda.ts
+++ b/src/patterns/kinesis-lambda.ts
@@ -95,6 +95,8 @@ export interface GuKinesisLambdaProps extends Omit<GuFunctionProps, "errorPercen
  * This pattern will create a new Kinesis stream by default. If you are migrating a stack from CloudFormation,
  * you will need to opt-out of this behaviour. For information on overriding the default behaviour,
  * see [[`GuKinesisLambdaProps`]].
+ *
+ * @alpha This pattern is in early development. The API is likely to change in future releases.
  */
 export class GuKinesisLambda extends GuLambdaFunction {
   constructor(scope: GuStack, id: string, props: GuKinesisLambdaProps) {

--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -77,6 +77,8 @@ export interface GuSnsLambdaProps extends Omit<GuFunctionProps, "errorPercentage
  * This pattern will create a new SNS topic by default. If you are migrating a stack from CloudFormation,
  * you will need to opt-out of this behaviour. For information on overriding the default behaviour,
  * see [[`GuSnsLambdaProps`]].
+ *
+ * @alpha This pattern is in early development. The API is likely to change in future releases.
  */
 export class GuSnsLambda extends GuLambdaFunction {
   constructor(scope: GuStack, id: string, props: GuSnsLambdaProps) {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The shape of the incoming props, specifically around handling of an existing resource, is likely to be changed over time as we understand use-cases. So, annotate these patterns as `alpha`.

See these attempts to update the incoming props:
  - https://github.com/guardian/cdk/pull/1264/files#r872391677
  - https://github.com/guardian/cdk/pull/1265
  - https://github.com/guardian/cdk/pull/1278#discussion_r876660606

Although [TypeDoc](https://typedoc.org/guides/doccomments/) doesn't [support](https://github.com/TypeStrong/typedoc/issues/1381) `@alpha` it does at least standout:

![image](https://user-images.githubusercontent.com/836140/169790282-b04449b1-ab4f-4303-a598-a5ebc695f3bb.png)

[TSDoc](https://tsdoc.org/pages/tags/alpha/) seems to support a wider range of tags, but not sure it's worth moving just yet.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Permission to break the API in future releases 🤞🏽 ?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Across the org, there is only [one use](https://github.com/guardian/google-chat-bots/blob/main/cdk/lib/sns-to-gchat.ts) of `GuSnsLambda`, this is in a DevX owned repo. That is, the risk of having an unstable API isn't really a reality yet.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
