### PR TITLE
fix: Add restriction to the slo target value

### DIFF
--- a/src/experimental/constructs/error-budget-alarm.test.ts
+++ b/src/experimental/constructs/error-budget-alarm.test.ts
@@ -26,7 +26,7 @@ describe("The ErrorBudgetAlarmExperimental construct", () => {
         validEvents: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
         snsTopicNameForAlerts: "test-sns-topic",
       });
-    }).toThrowError();
+    }).toThrowError("ErrorBudgetAlarm only works with SLO targets between 0.95 and 0.9995");
   });
 
   it("should fail to create Alarm when slo target is below 95%", () => {
@@ -39,7 +39,7 @@ describe("The ErrorBudgetAlarmExperimental construct", () => {
         validEvents: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
         snsTopicNameForAlerts: "test-sns-topic",
       });
-    }).toThrowError();
+    }).toThrowError("ErrorBudgetAlarm only works with SLO targets between 0.95 and 0.9995");
   });
 
   it("should accept math expressions for more complicated definitions of bad/valid events", () => {

--- a/src/experimental/constructs/error-budget-alarm.test.ts
+++ b/src/experimental/constructs/error-budget-alarm.test.ts
@@ -16,6 +16,32 @@ describe("The ErrorBudgetAlarmExperimental construct", () => {
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 
+  it("should fail to create Alarm when slo target is above 99.95%", () => {
+    const stack = simpleGuStackForTesting();
+    expect(() => {
+      new GuErrorBudgetAlarmExperimental(stack, {
+        sloName: "MapiFrontsAvailability",
+        sloTarget: 0.9996,
+        badEvents: new Metric({ metricName: "HttpErrors", namespace: "TestLoadBalancerMetrics" }),
+        validEvents: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
+        snsTopicNameForAlerts: "test-sns-topic",
+      });
+    }).toThrowError();
+  });
+
+  it("should fail to create Alarm when slo target is below 95%", () => {
+    const stack = simpleGuStackForTesting();
+    expect(() => {
+      new GuErrorBudgetAlarmExperimental(stack, {
+        sloName: "MapiFrontsAvailability",
+        sloTarget: 0.9499,
+        badEvents: new Metric({ metricName: "HttpErrors", namespace: "TestLoadBalancerMetrics" }),
+        validEvents: new Metric({ metricName: "HttpRequests", namespace: "TestLoadBalancerMetrics" }),
+        snsTopicNameForAlerts: "test-sns-topic",
+      });
+    }).toThrowError();
+  });
+
   it("should accept math expressions for more complicated definitions of bad/valid events", () => {
     const stack = simpleGuStackForTesting();
     new GuErrorBudgetAlarmExperimental(stack, {

--- a/src/experimental/constructs/error-budget-alarm.ts
+++ b/src/experimental/constructs/error-budget-alarm.ts
@@ -15,6 +15,16 @@ import { Topic } from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
 import type { GuStack } from "../../constructs/core";
 
+/**
+ * Props for creating an ErrorBudgetAlarm
+ *
+ * - sloName: The name of the SLO
+ * - sloTarget: The percentange target for the SLO, expressed as a decimal floating point number. Must be between 0.95 and 0.995
+ * - badEvents: the metric representing the bad events. Can be any IMetric type, like Metric or MathExpression
+ * - validEvents: the metric representing the events to be considered. Can be any IMetric type, like Metric or MathExpression
+ * - snsTopicNameForAlerts: the sns topic used by the alarm to send email alerts
+ *
+ */
 export interface ErrorBudgetAlarmProps {
   sloName: string;
   sloTarget: number;
@@ -76,9 +86,20 @@ interface CompositeBurnRateAlarmProps {
  * The composite alarms have an awareness of priority, meaning that low priority alarm notifications are suppressed if
  * a higher priority alarm is already firing. That is, if you receive an alert about fast error budget consumption, you
  * should not receive an alert from the medium or slow versions of the alarm.
+ *
+ * For how to instantiate an ErrorBudgetAlarm check the unit-test in error-budget-alarm.test.ts,
+ * and for a description of the props that need to be passed see [[ErrorBudgetAlarmProps]]
  */
 export class GuErrorBudgetAlarmExperimental extends Construct {
   constructor(scope: GuStack, props: ErrorBudgetAlarmProps) {
+    const lowestTargetAllowed = 0.95;
+    const highestTargetAllowed = 0.9995;
+    if (!(props.sloTarget >= lowestTargetAllowed && props.sloTarget <= highestTargetAllowed)) {
+      throw new Error(
+        `ErrorBudgetAlarm only works with SLO targets between ${lowestTargetAllowed} and ${highestTargetAllowed}`
+      );
+    }
+
     super(scope, props.sloName); // The assumption here is that `sloName` will be unique (per stack)
 
     const errorBudget = 1 - props.sloTarget;

--- a/src/experimental/constructs/error-budget-alarm.ts
+++ b/src/experimental/constructs/error-budget-alarm.ts
@@ -15,9 +15,6 @@ import { Topic } from "aws-cdk-lib/aws-sns";
 import { Construct } from "constructs";
 import type { GuStack } from "../../constructs/core";
 
-/**
- * Props for creating an ErrorBudgetAlarm
- */
 export interface ErrorBudgetAlarmProps {
   /**
    * The name of the SLO. Assumed to be unique per stack.

--- a/src/experimental/constructs/error-budget-alarm.ts
+++ b/src/experimental/constructs/error-budget-alarm.ts
@@ -22,7 +22,7 @@ import type { GuStack } from "../../constructs/core";
  * - sloTarget: The percentange target for the SLO, expressed as a decimal floating point number. Must be between 0.95 and 0.995
  * - badEvents: the metric representing the bad events. Can be any IMetric type, like Metric or MathExpression
  * - validEvents: the metric representing the events to be considered. Can be any IMetric type, like Metric or MathExpression
- * - snsTopicNameForAlerts: the sns topic used by the alarm to send email alerts
+ * - snsTopicNameForAlerts: the sns topic name (not the full arn) used by the alarm to send email alerts
  *
  */
 export interface ErrorBudgetAlarmProps {

--- a/src/experimental/constructs/error-budget-alarm.ts
+++ b/src/experimental/constructs/error-budget-alarm.ts
@@ -17,19 +17,27 @@ import type { GuStack } from "../../constructs/core";
 
 /**
  * Props for creating an ErrorBudgetAlarm
- *
- * - sloName: The name of the SLO
- * - sloTarget: The percentange target for the SLO, expressed as a decimal floating point number. Must be between 0.95 and 0.995
- * - badEvents: the metric representing the bad events. Can be any IMetric type, like Metric or MathExpression
- * - validEvents: the metric representing the events to be considered. Can be any IMetric type, like Metric or MathExpression
- * - snsTopicNameForAlerts: the sns topic name (not the full arn) used by the alarm to send email alerts
- *
  */
 export interface ErrorBudgetAlarmProps {
+  /**
+   * The name of the SLO. Assumed to be unique per stack.
+   */
   sloName: string;
+  /**
+   * The percentange target for the SLO, expressed as a decimal floating point number. Must be between 0.95 and 0.995.
+   */
   sloTarget: number;
+  /**
+   * The metric representing the bad events. Can be any IMetric type, like Metric or MathExpression.
+   */
   badEvents: IMetric;
+  /**
+   * The metric representing the events to be considered. Can be any IMetric type, like Metric or MathExpression.
+   */
   validEvents: IMetric;
+  /**
+   * The sns topic name (not the full arn) used by the alarm to send email alerts.
+   */
   snsTopicNameForAlerts: string;
 }
 


### PR DESCRIPTION
## What does this change?

This makes `GuErrorBudgetAlarmExperimental` throw an error if the client passes an SLO target outside the valid range, which is 95% to 99.95%.

This is because outside of these bounds, the way the alarms are configured do not produce useful results. For example, with an SLO target of 90%, the fast alarm will never trigger (this is the one that work on an hour-long time window).

If the SLO target is overambitious, for example 99.999%, then the alarm will fire but only after the SLO target has been missed, and its error budget consumed (in an hour long window, this would happen in 26 seconds). Because this alert wouldn't be actionable, we don't recommend people use it. For this level of availability, a totally different approach needs to be taken.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->
We have added unit tests to cover the different boundary conditions.

## Have we considered potential risks?
This is low risk because it's an experimental construct.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
