### PR TITLE
fix: ensure ID is unique

### DIFF
--- a/src/patterns/sns-lambda.ts
+++ b/src/patterns/sns-lambda.ts
@@ -78,7 +78,7 @@ export class GuSnsLambda extends GuLambdaFunction {
     this.snsTopic = existingSnsTopic
       ? Topic.fromTopicArn(
           scope,
-          "SnsExistingIncomingEventsTopic",
+          `${id}-SnsExistingIncomingEventsTopic`,
           `arn:aws:sns:${region}:${account}:${existingSnsTopic.externalTopicName}`
         )
       : AppIdentity.taggedConstruct(props, new GuSnsTopic(scope, "SnsIncomingEventsTopic"));


### PR DESCRIPTION
https://github.com/guardian/cdk/pull/1347 has a bug: the ID is not guaranteed unique, which means it errors when multiple lambdas are defined with this prop set.