### PR TITLE
feat: Support `aws-s3` Riff-Raff deployments

### DIFF
--- a/src/constructs/s3/index.test.ts
+++ b/src/constructs/s3/index.test.ts
@@ -1,6 +1,6 @@
 import { Template } from "aws-cdk-lib/assertions";
 import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
-import { GuS3Bucket } from "./index";
+import { GuS3Bucket, GuS3OriginBucket } from "./index";
 
 describe("The GuS3Bucket construct", () => {
   it("should set the bucket's policy to 'retain'", () => {
@@ -27,6 +27,35 @@ describe("The GuS3Bucket construct", () => {
 
     GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::S3::Bucket", {
       appIdentity: { app },
+    });
+  });
+});
+
+describe("The GuS3OriginBucket construct", () => {
+  it("should create a stage aware SSM parameter by default", () => {
+    const stack = simpleGuStackForTesting();
+    const app = "wordiply";
+
+    new GuS3OriginBucket(stack, `${app}-origin`, {
+      app,
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SSM::Parameter", {
+      Name: "/TEST/test-stack/wordiply/wordiply-origin-bucket",
+    });
+  });
+
+  it("should be configurable to be stage agnostic", () => {
+    const stack = simpleGuStackForTesting();
+    const app = "wordiply";
+
+    new GuS3OriginBucket(stack, `${app}-origin`, {
+      app,
+      withoutStageAwareness: true,
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SSM::Parameter", {
+      Name: "/test-stack/wordiply/wordiply-origin-bucket",
     });
   });
 });

--- a/src/constructs/s3/index.ts
+++ b/src/constructs/s3/index.ts
@@ -1,6 +1,7 @@
 import { RemovalPolicy } from "aws-cdk-lib";
 import type { BucketProps } from "aws-cdk-lib/aws-s3";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { AppIdentity, GuStack } from "../core";
 
@@ -16,6 +17,50 @@ export class GuS3Bucket extends GuAppAwareConstruct(Bucket) {
       publicReadAccess: false,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       ...props,
+    });
+  }
+}
+
+export interface GuS3OriginBucketProps extends GuS3BucketProps {
+  /**
+   * Customises the SSM Parameter path, making it stage agnostic.
+   * Useful when a single bucket is used across multiple stages.
+   *
+   * When `false` the path will be `/<STAGE>/<STACK>/<APP>/<APP>-origin-bucket`.
+   * When `true` the path will be `/<STACK>/<APP>/<APP>-origin-bucket`.
+   *
+   * @default false
+   */
+  withoutStageAwareness?: boolean;
+}
+
+/**
+ * An S3 bucket for use as an origin for a static site.
+ * The bucket name will be stored in an SSM Parameter.
+ * Other infrastructure, or applications, that use this bucket should discover its name by the Parameter.
+ */
+export class GuS3OriginBucket extends GuS3Bucket {
+  /**
+   * The name of the created SSM Parameter.
+   */
+  public readonly parameterName: string;
+
+  constructor(scope: GuStack, id: string, props: GuS3OriginBucketProps) {
+    const { stage, stack } = scope;
+    const { app, withoutStageAwareness = false } = props;
+
+    super(scope, id, props);
+
+    const stageAgnosticParameterParts = [stack, app, `${app}-origin-bucket`];
+    const parameterParts = withoutStageAwareness
+      ? stageAgnosticParameterParts
+      : [stage, ...stageAgnosticParameterParts];
+
+    this.parameterName = `/${parameterParts.join("/")}`;
+
+    new StringParameter(scope, `${id}-ssm-param`, {
+      parameterName: this.parameterName,
+      stringValue: this.bucketName,
     });
   }
 }

--- a/src/constructs/s3/index.ts
+++ b/src/constructs/s3/index.ts
@@ -1,7 +1,9 @@
+import type { Duration } from "aws-cdk-lib";
 import { RemovalPolicy } from "aws-cdk-lib";
 import type { BucketProps } from "aws-cdk-lib/aws-s3";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import type { IConstruct } from "constructs";
 import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { AppIdentity, GuStack } from "../core";
 
