### PR TITLE
feat: add Google Auth to EC2 patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Guardian CDK Library
+# Guardian CDK Library 
 
 ![npm][badge-npm] [![CD][badge-cd]][internal-cd-file]
 

--- a/src/constants/metadata-keys.ts
+++ b/src/constants/metadata-keys.ts
@@ -5,4 +5,5 @@ export const MetadataKeys = {
   PATTERN_NAME: "gu:cdk:pattern-name",
   LOG_KINESIS_STREAM_NAME: "LogKinesisStreamName",
   SYSTEMD_UNIT: "SystemdUnit",
+  CDK_FEATURE: "gu:cdk:feature",
 };

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -531,6 +531,8 @@ export class GuEc2App extends Construct {
       });
 
       listener.addAction("auth", { action: authAction });
+
+      Tags.of(loadBalancer).add(MetadataKeys.CDK_FEATURE, "google-auth");
     }
 
     // Since AWS won't create a security group automatically when open=false, we need to add our own

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -80,10 +80,12 @@ export interface Alarms {
  * https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html.
  */
 export interface GoogleAuthProps {
-  clientId: string;
+  // Parameter Store path containing your Google Client ID. Defaults to
+  // `/:STAGE/:stack/:app/googleClientId`.
+  clientIdPath?: string;
 
-  // The Secrets Manager path containing your Google Client Secret. Defaults to
-  // `/:STAGE/:stack/:app/googleClientSecret`.
+  // *Secrets Manager* (NOT Parameter Store) path containing your Google Client
+  // Secret. Defaults to `/:STAGE/:stack/:app/googleClientSecret`.
   clientSecretPath?: string;
 }
 
@@ -504,8 +506,10 @@ export class GuEc2App extends Construct {
 
     if (props.googleAuth) {
       const configPrefix = `${scope.stage}/${scope.stack}/${app}`;
+      const clientIdPath = props.googleAuth.clientIdPath ?? `/${configPrefix}/googleClientID`;
+
       const clientId = StringParameter.fromStringParameterAttributes(this, "clientID", {
-        parameterName: `/${configPrefix}/googleClientID`,
+        parameterName: clientIdPath,
       }).stringValue;
 
       const secretPath = props.googleAuth.clientSecretPath ?? `${configPrefix}/clientSecret`;


### PR DESCRIPTION
## What does this change?

Adds support for Google Auth at the ALB level for our EC2 patterns.

For more detail on this, see:

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html

And see also some prior art:

https://github.com/guardian/cdk/pull/1260
https://docs.google.com/document/d/1b3tnxdVUAiQ4DWDjrRGQOxOrL5MQPpbBsvlTcZrUTfk/edit#

## How to test

I'll test from this branch to confirm it works okay.

## How can we measure success?

Usage!

## Have we considered potential risks?

One risk is that people do not validate tokens in their app and assume the ALB check is sufficient. We should add some sample code to illustrate how to validate tokens to help here.