### PR TITLE
docs: add experimental constructs and patterns to TypeDoc site

### DIFF
--- a/src/experimental/constructs/index.ts
+++ b/src/experimental/constructs/index.ts
@@ -1,0 +1,2 @@
+export * from "./error-budget-alarm";
+export * from "./root";

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,6 +1,7 @@
 const { readdirSync, existsSync } = require("fs");
 
 const constructsDir = "src/constructs";
+const experimentalDir = "src/experimental";
 const utilsDir = "src/utils";
 
 function getEntryPointsFromSubdirectories(directory) {
@@ -16,8 +17,9 @@ module.exports = {
     "src/patterns/index.ts",
     "src/constants/index.ts",
     "src/types/index.ts",
-    // we purposefully do not have an index.ts in `src/constructs` or `src/utils`
+    // we purposefully do not have an index.ts in `src/constructs`, `src/experimental` or `src/utils`
     ...getEntryPointsFromSubdirectories(constructsDir),
+    ...getEntryPointsFromSubdirectories(experimentalDir),
     ...getEntryPointsFromSubdirectories(utilsDir),
   ],
   out: "target",


### PR DESCRIPTION
## What does this change?

I realised that experimental constructs and patterns were accidentally omitted from the TypeDoc site (inspired by https://github.com/guardian/cdk/pull/1580#discussion_r1011614027!), so I have fixed this in this PR.

## How to test

Run `./script/start-docs` locally.

## How can we measure success?

It's easier to learn how to use experimental constructs and patterns!

## Have we considered potential risks?

I don't think there are any risks associated with this PR.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