@@ -21,7 +23,7 @@ export class GuS3Bucket extends GuAppAwareConstruct(Bucket) {
   }
 }
 
-export interface GuS3OriginBucketProps extends GuS3BucketProps {
+interface GuS3OriginBucketDeploymentProps {
   /**
    * Customises the SSM Parameter path, making it stage agnostic.
    * Useful when a single bucket is used across multiple stages.
@@ -31,25 +33,100 @@ export interface GuS3OriginBucketProps extends GuS3BucketProps {
    *
    * @default false
    */
-  withoutStageAwareness?: boolean;
+  withoutStageAwareness: boolean;
+
+  /**
+   * Used to configure `bucketSsmKeyStageParam` in a generated `riff-raff.yaml` file.
+   *
+   * The SSM Parameter path, without a stage prefix.
+   *
+   * Not settable by user.
+   *
+   * @internal
+   */
+  baseParameterName: string;
+
+  /**
+   * Used to configure `cacheControl` in a generated `riff-raff.yaml` file.
+   * Only needed if you're also using {@link GuRootExperimental}.
+   *
+   * Set the cache control header for the uploaded files.
+   *
+   * The key is a regular expression to match uploaded files.
+   * The value is the max-age to set in the `Cache-Control` header.
+   *
+   * @example
+   * To cache all files for one hour:
+   * ```ts
+   * { ".*", Duration.hours(1) }
+   * ```
+   *
+   * @default cache nothing
+   * @see https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3
+   */
+  cacheControl: Record<string, Duration>;
+
+  /**
+   * Used to configure `surrogateControl` in a generated `riff-raff.yaml` file.
+   * Only needed if you're also using {@link GuRootExperimental}.
+   *
+   * Same as [[cacheControl]], but for setting the surrogate-control cache header, which is used by Fastly.
+   *
+   * @see https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3
+   */
+  surrogateControl: Record<string, Duration>;
+
+  /**
+   * Used to configure `mimeTypes` in a generated `riff-raff.yaml` file.
+   * Only needed if you're also using {@link GuRootExperimental}.
+   *
+   * A map of file extension to MIME type.
+   *
+   * When a file is uploaded with a file extension that is in this map, the Content-Type header will be set to the MIME type provided.
+   *
+   * @example
+   * ```ts
+   * { "xpi", "application/x-xpinstall" }
+   * ```
+   *
+   * @see https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3
+   */
+  mimeTypes: Record<string, string>;
 }
+
+export interface GuS3OriginBucketProps
+  extends GuS3BucketProps,
+    Partial<Omit<GuS3OriginBucketDeploymentProps, "baseParameterName">> {}
 
 /**
  * An S3 bucket for use as an origin for a static site.
  * The bucket name will be stored in an SSM Parameter.
  * Other infrastructure, or applications, that use this bucket should discover its name by the Parameter.
  */
-export class GuS3OriginBucket extends GuS3Bucket {
+// implementing `IConstruct` is a no-op here as `Bucket` ultimately does so already. We explicitly do so to avoid a `SuspiciousTypeOfGuard` warning in `riff-raff-yaml-file/index.ts`.
+export class GuS3OriginBucket extends GuS3Bucket implements IConstruct {
   /**
    * The name of the created SSM Parameter.
    */
   public readonly parameterName: string;
 
+  public readonly app: string;
+
+  /**
+   * For internal use only, used to generate a `riff-raff.yaml` file.
+   *
+   * @see [[RiffRaffYamlFileExperimental]]
+   * @internal
+   */
+  public readonly _deploymentProps: Required<GuS3OriginBucketDeploymentProps>;
+
   constructor(scope: GuStack, id: string, props: GuS3OriginBucketProps) {
     const { stage, stack } = scope;
-    const { app, withoutStageAwareness = false } = props;
+    const { app, withoutStageAwareness = false, cacheControl = {}, surrogateControl = {}, mimeTypes = {} } = props;
 
     super(scope, id, props);
+
+    this.app = app;
 
     const stageAgnosticParameterParts = [stack, app, `${app}-origin-bucket`];
     const parameterParts = withoutStageAwareness
@@ -62,5 +139,13 @@ export class GuS3OriginBucket extends GuS3Bucket {
       parameterName: this.parameterName,
       stringValue: this.bucketName,
     });
+
+    this._deploymentProps = {
+      withoutStageAwareness,
+      cacheControl,
+      surrogateControl,
+      mimeTypes,
+      baseParameterName: `/${stageAgnosticParameterParts.join("/")}`,
+    };
   }
 }

--- a/src/experimental/riff-raff-yaml-file/README.md
+++ b/src/experimental/riff-raff-yaml-file/README.md
@@ -13,6 +13,7 @@ Currently, it supports the following Riff-Raff deployment types:
 - `cloud-formation`
 - `aws-lambda` (for each `GuLambdaFunction` used)
 - `autoscaling` (for each `GuAutoScalingGroup` used)
+- `aws-s3` (for each `GuS3OriginBucket` used)
 
 ## Usage
 Usage should require minimal changes to a GuCDK project:
@@ -53,8 +54,12 @@ When the CDK stack is synthesized, a `riff-raff.yaml` file will be created in th
 ├── my-other-application
 │   └── my-other-application.jar
 │   └── my-other-application.service
-└── my-lambda
-    └── my-lambda.zip
+├── my-lambda
+│   └── my-lambda.zip
+└── my-static-site
+    ├── index.html
+    ├── main.js
+    └── index.css
 ```
 
 That is, all CloudFormation templates are in a `cdk.out` directory, and there is a directory per app.

--- a/src/experimental/riff-raff-yaml-file/deployments/s3.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/s3.ts
@@ -1,0 +1,61 @@
+import type { GuStack } from "../../../constructs/core";
+import type { GuS3OriginBucket } from "../../../constructs/s3";
+import type { RiffRaffDeployment } from "../types";
+
+export function uploadStaticFilesDeployment(
+  stages: string[],
+  originBucket: GuS3OriginBucket,
+  { name: cfnDeployName }: RiffRaffDeployment
+): RiffRaffDeployment {
+  const { app, _deploymentProps } = originBucket;
+  const { withoutStageAwareness, baseParameterName, cacheControl, surrogateControl, mimeTypes } = _deploymentProps;
+  const { stack, region } = originBucket.stack as GuStack;
+
+  const cacheControlValue = Object.entries(cacheControl).map(([pattern, duration]) => {
+    return {
+      pattern,
+      value: `public, max-age=${duration.toSeconds()}`,
+    };
+  });
+
+  const surrogateControlValue = Object.entries(surrogateControl).map(([pattern, duration]) => {
+    return {
+      pattern,
+      value: `public, max-age=${duration.toSeconds()}`,
+    };
+  });
+
+  return {
+    name: ["upload-static-files", region, stack, app].join("-"),
+    props: {
+      type: "aws-s3",
+      actions: ["uploadStaticFiles"],
+      dependencies: [cfnDeployName],
+      stacks: new Set([stack]),
+      regions: new Set([region]),
+      app,
+      contentDirectory: app,
+      parameters: {
+        bucketSsmKeyStageParam: stages.reduce(
+          (acc, stage) => ({
+            ...acc,
+            [stage]: withoutStageAwareness ? baseParameterName : `/${stage}${baseParameterName}`,
+          }),
+          {}
+        ),
+
+        // Never create per object ACLs.
+        // If the bucket content needs to be public, it’s better to control this via the bucket policy.
+        publicReadAcl: false,
+
+        cacheControl: cacheControlValue.length > 0 ? cacheControlValue : "private",
+
+        // only add the `surrogateControl` property if there are some
+        ...(surrogateControlValue.length > 0 && { surrogateControl: surrogateControlValue }),
+
+        // only add the `mimeTypes` property if there are some
+        ...(Object.keys(mimeTypes).length > 0 && { mimeTypes }),
+      },
+    },
+  };
+}

--- a/src/experimental/riff-raff-yaml-file/types.ts
+++ b/src/experimental/riff-raff-yaml-file/types.ts
@@ -20,7 +20,7 @@ export interface RiffRaffDeploymentProps {
   stacks: Set<StackTag>;
   app: string;
   contentDirectory: string;
-  parameters: Record<string, string | boolean | Record<string, string>>;
+  parameters: Record<string, string | boolean | Record<string, string> | Array<Record<string, string>>>;
   dependencies?: RiffRaffDeploymentName[];
   actions?: string[];
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In https://github.com/guardian/riff-raff/pull/948 Riff-Raff gained the ability to reference an S3 bucket using an SSM Parameter path 🎉 .

In this change we introduce a new construct: `GuS3OriginBucket`, creating:
  - [`AWS::S3::Bucket`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html) - a bucket destined to be an origin for a static site, whether that be a Fastly, CloudFront, etc.
  - [`AWS::SSM::Parameter`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-parameter.html) - a Parameter, whose value is the bucket name. Downstream services should reference the bucket using this.

We also add [`RiffRaffYamlFileExperimental`](https://github.com/guardian/cdk/tree/e06109412032bcb8eca51a753a3e4d0bcce83c46/src/experimental/riff-raff-yaml-file) support for the [`aws-s3` Riff-Raff deployment type](https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3), creating a `riff-raff.yaml` file that (in it's simplest form) contains (annotations added for illustration only):

```yaml
allowedStages:
  - CODE
  - PROD
deployments:
  cfn-eu-west-1-test-my-application-stack:
    type: cloud-formation
    regions:
      - eu-west-1
    stacks:
      - test
    app: my-application-stack
    contentDirectory: /tmp/cdk.out
    parameters:
      templateStagePaths:
        CODE: my-stack-CODE.template.json
        PROD: my-stack-PROD.template.json
  upload-static-files-eu-west-1-test-my-app:
    type: aws-s3 # <-- NEW!
    actions:
      - uploadStaticFiles
    dependencies:
      - cfn-eu-west-1-test-my-application-stack
    stacks:
      - test
    regions:
      - eu-west-1
    app: my-app
    contentDirectory: my-app # <-- Files in this directory within the Riff-Raff bundle will be uploaded to S3.
    parameters:
      bucketSsmKeyStageParam:
        CODE: /CODE/test/my-app/my-app-origin-bucket # <-- Stage aware!
        PROD: /PROD/test/my-app/my-app-origin-bucket
      publicReadAcl: false # <-- Never create per object ACLs. If the bucket content needs to be public, it’s better to control this via the bucket policy.
      cacheControl: private # <-- Default.
```

The above `riff-raff.yaml` is generated from:

```ts
// lib/my-application-stack.ts
class MyApplicationStack extends GuStack {
  // eslint-disable-next-line custom-rules/valid-constructors -- unit testing
  constructor(app: App, id: string, props: GuStackProps) {
    super(app, id, props);

    new GuS3OriginBucket(this, "my-static-site", {
      app: "my-app",
    });
  }
}

// bin/cdk.ts
const app = new GuRootExperimental();

new MyApplicationStack(app, "my-stack-CODE", { stack: "test", stage: "CODE", env: { region: "eu-west-1" } });
new MyApplicationStack(app, "my-stack-PROD", { stack: "test", stage: "PROD", env: { region: "eu-west-1" } });
```

You can optionally also set the following [`aws-s3` deployment parameters](https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3):
  - cacheControl
  - surrogateControl
  - mimeTypes

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

- See the added tests.
- [Validate](https://riffraff.gutools.co.uk/configuration/validation) the generated `riff-raff.yaml`

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More generation. Less frustration.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

- ❓ Should an `AWS::SSM::Parameter` be created as standard in `GuS3Bucket`?

- ❓ Is `GuS3OriginBucket` an appropriate name?

  The name `GuS3OriginBucket` suggests this will only work for static site type content. However, it can technically also be used for those cases where we use the `aws-s3` deployment type for configuration, for example the [DevX ELK stack](https://github.com/guardian/deploy-tools-platform/blob/main/elk/riff-raff.yaml).

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
