### PR TITLE
chore: new item test-update in package.json

### DIFF
--- a/src/bin/commands/new-project/utils/init.ts
+++ b/src/bin/commands/new-project/utils/init.ts
@@ -115,6 +115,7 @@ function createPackageJson(outputDirectory: string): void {
     scripts: {
       build: "tsc",
       test: "jest",
+      "test-update": "jest -u",
       format: 'prettier --write "{lib,bin}/**/*.ts"',
       lint: "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
       synth: "cdk synth --path-metadata false --version-reporting false",


### PR DESCRIPTION
## What does this change?
Added test-update to package.json to make pre commit check easier by including the snapshot ci will expect

## How to test
script/ci-project-generation
will create a test project in 
/private/tmp/cdk-project
where you can check out the generated package.json
