### PR TITLE
fix: hardcode ID of existing SNS topic in GuSnsLambda pattern

### DIFF
--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -78,7 +78,7 @@ export class GuSnsLambda extends GuLambdaFunction {
     this.snsTopic = existingSnsTopic
       ? Topic.fromTopicArn(
           scope,
-          existingSnsTopic.externalTopicName,
+          "SnsExistingIncomingEventsTopic",
           `arn:aws:sns:${region}:${account}:${existingSnsTopic.externalTopicName}`
         )
       : AppIdentity.taggedConstruct(props, new GuSnsTopic(scope, "SnsIncomingEventsTopic"));


### PR DESCRIPTION
Ensure tokens (such as params) can be used for the existing topic ARN prop in the GuSnsLambda pattern.

At the moment this is blocking the Image Copier migration with the following error:

`Error: ID components may not include unresolved tokens: ${Token[TOKEN.210]}.`