### PR TITLE
docs: add mock for version-info to best practices

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -30,6 +30,7 @@ To use it, first, create `jest.setup.js` and add the global mock:
 
 ```javascript
 jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock("@guardian/cdk/lib/constants/version-info");
 ```
 
 Next, edit `jest.config.js` setting the [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array) property:


### PR DESCRIPTION
## What does this change?

- Adds mock for `version-info` constants to the best practices docs, to ensure snapshot tests don't fail across GuCDK version upgrades following the introduction of the Metadata aspect (8f610647f53c3fe17a3b40f68a66202460281ba7) 
