### PR TITLE
feat: add first attempt at experimental error budget alarm

### DIFF
--- a/src/experimental/constructs/__snapshots__/error-budget-alarm.test.ts.snap
+++ b/src/experimental/constructs/__snapshots__/error-budget-alarm.test.ts.snap
@@ -1,0 +1,1033 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The ErrorBudgetAlarmExperimental construct should accept math expressions for more complicated definitions of bad/valid events 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuErrorBudgetAlarmExperimental",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Resources": {
+    "ChildAlarmForFastBurnOver1hour45C7AB22": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForFastBurnOver1 hour",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Expression": "loadBalancerErrors + targetErrors",
+            "Id": "badEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "loadBalancerErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "LbHttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 3600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "targetErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "TargetHttpErrors",
+                "Namespace": "TestTargetMetrics",
+              },
+              "Period": 3600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Expression": "allRequests - invalidRequests",
+            "Id": "validEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "allRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 3600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "invalidRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "BadRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 3600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.014400000000000013,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForFastBurnOver5minutes67EDAF36": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForFastBurnOver5 minutes",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Expression": "loadBalancerErrors + targetErrors",
+            "Id": "badEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "loadBalancerErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "LbHttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "targetErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "TargetHttpErrors",
+                "Namespace": "TestTargetMetrics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Expression": "allRequests - invalidRequests",
+            "Id": "validEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "allRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "invalidRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "BadRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.014400000000000013,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForMediumBurnOver30minutesF70BC2E5": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForMediumBurnOver30 minutes",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Expression": "loadBalancerErrors + targetErrors",
+            "Id": "badEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "loadBalancerErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "LbHttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 1800,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "targetErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "TargetHttpErrors",
+                "Namespace": "TestTargetMetrics",
+              },
+              "Period": 1800,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Expression": "allRequests - invalidRequests",
+            "Id": "validEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "allRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 1800,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "invalidRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "BadRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 1800,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.006000000000000005,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForMediumBurnOver6hoursC8B7C019": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForMediumBurnOver6 hours",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Expression": "loadBalancerErrors + targetErrors",
+            "Id": "badEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "loadBalancerErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "LbHttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 21600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "targetErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "TargetHttpErrors",
+                "Namespace": "TestTargetMetrics",
+              },
+              "Period": 21600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Expression": "allRequests - invalidRequests",
+            "Id": "validEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "allRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 21600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "invalidRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "BadRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 21600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.006000000000000005,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForSlowBurnOver1day9466C64F": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForSlowBurnOver1 day",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Expression": "loadBalancerErrors + targetErrors",
+            "Id": "badEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "loadBalancerErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "LbHttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 86400,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "targetErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "TargetHttpErrors",
+                "Namespace": "TestTargetMetrics",
+              },
+              "Period": 86400,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Expression": "allRequests - invalidRequests",
+            "Id": "validEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "allRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 86400,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "invalidRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "BadRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 86400,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.0030000000000000027,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForSlowBurnOver2hoursC240626B": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForSlowBurnOver2 hours",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Expression": "loadBalancerErrors + targetErrors",
+            "Id": "badEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "loadBalancerErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "LbHttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 7200,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "targetErrors",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "TargetHttpErrors",
+                "Namespace": "TestTargetMetrics",
+              },
+              "Period": 7200,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Expression": "allRequests - invalidRequests",
+            "Id": "validEvents",
+            "ReturnData": false,
+          },
+          {
+            "Id": "allRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 7200,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "invalidRequests",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "BadRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 7200,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.0030000000000000027,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MapiFrontsAvailabilityFastBurnCompositeAlarmA8F736A8": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-sns-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "TestMapiFrontsAvailabilityFastBurnCompositeAlarmF4979734",
+        "AlarmRule": {
+          "Fn::Join": [
+            "",
+            [
+              "(ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForFastBurnOver1hour45C7AB22",
+                  "Arn",
+                ],
+              },
+              "") AND ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForFastBurnOver5minutes67EDAF36",
+                  "Arn",
+                ],
+              },
+              ""))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "MapiFrontsAvailabilityMediumBurnCompositeAlarmEC8DC379": {
+      "Properties": {
+        "ActionsSuppressor": {
+          "Fn::GetAtt": [
+            "MapiFrontsAvailabilityFastBurnCompositeAlarmA8F736A8",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 1800,
+        "ActionsSuppressorWaitPeriod": 120,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-sns-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "TestMapiFrontsAvailabilityMediumBurnCompositeAlarm7022D40E",
+        "AlarmRule": {
+          "Fn::Join": [
+            "",
+            [
+              "(ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForMediumBurnOver6hoursC8B7C019",
+                  "Arn",
+                ],
+              },
+              "") AND ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForMediumBurnOver30minutesF70BC2E5",
+                  "Arn",
+                ],
+              },
+              ""))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "MapiFrontsAvailabilitySlowBurnCompositeAlarm1198F7B4": {
+      "Properties": {
+        "ActionsSuppressor": {
+          "Fn::GetAtt": [
+            "MapiFrontsAvailabilityMediumBurnCompositeAlarmEC8DC379",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 7200,
+        "ActionsSuppressorWaitPeriod": 120,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-sns-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "TestMapiFrontsAvailabilitySlowBurnCompositeAlarm5EDECA5E",
+        "AlarmRule": {
+          "Fn::Join": [
+            "",
+            [
+              "(ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForSlowBurnOver1day9466C64F",
+                  "Arn",
+                ],
+              },
+              "") AND ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForSlowBurnOver2hoursC240626B",
+                  "Arn",
+                ],
+              },
+              ""))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+  },
+}
+`;
+
+exports[`The ErrorBudgetAlarmExperimental construct should create the correct resources with basic config 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuErrorBudgetAlarmExperimental",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Resources": {
+    "ChildAlarmForFastBurnOver1hour45C7AB22": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForFastBurnOver1 hour",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Id": "badEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 3600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "validEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 3600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.014400000000000013,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForFastBurnOver5minutes67EDAF36": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForFastBurnOver5 minutes",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Id": "badEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "validEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.014400000000000013,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForMediumBurnOver30minutesF70BC2E5": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForMediumBurnOver30 minutes",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Id": "badEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 1800,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "validEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 1800,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.006000000000000005,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForMediumBurnOver6hoursC8B7C019": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForMediumBurnOver6 hours",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Id": "badEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 21600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "validEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 21600,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.006000000000000005,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForSlowBurnOver1day9466C64F": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForSlowBurnOver1 day",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Id": "badEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 86400,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "validEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 86400,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.0030000000000000027,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ChildAlarmForSlowBurnOver2hoursC240626B": {
+      "Properties": {
+        "AlarmName": "ChildAlarmForSlowBurnOver2 hours",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "badEvents/validEvents",
+            "Id": "expr_1",
+            "Label": "Observed failure rate",
+          },
+          {
+            "Id": "badEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpErrors",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 7200,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "validEvents",
+            "MetricStat": {
+              "Metric": {
+                "MetricName": "HttpRequests",
+                "Namespace": "TestLoadBalancerMetrics",
+              },
+              "Period": 7200,
+              "Stat": "Average",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0.0030000000000000027,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MapiFrontsAvailabilityFastBurnCompositeAlarmA8F736A8": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-sns-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "TestMapiFrontsAvailabilityFastBurnCompositeAlarmF4979734",
+        "AlarmRule": {
+          "Fn::Join": [
+            "",
+            [
+              "(ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForFastBurnOver1hour45C7AB22",
+                  "Arn",
+                ],
+              },
+              "") AND ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForFastBurnOver5minutes67EDAF36",
+                  "Arn",
+                ],
+              },
+              ""))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "MapiFrontsAvailabilityMediumBurnCompositeAlarmEC8DC379": {
+      "Properties": {
+        "ActionsSuppressor": {
+          "Fn::GetAtt": [
+            "MapiFrontsAvailabilityFastBurnCompositeAlarmA8F736A8",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 1800,
+        "ActionsSuppressorWaitPeriod": 120,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-sns-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "TestMapiFrontsAvailabilityMediumBurnCompositeAlarm7022D40E",
+        "AlarmRule": {
+          "Fn::Join": [
+            "",
+            [
+              "(ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForMediumBurnOver6hoursC8B7C019",
+                  "Arn",
+                ],
+              },
+              "") AND ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForMediumBurnOver30minutesF70BC2E5",
+                  "Arn",
+                ],
+              },
+              ""))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "MapiFrontsAvailabilitySlowBurnCompositeAlarm1198F7B4": {
+      "Properties": {
+        "ActionsSuppressor": {
+          "Fn::GetAtt": [
+            "MapiFrontsAvailabilityMediumBurnCompositeAlarmEC8DC379",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 7200,
+        "ActionsSuppressorWaitPeriod": 120,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":test-sns-topic",
+              ],
+            ],
+          },
+        ],
+        "AlarmName": "TestMapiFrontsAvailabilitySlowBurnCompositeAlarm5EDECA5E",
+        "AlarmRule": {
+          "Fn::Join": [
+            "",
+            [
+              "(ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForSlowBurnOver1day9466C64F",
+                  "Arn",
+                ],
+              },
+              "") AND ALARM("",
+              {
+                "Fn::GetAtt": [
+                  "ChildAlarmForSlowBurnOver2hoursC240626B",
+                  "Arn",
+                ],
+              },
+              ""))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+  },
+}
+`;

--- a/src/experimental/constructs/error-budget-alarm.test.ts
+++ b/src/experimental/constructs/error-budget-alarm.test.ts
@@ -1,0 +1,42 @@
+import { Template } from "aws-cdk-lib/assertions";
+import { MathExpression, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { simpleGuStackForTesting } from "../../utils/test";
+import { GuErrorBudgetAlarmExperimental } from "./error-budget-alarm";
+
+describe("The ErrorBudgetAlarmExperimental construct", () => {
+  it("should create the correct resources with basic config", () => {
+    const stack = simpleGuStackForTesting();
+    new GuErrorBudgetAlarmExperimental(stack, {
+      sloName: "MapiFrontsAvailability",
+      sloTarget: 0.999,
+      badEvents: new Metric({ metricName: "HttpErrors", namespace: "TestLoadBalancerMetrics" }),
+      validEvents: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
+      snsTopicNameForAlerts: "test-sns-topic",
+    });
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+
+  it("should accept math expressions for more complicated definitions of bad/valid events", () => {
+    const stack = simpleGuStackForTesting();
+    new GuErrorBudgetAlarmExperimental(stack, {
+      sloName: "MapiFrontsAvailability",
+      sloTarget: 0.999,
+      badEvents: new MathExpression({
+        expression: "loadBalancerErrors + targetErrors",
+        usingMetrics: {
+          loadBalancerErrors: new Metric({ metricName: "LbHttpErrors", namespace: "TestLoadBalancerMetrics" }),
+          targetErrors: new Metric({ metricName: "TargetHttpErrors", namespace: "TestTargetMetrics" }),
+        },
+      }),
+      validEvents: new MathExpression({
+        expression: "allRequests - invalidRequests",
+        usingMetrics: {
+          allRequests: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
+          invalidRequests: new Metric({ metricName: "BadRequests", namespace: "TestLoadBalancerMetrics" }),
+        },
+      }),
+      snsTopicNameForAlerts: "test-sns-topic",
+    });
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/experimental/constructs/error-budget-alarm.ts
+++ b/src/experimental/constructs/error-budget-alarm.ts
@@ -1,0 +1,208 @@
+import { Duration } from "aws-cdk-lib";
+import type { CfnCompositeAlarm, IMetric } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  Alarm,
+  AlarmRule,
+  AlarmState,
+  ComparisonOperator,
+  CompositeAlarm,
+  MathExpression,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import type { ITopic } from "aws-cdk-lib/aws-sns";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Construct } from "constructs";
+import type { GuStack } from "../../constructs/core";
+
+export interface ErrorBudgetAlarmProps {
+  sloName: string;
+  sloTarget: number;
+  badEvents: IMetric;
+  validEvents: IMetric;
+  snsTopicNameForAlerts: string;
+}
+
+interface BurnRate {
+  speed: "Fast" | "Medium" | "Slow";
+  burnRate: number;
+}
+
+interface BurnRateMonitoring extends BurnRate {
+  longPeriod: Duration;
+  shortPeriod: Duration;
+}
+
+interface MonitorBurnRateForPeriodProps {
+  alarmName: string;
+  burnRateSpeed: BurnRate;
+  period: Duration;
+  errorBudget: number;
+  badEvents: IMetric;
+  validEvents: IMetric;
+}
+
+interface CompositeBurnRateAlarmProps {
+  sloName: string;
+  burnRateMonitoring: BurnRateMonitoring;
+  errorBudget: number;
+  badEvents: IMetric;
+  validEvents: IMetric;
+  snsTopic: ITopic;
+  suppressorAlarm?: CompositeBurnRateAlarm;
+}
+
+/**
+ * Use this construct to create alarms that will notify you when you are at risk of missing your SLO targets.
+ *
+ * These alarms follow the recommendations in the [SRE Workbook](https://sre.google/workbook/alerting-on-slos/) to
+ * implement Multiwindow, Multi-Burn-Rate Alerts.
+ *
+ * The CloudWatch implementation of this strategy creates nine separate CloudWatch alarms. The main alarms that users
+ * need to care about are the three composite alarms. These track different burn rates of error budget consumption:
+ * fast (e.g. complete outages), medium (e.g. moderate error percentage over hours, rather than minutes) and slow (e.g.
+ * a small percentage of errors sustained over a much longer period). Multiple burn rates are used to ensure that
+ * we are able to pick up all scenarios which could threaten the SLO, without interrupting developers with an
+ * unnecessary level of urgency.
+ *
+ * Each composite alarm creates two child alarms; these are used to support multiple windows (or periods in CloudWatch
+ * terminology). A composite alarm is configured to send notifications if both of its child alarms are in an alarm state.
+ * The child alarms themselves have no actions/notifications configured and users should not need to interact with them
+ * directly. Multiple windows are helpful for accuracy and reset time. The long window helps us to avoid sending an
+ * alert in scenarios where no intervention is required, for example a very brief spike in errors that is resolved
+ * automatically (e.g. when AWS replaces a 'bad' EC2 instance). The short window helps to ensure that the alert is reset
+ * (or moved back into OK state, in CloudWatch terminology) promptly once a problem has been resolved.
+ *
+ * The composite alarms have an awareness of priority, meaning that low priority alarm notifications are suppressed if
+ * a higher priority alarm is already firing. That is, if you receive an alert about fast error budget consumption, you
+ * should not receive an alert from the medium or slow versions of the alarm.
+ */
+export class GuErrorBudgetAlarmExperimental extends Construct {
+  constructor(scope: GuStack, props: ErrorBudgetAlarmProps) {
+    super(scope, props.sloName); // The assumption here is that `sloName` will be unique (per stack)
+
+    const errorBudget = 1 - props.sloTarget;
+
+    const snsTopic: ITopic = Topic.fromTopicArn(
+      scope,
+      `SnsSloAlarmsFor${props.sloName}`,
+      `arn:aws:sns:${scope.region}:${scope.account}:${props.snsTopicNameForAlerts}`
+    );
+
+    const fastBurnRate: BurnRateMonitoring = {
+      speed: "Fast",
+      burnRate: 14.4,
+      longPeriod: Duration.hours(1),
+      shortPeriod: Duration.minutes(5),
+    };
+
+    const fastBurnAlarm = new CompositeBurnRateAlarm(scope, {
+      sloName: props.sloName,
+      badEvents: props.badEvents,
+      burnRateMonitoring: fastBurnRate,
+      errorBudget,
+      snsTopic,
+      validEvents: props.validEvents,
+    });
+
+    const mediumBurnRateMonitoring: BurnRateMonitoring = {
+      speed: "Medium",
+      burnRate: 6,
+      longPeriod: Duration.hours(6),
+      shortPeriod: Duration.minutes(30),
+    };
+
+    const mediumBurnRateAlarm = new CompositeBurnRateAlarm(scope, {
+      sloName: props.sloName,
+      badEvents: props.badEvents,
+      burnRateMonitoring: mediumBurnRateMonitoring,
+      errorBudget,
+      snsTopic,
+      validEvents: props.validEvents,
+      suppressorAlarm: fastBurnAlarm,
+    });
+
+    const slowBurnRate: BurnRateMonitoring = {
+      speed: "Slow",
+      burnRate: 3,
+      longPeriod: Duration.days(1),
+      shortPeriod: Duration.hours(2),
+    };
+
+    new CompositeBurnRateAlarm(scope, {
+      sloName: props.sloName,
+      badEvents: props.badEvents,
+      burnRateMonitoring: slowBurnRate,
+      errorBudget,
+      // TODO - use a different topic for tickets or figure out how to route notifications vs tickets using a single topic
+      snsTopic,
+      validEvents: props.validEvents,
+      suppressorAlarm: mediumBurnRateAlarm,
+    });
+  }
+}
+
+class MonitorBurnRateForPeriod extends Alarm {
+  constructor(scope: GuStack, props: MonitorBurnRateForPeriodProps) {
+    const undesirableErrorBudgetConsumption = props.errorBudget * props.burnRateSpeed.burnRate;
+    const alarmName = `ChildAlarmFor${props.burnRateSpeed.speed}BurnOver${props.period.toHumanString()}`;
+    super(scope, alarmName, {
+      alarmName: alarmName,
+      metric: new MathExpression({
+        expression: "badEvents/validEvents",
+        label: "Observed failure rate",
+        usingMetrics: {
+          badEvents: props.badEvents,
+          validEvents: props.validEvents,
+        },
+        period: props.period,
+      }),
+      evaluationPeriods: 1,
+      threshold: undesirableErrorBudgetConsumption,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+    });
+  }
+}
+
+class CompositeBurnRateAlarm extends CompositeAlarm {
+  constructor(scope: GuStack, props: CompositeBurnRateAlarmProps) {
+    const alarmName = `${props.sloName}${props.burnRateMonitoring.speed}BurnCompositeAlarm`;
+    const sharedIndividualAlarmProps = {
+      badEvents: props.badEvents,
+      burnRateSpeed: {
+        speed: props.burnRateMonitoring.speed,
+        burnRate: props.burnRateMonitoring.burnRate,
+      },
+      errorBudget: props.errorBudget,
+      validEvents: props.validEvents,
+    };
+    super(scope, alarmName, {
+      alarmRule: AlarmRule.allOf(
+        AlarmRule.fromAlarm(
+          new MonitorBurnRateForPeriod(scope, {
+            ...sharedIndividualAlarmProps,
+            alarmName: `ChildAlarmLongPeriod${alarmName}`,
+            period: props.burnRateMonitoring.longPeriod,
+          }),
+          AlarmState.ALARM
+        ),
+        AlarmRule.fromAlarm(
+          new MonitorBurnRateForPeriod(scope, {
+            ...sharedIndividualAlarmProps,
+            alarmName: `ChildAlarmShortPeriod${alarmName}`,
+            period: props.burnRateMonitoring.shortPeriod,
+          }),
+          AlarmState.ALARM
+        )
+      ),
+    });
+    this.addAlarmAction(new SnsAction(props.snsTopic));
+    if (props.suppressorAlarm) {
+      const cfnAlarm = this.node.defaultChild as CfnCompositeAlarm;
+      cfnAlarm.actionsSuppressor = props.suppressorAlarm.alarmArn;
+      cfnAlarm.actionsSuppressorWaitPeriod = 120;
+      cfnAlarm.actionsSuppressorExtensionPeriod = props.burnRateMonitoring.shortPeriod.toSeconds();
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

This PR adds a new experimental construct which aims to create alarms that will notify teams when they are at risk of missing their SLO targets.

The alarm configuration that we create follows the recommendations in the [SRE Workbook](https://sre.google/workbook/alerting-on-slos/) to implement `Multiwindow, Multi-Burn-Rate Alerts`. There is also another nice explanation of this alerting strategy [here](https://developers.soundcloud.com/blog/alerting-on-slos).
 
The CloudWatch implementation of this strategy creates nine separate CloudWatch alarms. The main alarms that users need to care about are the three [composite alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html). These track different burn rates of error budget consumption: 

* fast (e.g. complete outages)
* medium (e.g. moderate error percentage over hours, rather than minutes) 
* slow (e.g. a small percentage of errors sustained over a much longer period)

Multiple burn rates are used to ensure that we are able to pick up all scenarios which could threaten the SLO, without interrupting developers with an unnecessary level of urgency:

![image](https://user-images.githubusercontent.com/19384074/198985926-e6f38b03-aa4b-48a5-83c1-f2d338c4ceaf.png)
_The image above is taken from Google's `Alerting on SLOs` chapter._

Each composite alarm creates two child alarms; these are used to support multiple windows (or periods in CloudWatch terminology). A composite alarm is configured to send notifications if both of its child alarms are in an `ALARM` state. The child alarms themselves have no actions/notifications configured and users should not need to interact with them directly.  Here's an example of how that looks in the AWS console:

![image](https://user-images.githubusercontent.com/19384074/199013792-e7c3adbd-63cc-4b15-bb2a-8eaf6452b8aa.png)

Multiple windows are helpful for accuracy and reset time. The long window helps us to avoid sending an alert in scenarios where no intervention is required, for example a very brief spike in errors that is resolved automatically (e.g. when AWS replaces a 'bad' EC2 instance). The short window helps to ensure that the alert is reset (or moved back into `OK` state, in CloudWatch terminology) promptly once a problem has been resolved:

![image](https://user-images.githubusercontent.com/19384074/198985995-bd54e737-082d-43d0-9e4c-bc32c60be5ed.png)
_The image above is taken from Google's `Alerting on SLOs` chapter._

The composite alarms have an awareness of priority, meaning that low priority alarm notifications are [suppressed](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html#Create_Composite_Alarm_Suppression) if a higher priority alarm is already firing. That is, if you receive an alert about fast error budget consumption, you should not receive an alert from the medium or slow versions of the alarm. Here's an example of how that looks in the AWS console:

![image](https://user-images.githubusercontent.com/19384074/199013923-63d418a0-4706-4095-8b75-76a3e6584a4c.png)

Although the generated alarm configuration is quite complex most of this is abstracted away. Developers working on `cdk` code need only supply high level configuration like this:

```typescript
new GuErrorBudgetAlarmExperimental(stack, {
    sloName: "MapiFrontsAvailability",
    sloTarget: 0.999,
    badEvents: new Metric({ metricName: "HttpErrors", namespace: "TestLoadBalancerMetrics" }),
    validEvents: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
    snsTopicNameForAlerts: "test-sns-topic",
});
```

## How to test

I have (manually) tested this alert configuration using the `cdk-playground` project to confirm that it works as expected. I've added a couple of snapshot tests to document how this works and keep a record of a working version of the configuration. We'll need to continue to test this with real services so that we can see how it behaves with real traffic patterns and real SLOs etc.

## How can we measure success?

We will attempt to use this construct with the MSS team over the next couple of months. We hope that this approach to alerting will prove to be useful. If we're correct about that (and we decide that CloudWatch is an appropriate tool for this task) then we will look to 'productionise' this construct so that it can be used more widely. If it is not helpful (or if CloudWatch doesn't seem like the best tool for the job), we'll just delete this construct and help MSS to pick up the preferred solution instead.

## Have we considered potential risks?

I think this is pretty low risk. We are experimenting with a new technique and are therefore using an experimental construct, as per [this ADR](https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/005-x01-package-structure.md).

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
