### PR TITLE
fix(riff-raff.yaml): Loosen restrictions on GuStacks in an App

### DIFF
--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -9,6 +9,77 @@ import { GuEc2App, GuScheduledLambda } from "../../patterns";
 import { RiffRaffYamlFileExperimental } from "./index";
 
 describe("The RiffRaffYamlFileExperimental class", () => {
+  it("Should support deploying different GuStacks to multiple AWS accounts (aka Riff-Raff stacks)", () => {
+    const app = new App({ outdir: "/tmp/cdk.out" });
+
+    class ServiceRunningInDeployTools extends GuStack {}
+    class AnotherServiceRunningInDeployTools extends GuStack {}
+    class ServiceRunningInSecurity extends GuStack {}
+    const region = {
+      env: {
+        region: "eu-west-1",
+      },
+    };
+
+    new ServiceRunningInDeployTools(app, "App-CODE-deploy", {
+      ...region,
+      stack: "deploy",
+      stage: "CODE",
+    });
+    new AnotherServiceRunningInDeployTools(app, "AnotherApp-CODE-deploy", {
+      ...region,
+      stack: "deploy",
+      stage: "CODE",
+    });
+    new ServiceRunningInSecurity(app, "App-CODE-security", {
+      ...region,
+      stack: "security",
+      stage: "CODE",
+    });
+
+    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+
+    expect(actual).toMatchInlineSnapshot(`
+      "allowedStages:
+        - CODE
+      deployments:
+        cfn-eu-west-1-deploy-service-running-in-deploy-tools:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - deploy
+          app: service-running-in-deploy-tools
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              CODE: App-CODE-deploy.template.json
+        cfn-eu-west-1-deploy-another-service-running-in-deploy-tools:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - deploy
+          app: another-service-running-in-deploy-tools
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              CODE: AnotherApp-CODE-deploy.template.json
+        cfn-eu-west-1-security-service-running-in-security:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - security
+          app: service-running-in-security
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              CODE: App-CODE-security.template.json
+      "
+    `);
+  });
+
   it("Should throw when there are missing stack definitions", () => {
     const app = new App();
 

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -104,7 +104,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     expect(() => {
       new RiffRaffYamlFileExperimental(app);
-    }).toThrowError("Unable to produce a working riff-raff.yaml file; missing 4 definitions");
+    }).toThrowError("Unable to produce a working riff-raff.yaml file; missing 1 definitions"); // Stack of media-service has no CODE stage
   });
 
   it("Should throw if there is an unresolved region", () => {


### PR DESCRIPTION
## Background
When we added `riff-raff.yaml` generation in https://github.com/guardian/cdk/pull/1372, we had a validation step that:
  1. Discovered all the `GuStack`s in an `App`
  2. Discovered the set of `region`s
  3. Discovered the set of `stacks`s
  4. Discovered the set of `stage`s
  5. For [each combination of the above](https://github.com/guardian/cdk/blob/ea02fbdf010f968c09768a261a3692a083829fd6/src/experimental/riff-raff-yaml-file/group-by.ts#L21-L41), [expected to find](https://github.com/guardian/cdk/blob/ea02fbdf010f968c09768a261a3692a083829fd6/src/experimental/riff-raff-yaml-file/index.ts#L78-L97) a `GuStack` that matched.

This meant, for example, for the following:

```ts
class MyDatabaseStack extends GuStack {}
class MyAppStack extends GuStack {}

new MyDatabaseStack({ env: { region: 'eu-west-1' }, stack: 'frontend', stage: 'CODE' });
new MyAppStack({ env: { region: 'eu-west-1' }, stack: 'frontend', stage: 'CODE' });
new MyAppStack({ env: { region: 'eu-west-1' }, stack: 'frontend', stage: 'PROD' });
```

We'd get validation errors as there is no `PROD` `MyDatabaseStack` definition.

The aim of this validation is to only produce `riff-raff.yaml` that works.

With `MyDatabaseStack` of `PROD` missing, when we deploy `PROD`, Riff-Raff would fail to locate the CloudFormation template file, as it simply doesn't exist, and the deployment would fail.

This behaviour is due to `allowedStages` (correctly) being a property at the root of the `riff-raff.yaml` file, rather than a property per deployment.

However, there are some niche scenarios where this 4 part validation is too strict.

## What does this change?
In this change, we support the, rather niche, use-case of deploying different `GuStack`s to multiple AWS accounts (aka Riff-Raff stacks), and regions. For example:

```ts
class PrimaryWaf extends GuStack {}
class TeamcityWaf extends GuStack {}

new TeamcityWaf({ env: { region: 'eu-west-1' }, stack: 'deploy', stage: 'INFRA' });
new PrimaryWaf({ env: { region: 'eu-west-1' }, stack: 'deploy', stage: 'INFRA' });
new PrimaryWaf({ env: { region: 'eu-west-1' }, stack: 'security', stage: 'INFRA' });
new PrimaryWaf({ env: { region: 'us-east-1' }, stack: 'security', stage: 'INFRA' });
```

To get this to work, the validation step changes (see changes to `isCdkStackPresent`).

Previously the requirement was that every combination of `GuStack`, `stack`, `stage`, and `region` was present in an `App`, however this is unnecessarily restrictive for the above use-case.

In this change, the validation becomes every combination of `stack`, and `stage` are present in an `App`.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See the added tests, also https://github.com/guardian/waf/pull/21.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We can auto-generate the `riff-raff.yaml` file for more services, such as https://github.com/guardian/waf.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

N/A - the current tests continue to pass, so existing uses of this feature will continue to work.

## Checklist

- ~[ ] I have listed any breaking changes, along with a migration path [^1]~
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
