### PR TITLE
feat: Add `parameters` getter on `GuStack`

### DIFF
--- a/src/constructs/core/parameters/base.ts
+++ b/src/constructs/core/parameters/base.ts
@@ -22,7 +22,6 @@ export class GuParameter extends CfnParameter {
     });
 
     this.id = id;
-    scope.setParam(this);
   }
 }
 

--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -6,7 +6,6 @@ import { Queue } from "aws-cdk-lib/aws-sqs";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 import { ContextKeys, LibraryInfo, TagKeys } from "../../constants";
 import { GuTemplate } from "../../utils/test";
-import { GuParameter } from "./parameters";
 import type { GuStackProps } from "./stack";
 import { GuStack } from "./stack";
 
@@ -51,23 +50,6 @@ describe("The GuStack construct", () => {
         },
       ],
     });
-  });
-
-  it("should return a parameter that exists", () => {
-    const stack = new GuStack(new App(), "Test", { stack: "test", stage: "TEST" });
-    const testParam = new GuParameter(stack, "MyTestParam", {});
-    stack.setParam(testParam);
-
-    const actual = stack.getParam<GuParameter>("MyTestParam");
-    expect(actual).toBe(testParam);
-  });
-
-  it("should throw on attempt to get a parameter that doesn't exist", () => {
-    const stack = new GuStack(new App(), "Test", { stack: "test", stage: "TEST" });
-
-    expect(() => stack.getParam<GuParameter>("i-do-not-exist")).toThrowError(
-      "Attempting to read parameter i-do-not-exist which does not exist"
-    );
   });
 
   it("can persist the logicalId for any resource (consumer's POV)", () => {

--- a/src/constructs/stack-set/stack-set.ts
+++ b/src/constructs/stack-set/stack-set.ts
@@ -142,7 +142,9 @@ export class GuStackSet extends CfnStackSet {
     const stackSetInstanceParameters = props.stackSetInstanceParameters ?? {};
 
     const params = Object.keys(stackSetInstanceParameters);
-    const undefinedStackSetParams = props.stackSetInstance.parameterKeys.filter((_) => !params.includes(_));
+    const parameterKeys = Object.keys(props.stackSetInstance.parameters);
+
+    const undefinedStackSetParams = parameterKeys.filter((_) => !params.includes(_));
 
     if (undefinedStackSetParams.length !== 0) {
       throw new Error(`There are undefined stack set parameters: ${undefinedStackSetParams.join(", ")}`);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This is more correct than `getParam` as it return ALL parameters, not just those of type `GuParameter`. As a result the `getParam` and `setParam` functions on `GuStack` are also removed. (There's an argument that this getter could be internal/private to the library - see below.)

This change also somewhat reduces the utility of the [`GuParameter`](https://github.com/guardian/cdk/blob/90382af4c1939ffa7f5385da2739a0259b5b678b/src/constructs/core/parameters/base.ts#L14-L26) construct. We might be able to simplify (or even remove!) it.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI should continue to pass.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Less code, and a more complete API.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

> **Note**
> I propose we ship this as a minor update. The risk is this isn't inline with [semver](https://semver.org/).

Although this change removes the `getParam` and `setParam` functions on `GuStack`:
  - no-one is using them ([`getParam`](https://github.com/search?q=org%3Aguardian+getParam+extension%3Ats&type=Code&ref=advsearch&l=&l=), [`setParam`](https://github.com/search?q=org%3Aguardian+setParam+extension%3Ats&type=Code))
  - they were initially added (#92) to aid the sharing of parameters across constructs. However these kinds of parameters have since become singletons (e.g. [`GuDistributionBucketParameter`](https://github.com/guardian/cdk/blob/2b65959b7aadac5e39f0f691c156146c111d1f55/src/constructs/core/parameters/s3.ts#L6-L28)) which is a much simpler API

Given the above, there might be an argument to make the new `parameters` getter internal to the repository.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
