### PR TITLE
feat(riff-raff.yaml): make `AmigoStage` configurable for auto generating `riff-raff.yaml`

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -5,6 +5,7 @@ import { OperatingSystemType, UserData } from "aws-cdk-lib/aws-ec2";
 import type { ISecurityGroup, MachineImageConfig } from "aws-cdk-lib/aws-ec2";
 import type { ApplicationTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import type { GuAsgCapacity } from "../../types";
+import type { AmigoProps } from "../../types/amigo";
 import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import { GuAmiParameter } from "../core";
 import type { AppIdentity, GuStack } from "../core";
@@ -30,7 +31,7 @@ export interface GuAutoScalingGroupProps
     AppIdentity,
     GuAsgCapacity {
   imageId?: GuAmiParameter;
-  imageRecipe?: string;
+  imageRecipe?: string | AmigoProps;
   userData: UserData | string;
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
@@ -60,7 +61,7 @@ export interface GuAutoScalingGroupProps
 export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
   public readonly app: string;
   public readonly amiParameter: GuAmiParameter;
-  public readonly imageRecipe?: string;
+  public readonly imageRecipe?: string | AmigoProps;
 
   constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {
     const {

--- a/src/experimental/riff-raff-yaml-file/deployments/cloudformation.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/cloudformation.ts
@@ -58,12 +58,15 @@ export function addAmiParametersToCloudFormationDeployment(
       throw new Error(`Unable to produce a working riff-raff.yaml file; imageRecipe missing from ASG ${app}`);
     }
 
+    const Recipe = typeof imageRecipe === "string" ? imageRecipe : imageRecipe.Recipe;
+    const AmigoStage = typeof imageRecipe === "string" ? "PROD" : imageRecipe.AmigoStage ?? "PROD";
+
     return {
       ...acc,
       [amiParameter.node.id]: {
         BuiltBy: "amigo",
-        Recipe: imageRecipe,
-        AmigoStage: "PROD",
+        AmigoStage,
+        Recipe,
       },
     };
   }, {});

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -24,6 +24,7 @@ import {
 } from "../../constructs/loadbalancing";
 import { AppAccess } from "../../types";
 import type { GuAsgCapacity, GuDomainName } from "../../types";
+import type { AmigoProps } from "../../types/amigo";
 
 export interface AccessLoggingProps {
   enabled: boolean;
@@ -142,7 +143,7 @@ export interface GuEc2AppProps extends AppIdentity {
   scaling: GuAsgCapacity;
   certificateProps: GuDomainName;
   withoutImdsv2?: boolean;
-  imageRecipe?: string;
+  imageRecipe?: string | AmigoProps;
   vpc?: IVpc;
   privateSubnets?: ISubnet[];
   publicSubnets?: ISubnet[];

--- a/src/types/amigo.ts
+++ b/src/types/amigo.ts
@@ -1,0 +1,4 @@
+export interface AmigoProps {
+  Recipe: string;
+  AmigoStage?: string;
+}


### PR DESCRIPTION
## What does this change?
This builds on the changes in #1697, to make `AmigoStage` property of the cloudformation step of the auto generated `riff-raff.yaml` configurable. This is done via the existing `imageRecipe` property, to avoid making the props list any noisier - it is now `string | AmigoProps` which allows this further configuration, but with the same defaults. This also forms a placeholder for potentially making `Encrypted` configurable too (but given there's a riff-raff bug here - see https://github.com/guardian/riff-raff/pull/991 - we're not including that in this PR, although we may also choose to 'codify best practice' by hard coding that to `true` in CDK).

## How to test
Experiment with setting these additional properties and see them come out in the `riff-raff.yaml` in `cdk.out`.

## How can we measure success?
More flexible, I'll certainly want to make use of it in https://github.com/guardian/editorial-wires/pull/13

## Have we considered potential risks?
N/A - this just allows more control over the riff-raff.yaml output and therefore avoids people maintaining that file manually.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
