### PR TITLE
test: Purposefully use a different version of `aws-cdk-lib` and `aws-cdk`

### DIFF
--- a/src/bin/commands/new-project/utils/init.ts
+++ b/src/bin/commands/new-project/utils/init.ts
@@ -92,8 +92,8 @@ function createPackageJson(outputDirectory: string): void {
        */
     ...(!isTest && { "@guardian/cdk": LibraryInfo.VERSION }),
 
-    "aws-cdk": LibraryInfo.AWS_CDK_VERSION,
-    "aws-cdk-lib": LibraryInfo.AWS_CDK_VERSION,
+    "aws-cdk": "2.39.1",
+    "aws-cdk-lib": "2.44.0",
     constructs: LibraryInfo.CONSTRUCTS_VERSION,
   };
 


### PR DESCRIPTION
This is a demo PR to test the behaviour of using a mismatched version of `aws-cdk` and `aws-cdk-lib`.

See also: https://github.com/guardian/cdk/pull/1512.