### PR TITLE
fix(GuVpc): Configure AZs for eu-west-1 region, so you don't have to

### DIFF
--- a/src/constructs/vpc/__snapshots__/vpc.test.ts.snap
+++ b/src/constructs/vpc/__snapshots__/vpc.test.ts.snap
@@ -127,15 +127,8 @@ Object {
     },
     "MyVpcapplicationSubnet1Subnet0A4FCBEC": Object {
       "Properties": Object {
-        "AvailabilityZone": Object {
-          "Fn::Select": Array [
-            0,
-            Object {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
-        "CidrBlock": "10.0.128.0/18",
+        "AvailabilityZone": "eu-west-1a",
+        "CidrBlock": "10.0.96.0/19",
         "MapPublicIpOnLaunch": false,
         "Tags": Array [
           Object {
@@ -228,15 +221,8 @@ Object {
     },
     "MyVpcapplicationSubnet2Subnet04E944F4": Object {
       "Properties": Object {
-        "AvailabilityZone": Object {
-          "Fn::Select": Array [
-            1,
-            Object {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
-        "CidrBlock": "10.0.192.0/18",
+        "AvailabilityZone": "eu-west-1b",
+        "CidrBlock": "10.0.128.0/19",
         "MapPublicIpOnLaunch": false,
         "Tags": Array [
           Object {
@@ -274,6 +260,100 @@ Object {
       },
       "Type": "AWS::EC2::Subnet",
     },
+    "MyVpcapplicationSubnet3DefaultRouteD7A3BDF3": Object {
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "MyVpcingressSubnet3NATGateway8C3F8115",
+        },
+        "RouteTableId": Object {
+          "Ref": "MyVpcapplicationSubnet3RouteTable94563292",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "MyVpcapplicationSubnet3RouteTable94563292": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Test/MyVpc/applicationSubnet3",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "MyVpcF9F0CA6F",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "MyVpcapplicationSubnet3RouteTableAssociationE29CB40A": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "MyVpcapplicationSubnet3RouteTable94563292",
+        },
+        "SubnetId": Object {
+          "Ref": "MyVpcapplicationSubnet3Subnet36843A8F",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "MyVpcapplicationSubnet3Subnet36843A8F": Object {
+      "Properties": Object {
+        "AvailabilityZone": "eu-west-1c",
+        "CidrBlock": "10.0.160.0/19",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "application",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Test/MyVpc/applicationSubnet3",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "MyVpcF9F0CA6F",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
     "MyVpcdynamodb4933D0A6": Object {
       "Properties": Object {
         "RouteTableIds": Array [
@@ -284,10 +364,16 @@ Object {
             "Ref": "MyVpcapplicationSubnet2RouteTable1A5026C8",
           },
           Object {
+            "Ref": "MyVpcapplicationSubnet3RouteTable94563292",
+          },
+          Object {
             "Ref": "MyVpcingressSubnet1RouteTableBD23564A",
           },
           Object {
             "Ref": "MyVpcingressSubnet2RouteTable17765BD0",
+          },
+          Object {
+            "Ref": "MyVpcingressSubnet3RouteTable218CD36A",
           },
         ],
         "ServiceName": Object {
@@ -435,15 +521,8 @@ Object {
     },
     "MyVpcingressSubnet1Subnet05B4D133": Object {
       "Properties": Object {
-        "AvailabilityZone": Object {
-          "Fn::Select": Array [
-            0,
-            Object {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
-        "CidrBlock": "10.0.0.0/18",
+        "AvailabilityZone": "eu-west-1a",
+        "CidrBlock": "10.0.0.0/19",
         "MapPublicIpOnLaunch": true,
         "Tags": Array [
           Object {
@@ -607,15 +686,8 @@ Object {
     },
     "MyVpcingressSubnet2Subnet6E3FCA55": Object {
       "Properties": Object {
-        "AvailabilityZone": Object {
-          "Fn::Select": Array [
-            1,
-            Object {
-              "Fn::GetAZs": "",
-            },
-          ],
-        },
-        "CidrBlock": "10.0.64.0/18",
+        "AvailabilityZone": "eu-west-1b",
+        "CidrBlock": "10.0.32.0/19",
         "MapPublicIpOnLaunch": true,
         "Tags": Array [
           Object {
@@ -653,6 +725,171 @@ Object {
       },
       "Type": "AWS::EC2::Subnet",
     },
+    "MyVpcingressSubnet3DefaultRouteEEE78E68": Object {
+      "DependsOn": Array [
+        "MyVpcVPCGW488ACE0D",
+      ],
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "MyVpcIGW5C4A4F63",
+        },
+        "RouteTableId": Object {
+          "Ref": "MyVpcingressSubnet3RouteTable218CD36A",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "MyVpcingressSubnet3EIPCC82CF52": Object {
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Test/MyVpc/ingressSubnet3",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "MyVpcingressSubnet3NATGateway8C3F8115": Object {
+      "DependsOn": Array [
+        "MyVpcingressSubnet3DefaultRouteEEE78E68",
+        "MyVpcingressSubnet3RouteTableAssociation0850FC5F",
+      ],
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "MyVpcingressSubnet3EIPCC82CF52",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "MyVpcingressSubnet3SubnetB43CCB2C",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Test/MyVpc/ingressSubnet3",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "MyVpcingressSubnet3RouteTable218CD36A": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Test/MyVpc/ingressSubnet3",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "MyVpcF9F0CA6F",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "MyVpcingressSubnet3RouteTableAssociation0850FC5F": Object {
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "MyVpcingressSubnet3RouteTable218CD36A",
+        },
+        "SubnetId": Object {
+          "Ref": "MyVpcingressSubnet3SubnetB43CCB2C",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "MyVpcingressSubnet3SubnetB43CCB2C": Object {
+      "Properties": Object {
+        "AvailabilityZone": "eu-west-1c",
+        "CidrBlock": "10.0.64.0/19",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "ingress",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "Test/MyVpc/ingressSubnet3",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "MyVpcF9F0CA6F",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
     "MyVpcs3D9E23531": Object {
       "Properties": Object {
         "RouteTableIds": Array [
@@ -663,10 +900,16 @@ Object {
             "Ref": "MyVpcapplicationSubnet2RouteTable1A5026C8",
           },
           Object {
+            "Ref": "MyVpcapplicationSubnet3RouteTable94563292",
+          },
+          Object {
             "Ref": "MyVpcingressSubnet1RouteTableBD23564A",
           },
           Object {
             "Ref": "MyVpcingressSubnet2RouteTable17765BD0",
+          },
+          Object {
+            "Ref": "MyVpcingressSubnet3RouteTable218CD36A",
           },
         ],
         "ServiceName": Object {
@@ -709,6 +952,10 @@ Object {
               Object {
                 "Ref": "MyVpcapplicationSubnet2Subnet04E944F4",
               },
+              ",",
+              Object {
+                "Ref": "MyVpcapplicationSubnet3Subnet36843A8F",
+              },
             ],
           ],
         },
@@ -735,6 +982,10 @@ Object {
               ",",
               Object {
                 "Ref": "MyVpcingressSubnet2Subnet6E3FCA55",
+              },
+              ",",
+              Object {
+                "Ref": "MyVpcingressSubnet3SubnetB43CCB2C",
               },
             ],
           ],

--- a/src/constructs/vpc/vpc.test.ts
+++ b/src/constructs/vpc/vpc.test.ts
@@ -4,13 +4,16 @@ import { GuVpc } from "./vpc";
 
 describe("The GuVpc construct", () => {
   it("should match snapshot", () => {
-    const stack = simpleGuStackForTesting({ stack: "test-stack" });
+    const stack = simpleGuStackForTesting({
+      stack: "test-stack",
+      env: { region: "eu-west-1", account: "000000000000" },
+    });
     new GuVpc(stack, "MyVpc");
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 
   it("should create VPC SSM parameters by default", () => {
-    const stack = simpleGuStackForTesting({ stack: "test-stack" });
+    const stack = simpleGuStackForTesting({ stack: "test-stack", env: { account: "000000000000" } });
     new GuVpc(stack, "MyVpc", { ssmParameters: true });
 
     const template = Template.fromStack(stack);
@@ -25,7 +28,7 @@ describe("The GuVpc construct", () => {
   });
 
   it("should not create VPC SSM parameters if set to false", () => {
-    const stack = simpleGuStackForTesting({ stack: "test-stack" });
+    const stack = simpleGuStackForTesting({ stack: "test-stack", env: { account: "000000000000" } });
     new GuVpc(stack, "MyVpc", { ssmParameters: false });
 
     Template.fromStack(stack).resourceCountIs("AWS::SSM::Parameter", 0);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The number of AZs in eu-west-1 is fairly static (at least it hasn't changed in over a decade).

In this change, we programmatically set the context for the `GuVpc` construct so that users don't have to commit the, slightly magical, `cdk.context.json` file. This has caused some confusion in the past, see https://github.com/guardian/editorial-tools-platform/pull/623#discussion_r928768448.

Note: The [aws-account-setup](https://github.com/guardian/aws-account-setup/blob/e455a0826e4d827ef3ddb840efce280c942f6dff/lib/aws-account-setup.ts#L120-L125) repo is already successfully using this "trick".


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See CI?

It's worth noting that the snapshot test has been updated quite significantly. This is because the AZs are known at synth time, rather than runtime (i.e. we've shifted left). This is a good thing, as it means the shape of the resulting CFN resources become more deterministic.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Less confusion for the end user.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

What happens if we create a VPC outside of eu-west-1? Currently, the `cdk.context.json` file still needs to be added to VCS by users as before.

We're almost exclusively in this region though, so I'm not sure how much of an issue this is. I'd suggest we address it at the time.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
