### PR TITLE
docs: Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ development framework to define cloud infrastructure in code and provision it
 through AWS CloudFormation.
 
 `@guardian/cdk` builds on CDK to provide Guardian-specific [patterns](./src/patterns) and
-[constructs](./src/construcst). It is an opinionated and secure-by-default way to describe and
+[constructs](./src/constructs). It is an opinionated and secure-by-default way to describe and
 provision your AWS resources.
 
 Jump to:


### PR DESCRIPTION
## What does this change?

Fixes a typo that led to a broken link

## How to test
Click the link to verify it works
