### PR TITLE
feat: add Google Auth to EC2 patterns

### DIFF
--- a/src/constants/metadata-keys.ts
+++ b/src/constants/metadata-keys.ts
@@ -4,4 +4,5 @@ export const MetadataKeys = {
   REPOSITORY_NAME: "gu:repo",
   LOG_KINESIS_STREAM_NAME: "LogKinesisStreamName",
   SYSTEMD_UNIT: "SystemdUnit",
+  CDK_FEATURE: "gu:cdk:feature",
 };

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -767,4 +767,33 @@ describe("the GuEC2App pattern", function () {
       ],
     });
   });
+
+  it("tags google-auth usage", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "App";
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      access: { scope: AccessScope.PUBLIC },
+      app,
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      certificateProps: {
+        domainName: "code-guardian.com",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "",
+      accessLogging: { enabled: false },
+      googleAuth: { enabled: true },
+    });
+
+    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
+      additionalTags: [
+        { Key: "Name", Value: "Test/AutoScalingGroupApp" },
+        { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
+        { Key: MetadataKeys.CDK_FEATURE, Value: "google-auth" },
+      ],
+    });
+  });
 });

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -790,7 +790,7 @@ describe("the GuEC2App pattern", function () {
 
     GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
       additionalTags: [
-        { Key: "App", Value: "App"},
+        { Key: "App", Value: "App" },
         { Key: MetadataKeys.CDK_FEATURE, Value: "google-auth" },
       ],
     });

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -788,10 +788,9 @@ describe("the GuEC2App pattern", function () {
       googleAuth: { enabled: true },
     });
 
-    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
+    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
       additionalTags: [
-        { Key: "Name", Value: "Test/AutoScalingGroupApp" },
-        { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
+        { Key: "App", Value: "App"},
         { Key: MetadataKeys.CDK_FEATURE, Value: "google-auth" },
       ],
     });

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -513,7 +513,11 @@ export class GuEc2App extends Construct {
 
     if (props.googleAuth?.enabled) {
       const configPrefix = `${scope.stage}/${scope.stack}/${app}`;
-      const clientIdPath = props.googleAuth.clientIdPath ?? `/${configPrefix}/googleClientID`;
+
+      const {
+        clientIdPath = `/${configPrefix}/googleClientID`,
+        clientSecretPath = `${configPrefix}/clientSecret`,
+      } = props.googleAuth;
 
       const clientId = StringParameter.fromStringParameterAttributes(this, "clientID", {
         parameterName: clientIdPath,
@@ -521,8 +525,7 @@ export class GuEc2App extends Construct {
 
       // Unfortunately, Cloudformation doesn't support directly using secret
       // Parameter Store values. But it is possible to use Secrets Manager.
-      const secretPath = props.googleAuth.clientSecretPath ?? `${configPrefix}/clientSecret`;
-      const clientSecret = SecretValue.secretsManager(secretPath);
+      const clientSecret = SecretValue.secretsManager(clientSecretPath);
 
       const authAction = ListenerAction.authenticateOidc({
         next: ListenerAction.forward([targetGroup]),

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -514,10 +514,8 @@ export class GuEc2App extends Construct {
     if (props.googleAuth?.enabled) {
       const configPrefix = `${scope.stage}/${scope.stack}/${app}`;
 
-      const {
-        clientIdPath = `/${configPrefix}/googleClientID`,
-        clientSecretPath = `${configPrefix}/clientSecret`,
-      } = props.googleAuth;
+      const { clientIdPath = `/${configPrefix}/googleClientID`, clientSecretPath = `${configPrefix}/clientSecret` } =
+        props.googleAuth;
 
       const clientId = StringParameter.fromStringParameterAttributes(this, "clientID", {
         parameterName: clientIdPath,


### PR DESCRIPTION
*Resurrection of https://github.com/guardian/cdk/pull/1608. Now that we know it is possible to limit access to just `guardian.co.uk` emails at the Google level, I am less concerned that teams will fail to validate the token correctly. Nonetheless, this is still a risk here if teams do not effectively limit network access to their instances.*

*See also https://github.com/guardian/deploy-tools-platform/pull/634 - an example of us applying this recently to Riffraff.*

Introduces support for Google Auth as part of our GuEc2App patterns. Auth is handled at the ALB layer via AWS's OIDC support.

Note, to secure access, in addition to using this new feature, teams MUST:

* ensure that User Access is set to 'Internal' in the Google Console (under Consent Screen)
* ensure that network access to EC2 instances is limited to the ALB (via security groups)

This pattern, by default, provides the second out of the box, but cannot do the first.

For more information, see:
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html.
