### PR TITLE
fix: Force release of fixed critical vulnerability in pr 1364

### DIFF
--- a/docs/setting-up-a-gucdk-project.md
+++ b/docs/setting-up-a-gucdk-project.md
@@ -48,7 +48,7 @@ Patterns are TypeScript classes that create the requisite AWS resources for a co
 (e.g. when using [`serverless-express`](https://github.com/vendia/serverless-express))
   * when [routing different requests to different Lambda functions based on the path](https://guardian.github.io/cdk/classes/patterns.GuApiGatewayWithLambdaByPath.html)
 
-> Tip: You can find a full list of available patterns [here](https://guardian.github.io/cdk/modules/patterns.html).
+> Tip: You can find a full list of the available patterns [here](https://guardian.github.io/cdk/modules/patterns.html).
 
 Patterns can be imported from the top level of the library:
 


### PR DESCRIPTION
This PR's entire purpose is to force the release of https://github.com/guardian/cdk/pull/1364 which fixes a critical vulnerability in [git-url-parse](https://github.com/IonicaBizau/git-url-parse) by bumping it to the latest version.

## What does this change?
Actual change is a very minor readme change (I insert the word 'the' in a sentence where it fits)

