### PR TITLE
feat: Optional appName for tag

### DIFF
--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -23,7 +23,7 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
   /**
    * Optional name of the app. If defined, all resources will have an App tag.
    */
-  appName?: string;
+  app?: string;
 
   /**
    * The AWS CloudFormation stack name (as shown in the AWS CloudFormation UI).
@@ -74,7 +74,7 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
 export class GuStack extends Stack implements StackStageIdentity {
   private readonly _stack: string;
   private readonly _stage: string;
-  private readonly _appName?: string;
+  private readonly _app?: string;
 
   get stage(): string {
     return this._stage;
@@ -84,8 +84,8 @@ export class GuStack extends Stack implements StackStageIdentity {
     return this._stack;
   }
 
-  get appName(): string | undefined {
-    return this._appName;
+  get app(): string | undefined {
+    return this._app;
   }
 
   /**
@@ -117,10 +117,10 @@ export class GuStack extends Stack implements StackStageIdentity {
   }
 
   // eslint-disable-next-line custom-rules/valid-constructors -- GuStack is the exception as it must take an App
-  constructor(app: App, id: string, props: GuStackProps) {
+  constructor(scope: App, id: string, props: GuStackProps) {
     const { cloudFormationStackName = process.env.GU_CFN_STACK_NAME, stack, stage, withoutTags } = props;
 
-    super(app, id, {
+    super(scope, id, {
       ...props,
       stackName: cloudFormationStackName,
 
@@ -137,8 +137,8 @@ export class GuStack extends Stack implements StackStageIdentity {
 
       this.addTag("Stack", this.stack);
       this.addTag("Stage", this.stage);
-      if (this.appName) {
-        this.addTag("App", this.appName);
+      if (this.app) {
+        this.addTag("App", this.app);
       }
 
       this.tryAddRepositoryTag();

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -20,6 +20,8 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
 
   stage: string;
 
+  appName?: string;
+
   /**
    * The AWS CloudFormation stack name (as shown in the AWS CloudFormation UI).
    * @defaultValue the `GU_CFN_STACK_NAME` environment variable
@@ -69,6 +71,7 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
 export class GuStack extends Stack implements StackStageIdentity {
   private readonly _stack: string;
   private readonly _stage: string;
+  private readonly _appName?: string;
 
   get stage(): string {
     return this._stage;
@@ -76,6 +79,10 @@ export class GuStack extends Stack implements StackStageIdentity {
 
   get stack(): string {
     return this._stack;
+  }
+
+  get appName(): string | undefined {
+    return this._appName;
   }
 
   /**
@@ -127,6 +134,9 @@ export class GuStack extends Stack implements StackStageIdentity {
 
       this.addTag("Stack", this.stack);
       this.addTag("Stage", this.stage);
+      if (this.appName) {
+        this.addTag("App", this.appName);
+      }
 
       this.tryAddRepositoryTag();
     }

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -20,6 +20,9 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
 
   stage: string;
 
+  /**
+   * Optional name of the app. If defined, all resources will have an App tag.
+   */
   appName?: string;
 
   /**


### PR DESCRIPTION
It's useful to have all resources in a stack tagged with `App`, specifically for monitoring costs by app