### PR TITLE
feat: Allow users of GuApiGatewayWithLambdaByPathProps construct to require an apiKey on resources

### DIFF
--- a/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
+++ b/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
@@ -9,6 +9,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
       "GuApiGatewayWithLambdaByPath",
     ],
     "gu:cdk:version": "TEST",
@@ -140,12 +141,14 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50379728be2fcf730be7407c2847944bca5": {
+    "RestApiDeployment180EC50383363c5ced7927aa10a2d324d85bde7b": {
       "DependsOn": [
         "RestApitestalongpathGET4832AA08",
         "RestApitestalongpath289D7A7A",
         "RestApitestalong4FF54021",
         "RestApitesta85B86F6B",
+        "RestApitestapikeyGET1702B039",
+        "RestApitestapikey06021A80",
         "RestApitestGET8B10FED0",
         "RestApitestPOSTEE6B79A5",
         "RestApitest9059D171",
@@ -164,7 +167,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50379728be2fcf730be7407c2847944bca5",
+          "Ref": "RestApiDeployment180EC50383363c5ced7927aa10a2d324d85bde7b",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -595,6 +598,344 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "RestApitestapikey06021A80": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "RestApitest9059D171",
+        },
+        "PathPart": "api-key",
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApitestapikeyGET1702B039": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "lambdafour0ED67C43",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "RestApitestapikey06021A80",
+        },
+        "RestApiId": {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApitestapikeyGETApiPermissionTestRestApiF6F94545GETtestapikey32823AD8": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "lambdafour0ED67C43",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/",
+              {
+                "Ref": "RestApiDeploymentStageprod3855DE66",
+              },
+              "/GET/test/api-key",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "RestApitestapikeyGETApiPermissionTestTestRestApiF6F94545GETtestapikey743ED656": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "lambdafour0ED67C43",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "RestApi0C43BF4B",
+              },
+              "/test-invoke-stage/GET/test/api-key",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdafour0ED67C43": {
+      "DependsOn": [
+        "lambdafourServiceRoleDefaultPolicyA62AFE29",
+        "lambdafourServiceRole304B6DE3",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "test-stack/TEST/testing/my-app-4.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "handler.ts",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "lambdafourServiceRole304B6DE3",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "lambdafourServiceRole304B6DE3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "lambdafourServiceRoleDefaultPolicyA62AFE29": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/test-stack/TEST/testing/my-app-4.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/testing",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/testing/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "lambdafourServiceRoleDefaultPolicyA62AFE29",
+        "Roles": [
+          {
+            "Ref": "lambdafourServiceRole304B6DE3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "lambdaoneA536F07A": {
       "DependsOn": [

--- a/src/patterns/api-multiple-lambdas.test.ts
+++ b/src/patterns/api-multiple-lambdas.test.ts
@@ -24,6 +24,10 @@ describe("The GuApiGatewayWithLambdaByPath pattern", () => {
       ...defaultProps,
       fileName: "my-app-3.zip",
     });
+    const lambdaFour = new GuLambdaFunction(stack, "lambda-four", {
+      ...defaultProps,
+      fileName: "my-app-4.zip",
+    });
     new GuApiGatewayWithLambdaByPath(stack, {
       app: "testing",
       monitoringConfiguration: { noMonitoring: true },
@@ -42,6 +46,12 @@ describe("The GuApiGatewayWithLambdaByPath pattern", () => {
           path: "/test/a/long/path",
           httpMethod: "GET",
           lambda: lambdaThree,
+        },
+        {
+          path: "/test/api-key",
+          httpMethod: "GET",
+          lambda: lambdaFour,
+          apiKeyRequired: true,
         },
       ],
     });

--- a/src/patterns/api-multiple-lambdas.ts
+++ b/src/patterns/api-multiple-lambdas.ts
@@ -22,6 +22,10 @@ export interface ApiTarget {
    * The Lambda function responsible for handling the request.
    */
   lambda: GuLambdaFunction;
+  /**
+   * Whether an apiKey is required for this method.
+   */
+  apiKeyRequired?: true;
 }
 
 /**
@@ -134,7 +138,9 @@ export class GuApiGatewayWithLambdaByPath extends Construct {
     this.api = apiGateway;
     props.targets.map((target) => {
       const resource = apiGateway.root.resourceForPath(target.path);
-      resource.addMethod(target.httpMethod, new LambdaIntegration(target.lambda));
+      resource.addMethod(target.httpMethod, new LambdaIntegration(target.lambda), {
+        apiKeyRequired: target.apiKeyRequired,
+      });
     });
     if (!isNoMonitoring(props.monitoringConfiguration)) {
       new GuApiGateway5xxPercentageAlarm(scope, {


### PR DESCRIPTION
## What does this change?
The `GuApiGatewayWithLambdaByPathProps` construct provides an easy way to set up an Api Gateway endpoint backed by a lambda, however there was previously no way to specify that this endpoint should require an api key. 

This PR adds that functionality by adding an optional `apiKeyRequired` property to the `ApiTarget` interface used to specify endpoints.

## How to test
There is a Jest test provided

## How can we measure success?
Users of the `GuApiGatewayWithLambdaByPathProps` construct should be able to create endpoints secured by an api key without additional code.

## Have we considered potential risks?
None that I can see, the property is optional so behaviour for existing clients is unchanged

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
