### PR TITLE
revert: Revert "ci: Run AWS CDK updater today" [skip-ci]

### DIFF
--- a/.github/workflows/update-aws-cdk.yaml
+++ b/.github/workflows/update-aws-cdk.yaml
@@ -3,9 +3,6 @@ on:
     # At 10:00 on day-of-month 10.
     # See https://crontab.guru/#0_10_10_*_*
     - cron: '0 10 10 * *'
-
-    # only temporary for today, will remove afterwards
-    - cron: '0 13 * * *'
 jobs:
   update-aws-cdk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts guardian/cdk#1518, as promised!

To merge after 2PM BST, as schedules are UTC.