### PR TITLE
fix(metadata): Enable reporting on more constructs

### DIFF
--- a/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
+++ b/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
@@ -5,6 +5,7 @@ exports[`The GuCname construct should create the correct resources with minimal 
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStack",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -30,6 +31,7 @@ exports[`The GuDnsRecordSet construct should create the correct resources with m
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStack",
+      "GuDnsRecordSet",
     ],
     "gu:cdk:version": "TEST",
   },

--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -1,5 +1,6 @@
 import type { Duration } from "aws-cdk-lib";
 import { CfnResource } from "aws-cdk-lib";
+import { Construct } from "constructs";
 import type { GuDomainName } from "../../types";
 import type { AppIdentity, GuStack } from "../core";
 
@@ -20,10 +21,20 @@ export interface GuDnsRecordSetProps {
  * Prefer to use [[`GuCname`]] when creating a CNAME for a load balancer,
  * as this requires less boilerplate.
  */
-export class GuDnsRecordSet {
+export class GuDnsRecordSet extends Construct {
   constructor(scope: GuStack, id: string, props: GuDnsRecordSetProps) {
     const { name, recordType, resourceRecords, ttl } = props;
     const { stage } = scope;
+
+    /*
+    Nodes in the CDK tree must have a unique ID. This class adds two nodes to the tree, so we have two IDs.
+    `id`, by definition, must be unique. `name` represents a fully qualified domain name, which must also be unique.
+    `id` being given to the level 1 construct means it also becomes the logicalId in the template.
+     */
+    const level2ConstructId = name;
+    const level1ConstructId = id;
+
+    super(scope, level2ConstructId);
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- more `RecordType`s will be added soon!
     if (recordType === RecordType.CNAME) {
@@ -45,7 +56,7 @@ export class GuDnsRecordSet {
 
     // The spec for this private resource type can be found here:
     // https://github.com/guardian/cfn-private-resource-types/tree/main/dns/guardian-dns-record-set-type/docs#syntax
-    new CfnResource(scope, id, {
+    new CfnResource(scope, level1ConstructId, {
       type: "Guardian::DNS::RecordSet",
       properties: {
         Name: name,

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -99,6 +99,7 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStack",
+      "GuEcsTask",
       "GuDistributionBucketParameter",
     ],
     "gu:cdk:version": "TEST",

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -16,6 +16,7 @@ import { Topic } from "aws-cdk-lib/aws-sns";
 import { IntegrationPattern, StateMachine } from "aws-cdk-lib/aws-stepfunctions";
 import type { TaskEnvironmentVariable } from "aws-cdk-lib/aws-stepfunctions-tasks";
 import { EcsFargateLaunchTarget, EcsRunTask } from "aws-cdk-lib/aws-stepfunctions-tasks";
+import { Construct } from "constructs";
 import type { NoMonitoring } from "../cloudwatch";
 import type { GuStack } from "../core";
 import { AppIdentity } from "../core";
@@ -135,10 +136,12 @@ const getContainer = (config: ContainerConfiguration) => {
  * Note that if your task reliably completes in less than 15 minutes then you should probably use a [[`GuLambda`]] instead. This
  * pattern was mainly created to work around the 15 minute lambda timeout.
  */
-export class GuEcsTask {
+export class GuEcsTask extends Construct {
   stateMachine: StateMachine;
 
   constructor(scope: GuStack, id: string, props: GuEcsTaskProps) {
+    super(scope, id);
+
     const {
       app,
 

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -8,6 +8,7 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
       "GuDistributionBucketParameter",
       "GuApiLambda",
       "GuCertificate",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },

--- a/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
+++ b/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
@@ -9,6 +9,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuApiGatewayWithLambdaByPath",
     ],
     "gu:cdk:version": "TEST",
   },

--- a/src/patterns/api-multiple-lambdas.ts
+++ b/src/patterns/api-multiple-lambdas.ts
@@ -1,5 +1,6 @@
 import type { RestApiProps } from "aws-cdk-lib/aws-apigateway";
 import { LambdaIntegration, RestApi } from "aws-cdk-lib/aws-apigateway";
+import { Construct } from "constructs";
 import type { Http5xxAlarmProps, NoMonitoring } from "../constructs/cloudwatch";
 import { GuApiGateway5xxPercentageAlarm } from "../constructs/cloudwatch/api-gateway-alarms";
 import type { AppIdentity, GuStack } from "../constructs/core";
@@ -119,10 +120,11 @@ function isNoMonitoring(
  *
  * For details on configuring the individual Lambda functions, see [[`GuLambdaFunction`]].
  */
-export class GuApiGatewayWithLambdaByPath {
+export class GuApiGatewayWithLambdaByPath extends Construct {
   public readonly api: RestApi;
 
   constructor(scope: GuStack, props: GuApiGatewayWithLambdaByPathProps) {
+    super(scope, props.app); // The assumption is `app` is unique
     const apiGateway = new RestApi(scope, "RestApi", {
       // Override to avoid clashes as default is just api ID, which is often shared across stages.
       restApiName: `${scope.stack}-${scope.stage}-${props.app}`,

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -5,6 +5,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStack",
+      "GuEc2App",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuCertificate",
@@ -829,6 +830,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
   "Metadata": {
     "gu:cdk:constructs": [
       "GuStack",
+      "GuEc2App",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuCertificate",

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -5,6 +5,7 @@ import type { InstanceType, IPeer, IVpc } from "aws-cdk-lib/aws-ec2";
 import { Port } from "aws-cdk-lib/aws-ec2";
 import { ApplicationProtocol } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
 import { AccessScope, MetadataKeys, NAMED_SSM_PARAMETER_PATHS } from "../../constants";
 import { GuCertificate } from "../../constructs/acm";
 import type { GuUserDataProps } from "../../constructs/autoscaling";
@@ -313,7 +314,7 @@ function restrictedCidrRanges(ranges: IPeer[]) {
  * cfnLb.securityGroups = [sg.securityGroupId];
  * ```
  */
-export class GuEc2App {
+export class GuEc2App extends Construct {
   /*
    * These are public for now, as this allows users to
    * modify these constructs as desired to fit their
@@ -347,6 +348,8 @@ export class GuEc2App {
       withoutImdsv2,
       imageRecipe,
     } = props;
+
+    super(scope, app); // The assumption is `app` is unique
 
     // We should really prevent users from doing this via the type system,
     // but that requires a breaking change to the API


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In #1394 we introduced an Aspect to add a Metadata element to the synthesised template. It walks the CDK tree and if it finds a node that starts with "Gu", it adds to the Metadata element.

A node on the CDK tree is a specific type - [`Node`](https://github.com/aws/constructs/blob/4926d6f304442915777db36f039ea7b38c83ad1d/src/construct.ts#L18-L21). In this change, we make some of our custom "constructs" formally extend [`Construct`](https://github.com/aws/constructs/blob/4926d6f304442915777db36f039ea7b38c83ad1d/src/construct.ts#L418-L424). A `Construct` [has a `Node`](https://github.com/aws/constructs/blob/4926d6f304442915777db36f039ea7b38c83ad1d/src/construct.ts#L8-L16), and so appears on the tree.

That is, by extending `Construct` _and_ having a class name prefixed "Gu", we are able to report usage of these constructs.

In this change, we begin to report on the following (and any sub-classes):
- `GuDnsRecordSet `
- `GuEcsTask`
- `GuEc2App`
- `GuApiGatewayWithLambdaByPath`

### Notes
- A `Construct` also has a validate phase, so it might make sense to refactor [some checks](https://github.com/guardian/cdk/blob/59e7ad230158ecf41d96a97790539a404d2e48cd/src/constructs/ecs/ecs-task.ts#L159-L163) to this model, but suggest we do this separately.
- Not everything can be tracked via the Metadata Aspect by simply extending `Construct`, only nodes that sit within/below a `GuStack` can. [`RiffRaffYamlFileExperimental`](https://github.com/guardian/cdk/blob/59e7ad230158ecf41d96a97790539a404d2e48cd/src/experimental/riff-raff-yaml-file/index.ts), for example, sits _above_ a `GuStack` in the tree.
- Is there potential for a lint rule here - any exported class should extend `Construct`? It shouldn't error though!

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See CI - the snapshots have been updated to reflect the changes.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More usage data.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
