### PR TITLE
chore: Enable `noUncheckedIndexedAccess`

### DIFF
--- a/src/bin/commands/account-readiness/ssm.ts
+++ b/src/bin/commands/account-readiness/ssm.ts
@@ -1,7 +1,7 @@
 import AWS from "aws-sdk";
 import chalk from "chalk";
 import type { SsmParameterPath } from "../../../constants";
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { ALL_SSM_PARAMETER_PATHS } from "../../../constants";
 import type { AwsConfig } from "../../../types/cli";
 import { getSsmParametersForVpc, getVpcsInDetail } from "../../../utils/cli/vpc";
 import type { Report } from ".";
@@ -23,8 +23,8 @@ const ssmParamReadiness = async ({ credentialProvider, region }: AwsConfig): Pro
     region,
   });
 
-  const ssmParams = Object.values(SSM_PARAMETER_PATHS).filter((param) => !param.optional);
-  const paths: string[] = ssmParams.map((param) => param.path);
+  const ssmParams = ALL_SSM_PARAMETER_PATHS.filter((param) => !param.optional);
+  const paths: string[] = ssmParams.map((param: SsmParameterPath) => param.path);
 
   const awsResponse = await ssmClient.getParameters({ Names: paths }).promise();
 

--- a/src/bin/commands/bootstrap/index.ts
+++ b/src/bin/commands/bootstrap/index.ts
@@ -1,11 +1,10 @@
 import chalk from "chalk";
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { ALL_SSM_PARAMETER_PATHS } from "../../../constants";
 import type { AwsBootstrap, CliCommandResponse } from "../../../types/cli";
 import { accountBootstrapCfn, createBootstrapStack } from "./bootstrap-stack";
 
 export const bootstrapCommand = async (props: AwsBootstrap): CliCommandResponse => {
-  const params = Object.values(SSM_PARAMETER_PATHS);
-  const tpl = await accountBootstrapCfn(params);
+  const tpl = await accountBootstrapCfn(ALL_SSM_PARAMETER_PATHS);
 
   if (props.dryRun) {
     console.log(tpl);

--- a/src/bin/commands/new-project/index.ts
+++ b/src/bin/commands/new-project/index.ts
@@ -7,7 +7,7 @@ import type { CliCommandResponse } from "../../../types/cli";
 import { execute } from "../../../utils/exec";
 import { gitRootOrCwd } from "../../../utils/git";
 import { constructApp } from "./utils/app";
-import { newAppImports, newStackImports, newTestImports } from "./utils/imports";
+import { Imports } from "./utils/imports";
 import { buildDirectory } from "./utils/init";
 import { constructTest } from "./utils/snapshot";
 import { constructStack } from "./utils/stack";
@@ -111,13 +111,13 @@ export const newCdkProject = async (props: NewProjectProps): CliCommandResponse 
     outputFile: "cdk.ts",
     outputDir: dirname(config.appPath),
     stack: config.stackName,
-    imports: newAppImports(config.appName),
+    imports: Imports.newAppImports(config.appName),
     stages: config.stages,
   });
 
   // lib directory
   await constructStack({
-    imports: newStackImports(),
+    imports: Imports.newStackImports(),
     appName: config.appName,
     outputFile: basename(config.stackPath),
     outputDir: dirname(config.stackPath),
@@ -126,7 +126,7 @@ export const newCdkProject = async (props: NewProjectProps): CliCommandResponse 
 
   // lib directory
   await constructTest({
-    imports: newTestImports(config.appName),
+    imports: Imports.newTestImports(config.appName),
     stackName: config.stackName,
     appName: config.appName,
     outputFile: basename(config.testPath),

--- a/src/bin/commands/new-project/utils/imports.ts
+++ b/src/bin/commands/new-project/utils/imports.ts
@@ -10,11 +10,11 @@ interface Import {
 export class Imports {
   imports: Record<string, Import>;
 
-  constructor(imports?: Record<string, Import>) {
-    this.imports = imports ?? {};
+  private constructor(imports: Record<string, Import>) {
+    this.imports = imports;
   }
 
-  addImport(lib: string, components: string[], type = false): void {
+  private addImport(lib: string, components: string[], type = false): void {
     if (!Object.keys(this.imports).includes(lib)) {
       const imports = type ? { types: components, components: [] } : { types: [], components };
 
@@ -35,6 +35,62 @@ export class Imports {
     }
 
     this.imports[lib] = imports;
+  }
+
+  public static newStackImports(): Imports {
+    return new Imports({
+      path: {
+        types: [],
+        components: ["join"],
+      },
+      "aws-cdk-lib/cloudformation-include": {
+        types: [],
+        components: ["CfnInclude"],
+      },
+      "aws-cdk-lib": {
+        types: ["App"],
+        components: [],
+      },
+      "@guardian/cdk/lib/constructs/core": {
+        types: ["GuStackProps"],
+        components: ["GuStack"],
+      },
+    });
+  }
+
+  public static newAppImports({ kebab, pascal }: Name): Imports {
+    const imports = new Imports({
+      "aws-cdk-lib": {
+        types: [],
+        components: ["App"],
+      },
+      "source-map-support/register": {
+        basic: true,
+        types: [],
+        components: [],
+      },
+    });
+
+    imports.addImport(`../lib/${kebab}`, [pascal]);
+
+    return imports;
+  }
+
+  public static newTestImports({ kebab, pascal }: Name): Imports {
+    const imports = new Imports({
+      "aws-cdk-lib": {
+        types: [],
+        components: ["App"],
+      },
+      "aws-cdk-lib/assertions": {
+        types: [],
+        components: ["Template"],
+      },
+    });
+
+    imports.addImport(`./${kebab}`, [pascal]);
+
+    return imports;
   }
 
   render(code: CodeMaker): void {
@@ -64,59 +120,3 @@ export class Imports {
     code.line();
   }
 }
-
-export const newStackImports = (): Imports => {
-  return new Imports({
-    path: {
-      types: [],
-      components: ["join"],
-    },
-    "aws-cdk-lib/cloudformation-include": {
-      types: [],
-      components: ["CfnInclude"],
-    },
-    "aws-cdk-lib": {
-      types: ["App"],
-      components: [],
-    },
-    "@guardian/cdk/lib/constructs/core": {
-      types: ["GuStackProps"],
-      components: ["GuStack"],
-    },
-  });
-};
-
-export const newAppImports = (app: Name): Imports => {
-  const imports = new Imports({
-    "aws-cdk-lib": {
-      types: [],
-      components: ["App"],
-    },
-    "source-map-support/register": {
-      basic: true,
-      types: [],
-      components: [],
-    },
-  });
-
-  imports.addImport(`../lib/${app.kebab}`, [app.pascal]);
-
-  return imports;
-};
-
-export const newTestImports = (appName: Name): Imports => {
-  const imports = new Imports({
-    "aws-cdk-lib": {
-      types: [],
-      components: ["App"],
-    },
-    "aws-cdk-lib/assertions": {
-      types: [],
-      components: ["Template"],
-    },
-  });
-
-  imports.addImport(`./${appName.kebab}`, [appName.pascal]);
-
-  return imports;
-};

--- a/src/bin/commands/new-project/utils/imports.ts
+++ b/src/bin/commands/new-project/utils/imports.ts
@@ -8,33 +8,10 @@ interface Import {
 }
 
 export class Imports {
-  imports: Record<string, Import>;
+  private readonly imports: Record<string, Import>;
 
   private constructor(imports: Record<string, Import>) {
     this.imports = imports;
-  }
-
-  private addImport(lib: string, components: string[], type = false): void {
-    if (!Object.keys(this.imports).includes(lib)) {
-      const imports = type ? { types: components, components: [] } : { types: [], components };
-
-      this.imports[lib] = imports;
-      return;
-    }
-
-    const imports = this.imports[lib];
-    if (type) {
-      // Check if any of the new types are already imported as components
-      // if so, don't add them as types too
-      imports.types = [...new Set(imports.types.concat(components.filter((c) => !imports.components.includes(c))))];
-    } else {
-      // Check if any of the new components are already imported as types
-      // if so, remove them from types before we add them to components
-      imports.types = imports.types.filter((t) => !components.includes(t));
-      imports.components = [...new Set(imports.components.concat(components))];
-    }
-
-    this.imports[lib] = imports;
   }
 
   public static newStackImports(): Imports {
@@ -59,7 +36,7 @@ export class Imports {
   }
 
   public static newAppImports({ kebab, pascal }: Name): Imports {
-    const imports = new Imports({
+    return new Imports({
       "aws-cdk-lib": {
         types: [],
         components: ["App"],
@@ -69,15 +46,15 @@ export class Imports {
         types: [],
         components: [],
       },
+      [`../lib/${kebab}`]: {
+        types: [],
+        components: [pascal],
+      },
     });
-
-    imports.addImport(`../lib/${kebab}`, [pascal]);
-
-    return imports;
   }
 
   public static newTestImports({ kebab, pascal }: Name): Imports {
-    const imports = new Imports({
+    return new Imports({
       "aws-cdk-lib": {
         types: [],
         components: ["App"],
@@ -86,11 +63,11 @@ export class Imports {
         types: [],
         components: ["Template"],
       },
+      [`./${kebab}`]: {
+        types: [],
+        components: [pascal],
+      },
     });
-
-    imports.addImport(`./${kebab}`, [pascal]);
-
-    return imports;
   }
 
   render(code: CodeMaker): void {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -125,7 +125,7 @@ parseCommandLineArguments()
         });
       }
       default:
-        throw new Error(`Unknown command: ${command}`);
+        throw new Error(`Unknown command: ${command ?? ""}`);
     }
   })
   .then((commandResponse) => {

--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -10,7 +10,7 @@ export interface SsmParameterPath {
 
 export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
 
-export const SSM_PARAMETER_PATHS: Record<string, SsmParameterPath> = {
+export const SSM_PARAMETER_PATHS = {
   Anghammarad: {
     path: "/account/services/anghammarad.topic.arn",
     description: "SSM parameter containing the ARN of the Anghammarad SNS topic",

--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -8,9 +8,21 @@ export interface SsmParameterPath {
   namingPattern?: string;
 }
 
+interface SsmParameterPaths {
+  Anghammarad: SsmParameterPath;
+  LoggingStreamName: SsmParameterPath;
+  DistributionBucket: SsmParameterPath;
+  AccessLoggingBucket: SsmParameterPath;
+  ConfigurationBucket: SsmParameterPath;
+  PrimaryVpcId: SsmParameterPath;
+  PrimaryVpcPrivateSubnets: SsmParameterPath;
+  PrimaryVpcPublicSubnets: SsmParameterPath;
+  FastlyCustomerId: SsmParameterPath;
+}
+
 export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
 
-export const SSM_PARAMETER_PATHS = {
+export const SSM_PARAMETER_PATHS: SsmParameterPaths = {
   Anghammarad: {
     path: "/account/services/anghammarad.topic.arn",
     description: "SSM parameter containing the ARN of the Anghammarad SNS topic",

--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -8,7 +8,7 @@ export interface SsmParameterPath {
   namingPattern?: string;
 }
 
-interface SsmParameterPaths {
+interface NamedSsmParameterPaths {
   Anghammarad: SsmParameterPath;
   LoggingStreamName: SsmParameterPath;
   DistributionBucket: SsmParameterPath;
@@ -22,7 +22,7 @@ interface SsmParameterPaths {
 
 export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
 
-export const SSM_PARAMETER_PATHS: SsmParameterPaths = {
+export const NAMED_SSM_PARAMETER_PATHS: NamedSsmParameterPaths = {
   Anghammarad: {
     path: "/account/services/anghammarad.topic.arn",
     description: "SSM parameter containing the ARN of the Anghammarad SNS topic",
@@ -64,3 +64,7 @@ export const SSM_PARAMETER_PATHS: SsmParameterPaths = {
     optional: true,
   },
 };
+
+export const ALL_SSM_PARAMETER_PATHS: SsmParameterPath[] = Object.values(
+  NAMED_SSM_PARAMETER_PATHS
+) as SsmParameterPath[];

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -49,6 +49,11 @@ export class GuUserData {
     props.files.forEach((bucketKey) => {
       const fileName = bucketKey.split("/").slice(-1)[0];
 
+      // `fileName` is typed as `string | undefined`. Throw if `fileName` is falsy.
+      if (!fileName) {
+        throw new Error("Failed to create configuration section in UserData");
+      }
+
       this.addS3DownloadCommand({
         bucket,
         bucketKey,

--- a/src/constructs/core/parameters/anghammarad.ts
+++ b/src/constructs/core/parameters/anghammarad.ts
@@ -1,4 +1,4 @@
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { NAMED_SSM_PARAMETER_PATHS } from "../../../constants";
 import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -15,8 +15,8 @@ export class GuAnghammaradTopicParameter extends GuStringParameter {
   private constructor(scope: GuStack) {
     super(scope, "AnghammaradSnsArn", {
       fromSSM: true,
-      default: SSM_PARAMETER_PATHS.Anghammarad.path,
-      description: SSM_PARAMETER_PATHS.Anghammarad.description,
+      default: NAMED_SSM_PARAMETER_PATHS.Anghammarad.path,
+      description: NAMED_SSM_PARAMETER_PATHS.Anghammarad.description,
     });
   }
 

--- a/src/constructs/core/parameters/fastly.ts
+++ b/src/constructs/core/parameters/fastly.ts
@@ -1,4 +1,4 @@
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { NAMED_SSM_PARAMETER_PATHS } from "../../../constants";
 import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -13,8 +13,8 @@ export class GuFastlyCustomerIdParameter extends GuStringParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "FastlyCustomerId", {
-      description: SSM_PARAMETER_PATHS.FastlyCustomerId.description,
-      default: SSM_PARAMETER_PATHS.FastlyCustomerId.path,
+      description: NAMED_SSM_PARAMETER_PATHS.FastlyCustomerId.description,
+      default: NAMED_SSM_PARAMETER_PATHS.FastlyCustomerId.path,
       fromSSM: true,
     });
   }

--- a/src/constructs/core/parameters/log-shipping.ts
+++ b/src/constructs/core/parameters/log-shipping.ts
@@ -1,4 +1,4 @@
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { NAMED_SSM_PARAMETER_PATHS } from "../../../constants";
 import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -8,8 +8,8 @@ export class GuLoggingStreamNameParameter extends GuStringParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "LoggingStreamName", {
-      description: SSM_PARAMETER_PATHS.LoggingStreamName.description,
-      default: SSM_PARAMETER_PATHS.LoggingStreamName.path,
+      description: NAMED_SSM_PARAMETER_PATHS.LoggingStreamName.description,
+      default: NAMED_SSM_PARAMETER_PATHS.LoggingStreamName.path,
       fromSSM: true,
     });
   }

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -1,4 +1,4 @@
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { NAMED_SSM_PARAMETER_PATHS } from "../../../constants";
 import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuStringParameter } from "./base";
@@ -12,8 +12,8 @@ export class GuDistributionBucketParameter extends GuStringParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "DistributionBucketName", {
-      description: SSM_PARAMETER_PATHS.DistributionBucket.description,
-      default: SSM_PARAMETER_PATHS.DistributionBucket.path,
+      description: NAMED_SSM_PARAMETER_PATHS.DistributionBucket.description,
+      default: NAMED_SSM_PARAMETER_PATHS.DistributionBucket.path,
       fromSSM: true,
     });
   }
@@ -32,8 +32,8 @@ export class GuPrivateConfigBucketParameter extends GuStringParameter {
 
   constructor(scope: GuStack) {
     super(scope, GuPrivateConfigBucketParameter.parameterName, {
-      description: SSM_PARAMETER_PATHS.ConfigurationBucket.description,
-      default: SSM_PARAMETER_PATHS.ConfigurationBucket.path,
+      description: NAMED_SSM_PARAMETER_PATHS.ConfigurationBucket.description,
+      default: NAMED_SSM_PARAMETER_PATHS.ConfigurationBucket.path,
       fromSSM: true,
     });
   }

--- a/src/constructs/core/parameters/vpc.ts
+++ b/src/constructs/core/parameters/vpc.ts
@@ -1,4 +1,4 @@
-import { SSM_PARAMETER_PATHS } from "../../../constants";
+import { NAMED_SSM_PARAMETER_PATHS } from "../../../constants";
 import { isSingletonPresentInStack } from "../../../utils/singleton";
 import type { GuStack } from "../stack";
 import { GuParameter } from "./base";
@@ -20,8 +20,8 @@ export class GuVpcParameter extends GuParameter {
 
   private constructor(scope: GuStack) {
     super(scope, "VpcId", {
-      description: SSM_PARAMETER_PATHS.PrimaryVpcId.description,
-      default: SSM_PARAMETER_PATHS.PrimaryVpcId.path,
+      description: NAMED_SSM_PARAMETER_PATHS.PrimaryVpcId.description,
+      default: NAMED_SSM_PARAMETER_PATHS.PrimaryVpcId.path,
       type: "AWS::EC2::VPC::Id",
       fromSSM: true,
     });

--- a/src/constructs/ec2/vpc.test.ts
+++ b/src/constructs/ec2/vpc.test.ts
@@ -9,8 +9,8 @@ describe("The GuVpc class", () => {
 
       const [subnet1, subnet2, ...rest] = GuVpc.subnets(stack, ["subnet1", "subnet2"]);
 
-      expect(subnet1.subnetId).toBe("subnet1");
-      expect(subnet2.subnetId).toBe("subnet2");
+      expect(subnet1?.subnetId).toBe("subnet1");
+      expect(subnet2?.subnetId).toBe("subnet2");
 
       // test that no extra subnets are defined
       expect(rest.length).toBe(0);

--- a/src/constructs/ec2/vpc.ts
+++ b/src/constructs/ec2/vpc.ts
@@ -52,7 +52,7 @@ export class GuVpc {
     const subnets = new GuSubnetListParameter(scope, `${maybeApp(props)}${type}Subnets`, {
       description: `A list of ${type.toLowerCase()} subnets`,
 
-      // TODO use `SSM_PARAMETER_PATHS.PrimaryVpcPrivateSubnets` or `SSM_PARAMETER_PATHS.PrimaryVpcPublicSubnets`
+      // TODO use `NAMED_SSM_PARAMETER_PATHS.PrimaryVpcPrivateSubnets` or `NAMED_SSM_PARAMETER_PATHS.PrimaryVpcPublicSubnets`
       default: `/account/vpc/primary/subnets/${type.toLowerCase()}`,
       fromSSM: true,
     });

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -5,7 +5,7 @@ import type { InstanceType, IPeer, IVpc } from "aws-cdk-lib/aws-ec2";
 import { Port } from "aws-cdk-lib/aws-ec2";
 import { ApplicationProtocol } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { AccessScope, SSM_PARAMETER_PATHS, TagKeys } from "../../constants";
+import { AccessScope, NAMED_SSM_PARAMETER_PATHS, TagKeys } from "../../constants";
 import { GuCertificate } from "../../constructs/acm";
 import type { GuUserDataProps } from "../../constructs/autoscaling";
 import { GuAutoScalingGroup, GuUserData } from "../../constructs/autoscaling";
@@ -427,8 +427,8 @@ export class GuEc2App {
 
     if (accessLogging.enabled) {
       const accessLoggingBucket = new GuStringParameter(scope, "AccessLoggingBucket", {
-        description: SSM_PARAMETER_PATHS.AccessLoggingBucket.description,
-        default: SSM_PARAMETER_PATHS.AccessLoggingBucket.path,
+        description: NAMED_SSM_PARAMETER_PATHS.AccessLoggingBucket.description,
+        default: NAMED_SSM_PARAMETER_PATHS.AccessLoggingBucket.path,
         fromSSM: true,
       });
 

--- a/src/utils/cli/vpc.ts
+++ b/src/utils/cli/vpc.ts
@@ -1,13 +1,13 @@
 import type AWS from "aws-sdk";
 import type { DescribeSubnetsResult, DescribeVpcsResult, SubnetList, Vpc, VpcList } from "aws-sdk/clients/ec2";
 import type { ParameterList } from "aws-sdk/clients/ssm";
-import { SSM_PARAMETER_PATHS, VPC_SSM_PARAMETER_PREFIX } from "../../constants";
+import { ALL_SSM_PARAMETER_PATHS, VPC_SSM_PARAMETER_PREFIX } from "../../constants";
 import type { VpcInDetail } from "../../types/cli";
 import { sum } from "../math";
 
-export const primaryVpcSsmParameterPaths: string[] = Object.values(SSM_PARAMETER_PATHS)
-  .map((_) => _.path)
-  .filter((_) => _.startsWith(VPC_SSM_PARAMETER_PREFIX));
+export const primaryVpcSsmParameterPaths: string[] = ALL_SSM_PARAMETER_PATHS.map((_) => _.path).filter((_) =>
+  _.startsWith(VPC_SSM_PARAMETER_PREFIX)
+);
 
 export const vpcSsmParameterPaths: RegExp[] = primaryVpcSsmParameterPaths.map((primaryPath) => {
   const reBody = primaryPath.replace("primary", "([A-z0-9.-_])+");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
     "sourceMap": true,
     "inlineSourceMap": false,
     "inlineSources": true,


### PR DESCRIPTION
It might be easier to review this change commit by commit.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[Introduced](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess) in TS 4.1, [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) offers stricter type checking, which is a good thing!

From the release notes:

> That means that in our last example, `opts.yadda` will have the type `string | number | undefined` as opposed to just `string | number`. If you need to access that property, you’ll either have to check for its existence first or use a non-null assertion operator (the postfix `!` character).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

CI passing should be sufficient.