### PR TITLE
feat(riff-raff.yaml): Add support for encrypted AMIs

### DIFF
--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -15,6 +15,7 @@ import { GuInstanceRole } from "../iam";
 // Since we want to override the types of what gets passed in for the below props,
 // we need to use Omit<T, U> to remove them from the interface this extends
 // https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys
+// TODO avoid prop nesting to improve discoverability. See https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md#flat.
 export interface GuAutoScalingGroupProps
   extends Omit<
       AutoScalingGroupProps,

--- a/src/experimental/riff-raff-yaml-file/deployments/cloudformation.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/cloudformation.ts
@@ -61,12 +61,16 @@ export function addAmiParametersToCloudFormationDeployment(
     const Recipe = typeof imageRecipe === "string" ? imageRecipe : imageRecipe.Recipe;
     const AmigoStage = typeof imageRecipe === "string" ? "PROD" : imageRecipe.AmigoStage ?? "PROD";
 
+    // In YAML `true` is a Boolean. Riff-Raff expects a String here, so call `toString` to make it `'true'`.
+    const Encrypted = (typeof imageRecipe === "string" ? true : imageRecipe.Encrypted ?? true).toString();
+
     return {
       ...acc,
       [amiParameter.node.id]: {
         BuiltBy: "amigo",
         AmigoStage,
         Recipe,
+        Encrypted,
       },
     };
   }, {});

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -450,6 +450,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
                 BuiltBy: amigo
                 AmigoStage: PROD
                 Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
           dependencies:
             - asg-upload-eu-west-1-test-my-app
         asg-update-eu-west-1-test-my-app:
@@ -568,6 +569,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
                 BuiltBy: amigo
                 AmigoStage: PROD
                 Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
           dependencies:
             - lambda-upload-eu-west-1-test-my-lambda-app
             - asg-upload-eu-west-1-test-my-ec2-app
@@ -646,6 +648,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
                 BuiltBy: amigo
                 AmigoStage: PROD
                 Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
           dependencies:
             - lambda-upload-us-east-1-test-my-lambda-app
             - asg-upload-us-east-1-test-my-ec2-app
@@ -709,7 +712,10 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           scaling: {
             minimumInstances: 1,
           },
-          imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
+          imageRecipe: {
+            Recipe: "arm64-bionic-java11-deploy-infrastructure",
+            Encrypted: false,
+          },
         });
 
         new GuNodeApp(this, {
@@ -729,7 +735,10 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           scaling: {
             minimumInstances: 1,
           },
-          imageRecipe: "arm64-bionic-node18-deploy-infrastructure",
+          imageRecipe: {
+            Recipe: "arm64-bionic-node18-deploy-infrastructure",
+            Encrypted: true,
+          },
         });
       }
     }
@@ -784,10 +793,12 @@ describe("The RiffRaffYamlFileExperimental class", () => {
                 BuiltBy: amigo
                 AmigoStage: PROD
                 Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'false'
               AMIMydatacollector:
                 BuiltBy: amigo
                 AmigoStage: PROD
                 Recipe: arm64-bionic-node18-deploy-infrastructure
+                Encrypted: 'true'
           dependencies:
             - asg-upload-eu-west-1-test-my-api
             - asg-upload-eu-west-1-test-my-data-collector
@@ -852,6 +863,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           imageRecipe: {
             Recipe: "arm64-bionic-java11-deploy-infrastructure",
             AmigoStage: "CODE",
+            Encrypted: true,
           },
         });
       }
@@ -894,6 +906,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
                 BuiltBy: amigo
                 AmigoStage: CODE
                 Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
           dependencies:
             - asg-upload-eu-west-1-test-my-api
         asg-update-eu-west-1-test-my-api:

--- a/src/types/amigo.ts
+++ b/src/types/amigo.ts
@@ -1,4 +1,18 @@
 export interface AmigoProps {
+  /**
+   * The name of the AMIgo recipe.
+   */
   Recipe: string;
+
+  /**
+   * Whether the AMI has been baked with encryption.
+   * @default true
+   */
+  Encrypted?: boolean;
+
+  /**
+   * The AMIgo stage that baked the AMI.
+   * @default PROD
+   */
   AmigoStage?: string;
 }


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/riff-raff/pull/991, add support for encrypted AMIs. By default AMIs are assumed to be encrypted, as this is best practice. Not sure if this would be surprising?

## How to test
See updated tests.

## How can we measure success?
It's possible to auto-generate a more complete `riff-raff.yaml` file.

## Have we considered potential risks?
If an AMIgo recipe is not configured to create an encrypted copy, and one hasn't explcitly said `Encrypted: false`, then the deployment will fail with Riff-Raff unable to locate a relevant AMI.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
