### PR TITLE
ci: Remove unnecessary Snyk schedule

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,11 +1,6 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
-# Otherwise it will run snyk test
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this change?

Removes the Snyk schedule, which is unnecessary and will cause the workflow to become suspended after 60 days of inactivity on the repo!