### PR TITLE
fix(dns): Ensure Level 2 construct has unique ID

### DIFF
--- a/src/constructs/dns/dns-records.ts
+++ b/src/constructs/dns/dns-records.ts
@@ -31,7 +31,7 @@ export class GuDnsRecordSet extends Construct {
     `id`, by definition, must be unique. `name` represents a fully qualified domain name, which must also be unique.
     `id` being given to the level 1 construct means it also becomes the logicalId in the template.
      */
-    const level2ConstructId = name;
+    const level2ConstructId = `${name}-DnsRecordSet`;
     const level1ConstructId = id;
 
     super(scope, level2ConstructId);


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Fixes a regression introduced in https://github.com/guardian/cdk/pull/1532. Nodes in a CDK tree must have a unique ID. A [typical usage](https://github.com/guardian/security-hq/blob/aa2f2c03277faac9dc01a06d2082f1c85bb439ed/cdk/lib/security-hq.ts#L135-L140) of `GuCname` looks like this:

```ts
new GuCname(this, 'security-hq.gutools.co.uk', {
  app: "security-hq",
  domainName: 'security-hq.gutools.co.uk',
  ttl: Duration.hours(1),
  resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
});
```

Here:
 - `level1ConstructId` = `security-hq.gutools.co.uk`, as set by the user
 - `level2ConstructId` = `security-hq.gutools.co.uk`, as derived from `domainName` prop

This results in an attempt to add the same ID to the CDK tree.

In this change we update the `GuDnsRecordSet` level 2 construct, to have a unique ID compared to the level 1 construct it creates:
 - `level1ConstructId` = `security-hq.gutools.co.uk`, as set by the user
 - `level2ConstructId` = `security-hq.gutools.co.uk-DnsRecordSet`

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

N/A. The value of `level2ConstructId` never makes it's way to the synthed template, so no tests are changed.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The upgrade path for Security HQ is simpler.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

N/A - see note in "How to test" above.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
