### PR TITLE
refactor: Clearer default value for GuParameter

### DIFF
--- a/src/constructs/core/parameters/base.test.ts
+++ b/src/constructs/core/parameters/base.test.ts
@@ -19,7 +19,7 @@ describe("The GuParameter class", () => {
     new GuParameter(stack, "Parameter", { type: "Boolean", fromSSM: true });
 
     Template.fromStack(stack).hasParameter("Parameter", {
-      Default: "/$STAGE/$STACK/$APP/parameter",
+      Default: "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param",
       Type: "AWS::SSM::Parameter::Value<Boolean>",
     });
   });
@@ -30,7 +30,7 @@ describe("The GuParameter class", () => {
     new GuParameter(stack, "Parameter", { fromSSM: true });
 
     Template.fromStack(stack).hasParameter("Parameter", {
-      Default: "/$STAGE/$STACK/$APP/parameter",
+      Default: "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param",
       Type: "AWS::SSM::Parameter::Value<String>",
     });
   });
@@ -41,7 +41,7 @@ describe("The GuParameter class", () => {
     new GuParameter(stack, "Parameter", { type: "Boolean", fromSSM: true, description: "This is a test" });
 
     Template.fromStack(stack).hasParameter("Parameter", {
-      Default: "/$STAGE/$STACK/$APP/parameter",
+      Default: "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param",
       Type: "AWS::SSM::Parameter::Value<Boolean>",
       Description: "This is a test",
     });
@@ -53,7 +53,7 @@ describe("The GuParameter class", () => {
     new GuParameter(stack, "Parameter", { fromSSM: true });
 
     Template.fromStack(stack).hasParameter("Parameter", {
-      Default: "/$STAGE/$STACK/$APP/parameter",
+      Default: "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param",
     });
   });
 

--- a/src/constructs/core/parameters/base.ts
+++ b/src/constructs/core/parameters/base.ts
@@ -16,7 +16,7 @@ export class GuParameter extends CfnParameter {
 
   constructor(scope: GuStack, id: string, props: GuParameterProps) {
     super(scope, id, {
-      ...(props.fromSSM && { default: "/$STAGE/$STACK/$APP/parameter" }),
+      ...(props.fromSSM && { default: "Add the SSM path as the default value e.g. /$stage/$stack/$app/$param" }),
       ...props,
       type: props.fromSSM ? `AWS::SSM::Parameter::Value<${props.type ?? "String"}>` : props.type,
     });


### PR DESCRIPTION
## What does this change?

This change update the default value for `GuParameter` to describe that the value is used to route to the value in SSM, which is non-obvious.

The intention is to provide slightly better hints to consumers when they use `GuParameter` in their projects in order to make using GuCDK a more pleasant experience.

