### PR TITLE
feat: Use LaunchTemplates instead of LaunchConfiguration

### DIFF
--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -62,9 +62,11 @@ describe("The GuAutoScalingGroup", () => {
       Type: "AWS::EC2::Image::Id",
     });
 
-    template.hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      ImageId: {
-        Ref: "AMITesting",
+    template.hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        ImageId: {
+          Ref: "AMITesting",
+        },
       },
     });
   });
@@ -74,8 +76,10 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", { ...defaultProps, instanceType: new InstanceType("t3.small") });
 
-    Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      InstanceType: "t3.small",
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        InstanceType: "t3.small",
+      },
     });
   });
 
@@ -84,9 +88,11 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", defaultProps);
 
-    Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      UserData: {
-        "Fn::Base64": "#!/bin/bash\nservice some-dependency start\nservice my-app start",
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        UserData: {
+          "Fn::Base64": "#!/bin/bash\nservice some-dependency start\nservice my-app start",
+        },
       },
     });
   });
@@ -128,24 +134,26 @@ describe("The GuAutoScalingGroup", () => {
       additionalSecurityGroups: [securityGroup, securityGroup1, securityGroup2],
     });
 
-    Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      SecurityGroups: [
-        {
-          "Fn::GetAtt": [Match.stringLikeRegexp(`GuHttpsEgressSecurityGroup${app}[A-Z0-9]+`), "GroupId"],
-        },
-        {
-          "Fn::GetAtt": ["WazuhSecurityGroup", "GroupId"],
-        },
-        {
-          "Fn::GetAtt": [Match.stringLikeRegexp("SecurityGroupTesting[A-Z0-9]+"), "GroupId"],
-        },
-        {
-          "Fn::GetAtt": [Match.stringLikeRegexp("SecurityGroup1Testing[A-Z0-9]+"), "GroupId"],
-        },
-        {
-          "Fn::GetAtt": [Match.stringLikeRegexp("SecurityGroup2Testing[A-Z0-9]+"), "GroupId"],
-        },
-      ],
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        SecurityGroupIds: [
+          {
+            "Fn::GetAtt": [Match.stringLikeRegexp(`GuHttpsEgressSecurityGroup${app}[A-Z0-9]+`), "GroupId"],
+          },
+          {
+            "Fn::GetAtt": ["WazuhSecurityGroup", "GroupId"],
+          },
+          {
+            "Fn::GetAtt": [Match.stringLikeRegexp("SecurityGroupTesting[A-Z0-9]+"), "GroupId"],
+          },
+          {
+            "Fn::GetAtt": [Match.stringLikeRegexp("SecurityGroup1Testing[A-Z0-9]+"), "GroupId"],
+          },
+          {
+            "Fn::GetAtt": [Match.stringLikeRegexp("SecurityGroup2Testing[A-Z0-9]+"), "GroupId"],
+          },
+        ],
+      },
     });
   });
 

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -36,16 +36,10 @@ describe("The GuAutoScalingGroup", () => {
     const template = GuTemplate.fromStack(stack);
 
     template.hasResourceWithLogicalId("AWS::AutoScaling::AutoScalingGroup", /MyAutoScalingGroupTesting[A-Z0-9]+/);
+
     template.hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
       appIdentity: { app: "testing" },
       propagateAtLaunch: true,
-      additionalTags: [
-        {
-          Key: "Name",
-          PropagateAtLaunch: true,
-          Value: "Test/MyAutoScalingGroupTesting",
-        },
-      ],
     });
   });
 

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -98,7 +98,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
     const userData = userDataLike instanceof UserData ? userDataLike : UserData.custom(userDataLike);
 
     // Generate an ID unique to this app
-    const launchTemplateId =`${scope.stack}-${scope.stage}-${app}`
+    const launchTemplateId = `${scope.stack}-${scope.stage}-${app}`;
     const launchTemplate = new LaunchTemplate(scope, launchTemplateId, {
       blockDevices,
       instanceType,

--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -36,19 +36,21 @@ describe("GuUserData", () => {
       app: "testing",
     });
 
-    Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      UserData: {
-        "Fn::Base64": {
-          "Fn::Join": [
-            "",
-            [
-              "#!/bin/bash\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
-              {
-                Ref: "DistributionBucketName",
-              },
-              "/test-stack/TEST/testing/my-app.deb' '/testing/my-app.deb'\ndpkg -i /testing/my-app.deb",
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        UserData: {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
+                {
+                  Ref: "DistributionBucketName",
+                },
+                "/test-stack/TEST/testing/my-app.deb' '/testing/my-app.deb'\ndpkg -i /testing/my-app.deb",
+              ],
             ],
-          ],
+          },
         },
       },
     });
@@ -80,27 +82,29 @@ describe("GuUserData", () => {
       app: "testing",
     });
 
-    Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      UserData: {
-        "Fn::Base64": {
-          "Fn::Join": [
-            "",
-            [
-              "#!/bin/bash\nmkdir -p $(dirname '/etc/testing/secrets.json')\naws s3 cp 's3://",
-              {
-                Ref: "PrivateConfigBucketName",
-              },
-              "/secrets.json' '/etc/testing/secrets.json'\nmkdir -p $(dirname '/etc/testing/application.conf')\naws s3 cp 's3://",
-              {
-                Ref: "PrivateConfigBucketName",
-              },
-              "/application.conf' '/etc/testing/application.conf'\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
-              {
-                Ref: "DistributionBucketName",
-              },
-              "/test-stack/TEST/testing/my-app.deb' '/testing/my-app.deb'\ndpkg -i /testing/my-app.deb",
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        UserData: {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash\nmkdir -p $(dirname '/etc/testing/secrets.json')\naws s3 cp 's3://",
+                {
+                  Ref: "PrivateConfigBucketName",
+                },
+                "/secrets.json' '/etc/testing/secrets.json'\nmkdir -p $(dirname '/etc/testing/application.conf')\naws s3 cp 's3://",
+                {
+                  Ref: "PrivateConfigBucketName",
+                },
+                "/application.conf' '/etc/testing/application.conf'\nmkdir -p $(dirname '/testing/my-app.deb')\naws s3 cp 's3://",
+                {
+                  Ref: "DistributionBucketName",
+                },
+                "/test-stack/TEST/testing/my-app.deb' '/testing/my-app.deb'\ndpkg -i /testing/my-app.deb",
+              ],
             ],
-          ],
+          },
         },
       },
     });

--- a/src/experimental/constructs/__snapshots__/error-budget-alarm.test.ts.snap
+++ b/src/experimental/constructs/__snapshots__/error-budget-alarm.test.ts.snap
@@ -637,8 +637,8 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -693,8 +693,16 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupTestguec2appLaunchConfigA7394577",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestguec2appAA7F41BE",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestguec2appAA7F41BE",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -722,11 +730,6 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "Test/AutoScalingGroupTestguec2app",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "test-stack",
@@ -747,51 +750,6 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupTestguec2appInstanceProfile69E61F9E": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleTestguec2appC325BE42",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupTestguec2appLaunchConfigA7394577": {
-      "DependsOn": [
-        "InstanceRoleTestguec2appC325BE42",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupTestguec2appInstanceProfile69E61F9E",
-        },
-        "ImageId": {
-          "Ref": "AMITestguec2app",
-        },
-        "InstanceType": "t4g.medium",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": "#!/bin/dev foobarbaz",
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
@@ -1721,6 +1679,27 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerTestguec2appSecurityGrouptoTestWazuhSecurityGroup8092AEDC3000E12CA15B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "MapiFrontsAvailabilityFastBurnCompositeAlarmA8F736A8": {
       "Properties": {
         "AlarmActions": [
@@ -2026,6 +2005,155 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "WazuhSecurityGroupfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C9300023EFEFE4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "teststackTESTtestguec2appAA7F41BE": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguec2appProfileC5759753",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestguec2app",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": "#!/bin/dev foobarbaz",
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguec2appProfileC5759753": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
   },
 }
 `;
@@ -2049,8 +2177,8 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -2105,8 +2233,16 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupTestguec2appLaunchConfigA7394577",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestguec2appAA7F41BE",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestguec2appAA7F41BE",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -2134,11 +2270,6 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "Test/AutoScalingGroupTestguec2app",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "test-stack",
@@ -2159,51 +2290,6 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupTestguec2appInstanceProfile69E61F9E": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleTestguec2appC325BE42",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupTestguec2appLaunchConfigA7394577": {
-      "DependsOn": [
-        "InstanceRoleTestguec2appC325BE42",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupTestguec2appInstanceProfile69E61F9E",
-        },
-        "ImageId": {
-          "Ref": "AMITestguec2app",
-        },
-        "InstanceType": "t4g.medium",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": "#!/bin/dev foobarbaz",
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
@@ -2965,6 +3051,27 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerTestguec2appSecurityGrouptoTestWazuhSecurityGroup8092AEDC3000E12CA15B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "MapiFrontsLatencyFastBurnCompositeAlarmEBFA1AC4": {
       "Properties": {
         "AlarmActions": [
@@ -3269,6 +3376,155 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C9300023EFEFE4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "teststackTESTtestguec2appAA7F41BE": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguec2appProfileC5759753",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestguec2app",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": "#!/bin/dev foobarbaz",
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguec2appProfileC5759753": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -19,8 +19,8 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -75,8 +75,16 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupTestguec2appLaunchConfigA7394577",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestguec2appAA7F41BE",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestguec2appAA7F41BE",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -104,11 +112,6 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "Test/AutoScalingGroupTestguec2app",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "test-stack",
@@ -129,51 +132,6 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupTestguec2appInstanceProfile69E61F9E": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleTestguec2appC325BE42",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupTestguec2appLaunchConfigA7394577": {
-      "DependsOn": [
-        "InstanceRoleTestguec2appC325BE42",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupTestguec2appInstanceProfile69E61F9E",
-        },
-        "ImageId": {
-          "Ref": "AMITestguec2app",
-        },
-        "InstanceType": "t4g.medium",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": "#!/bin/dev foobarbaz",
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
@@ -575,6 +533,27 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerTestguec2appSecurityGrouptoTestWazuhSecurityGroup8092AEDC3000E12CA15B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ParameterStoreReadTestguec2app072DCDE1": {
       "Properties": {
         "PolicyDocument": {
@@ -695,6 +674,27 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "RestrictedIngressSecurityGroupTestguec2apptoTestWazuhSecurityGroup8092AEDC3000E2216923": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "RestrictedIngressSecurityGroupTestguec2appF4DE7574",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "TargetGroupTestguec2app9F67D503": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
@@ -787,6 +787,176 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "WazuhSecurityGroupfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C9300023EFEFE4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGroupfromTestRestrictedIngressSecurityGroupTestguec2app006B9AC1300032C8ABF9": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "RestrictedIngressSecurityGroupTestguec2appF4DE7574",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "teststackTESTtestguec2appAA7F41BE": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguec2appProfileC5759753",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestguec2app",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": "#!/bin/dev foobarbaz",
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguec2appProfileC5759753": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
   },
 }
 `;
@@ -810,8 +980,8 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -865,8 +1035,16 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupTestguec2appLaunchConfigA7394577",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestguec2appAA7F41BE",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestguec2appAA7F41BE",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -894,11 +1072,6 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "Test/AutoScalingGroupTestguec2app",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "test-stack",
@@ -919,51 +1092,6 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupTestguec2appInstanceProfile69E61F9E": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleTestguec2appC325BE42",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupTestguec2appLaunchConfigA7394577": {
-      "DependsOn": [
-        "InstanceRoleTestguec2appC325BE42",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupTestguec2appInstanceProfile69E61F9E",
-        },
-        "ImageId": {
-          "Ref": "AMITestguec2app",
-        },
-        "InstanceType": "t4g.medium",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": "#!/bin/dev foobarbaz",
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
@@ -1347,6 +1475,27 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerTestguec2appSecurityGrouptoTestWazuhSecurityGroup8092AEDC3000E12CA15B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ParameterStoreReadTestguec2app072DCDE1": {
       "Properties": {
         "PolicyDocument": {
@@ -1497,6 +1646,155 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C9300023EFEFE4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "teststackTESTtestguec2appAA7F41BE": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguec2appProfileC5759753",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestguec2app",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": "#!/bin/dev foobarbaz",
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguec2appProfileC5759753": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -481,16 +481,18 @@ describe("the GuEC2App pattern", function () {
       ],
     });
 
-    Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::LaunchConfiguration", {
-      BlockDeviceMappings: [
-        {
-          DeviceName: "/dev/sda1",
-          Ebs: {
-            VolumeSize: 8,
-            VolumeType: "gp2",
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        BlockDeviceMappings: [
+          {
+            DeviceName: "/dev/sda1",
+            Ebs: {
+              VolumeSize: 8,
+              VolumeType: "gp2",
+            },
           },
-        },
-      ],
+        ],
+      },
     });
   });
 
@@ -591,6 +593,7 @@ describe("the GuEC2App pattern", function () {
         { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });
+    
   });
 
   it("can be configured with access logging", function () {

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -579,19 +579,14 @@ describe("the GuEC2App pattern", function () {
     template.hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
       appIdentity: { app: "PlayApp" },
       propagateAtLaunch: true,
-      additionalTags: [
-        { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
-      ],
+      additionalTags: [{ Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } }],
     });
 
     template.hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
       appIdentity: { app: "NodeApp" },
       propagateAtLaunch: true,
-      additionalTags: [
-        { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
-      ],
+      additionalTags: [{ Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } }],
     });
-    
   });
 
   it("can be configured with access logging", function () {
@@ -760,9 +755,7 @@ describe("the GuEC2App pattern", function () {
     GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
       appIdentity: { app },
       propagateAtLaunch: true,
-      additionalTags: [
-        { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
-      ],
+      additionalTags: [{ Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } }],
     });
   });
 });

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -580,7 +580,6 @@ describe("the GuEC2App pattern", function () {
       appIdentity: { app: "PlayApp" },
       propagateAtLaunch: true,
       additionalTags: [
-        { Key: "Name", Value: "Test/AutoScalingGroupPlayApp" },
         { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });
@@ -589,7 +588,6 @@ describe("the GuEC2App pattern", function () {
       appIdentity: { app: "NodeApp" },
       propagateAtLaunch: true,
       additionalTags: [
-        { Key: "Name", Value: "Test/AutoScalingGroupNodeApp" },
         { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });
@@ -677,7 +675,6 @@ describe("the GuEC2App pattern", function () {
       appIdentity: { app },
       propagateAtLaunch: true,
       additionalTags: [
-        { Key: "Name", Value: "Test/AutoScalingGroupTestguec2app" },
         { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
         { Key: MetadataKeys.SYSTEMD_UNIT, Value: "test-gu-ec2-app.service" },
       ],
@@ -707,7 +704,6 @@ describe("the GuEC2App pattern", function () {
       appIdentity: { app },
       propagateAtLaunch: true,
       additionalTags: [
-        { Key: "Name", Value: "Test/AutoScalingGroupTestguec2app" },
         { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
         { Key: MetadataKeys.SYSTEMD_UNIT, Value: "not-my-app-name.service" },
       ],
@@ -765,7 +761,6 @@ describe("the GuEC2App pattern", function () {
       appIdentity: { app },
       propagateAtLaunch: true,
       additionalTags: [
-        { Key: "Name", Value: "Test/AutoScalingGroupApp" },
         { Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } },
       ],
     });


### PR DESCRIPTION
## What does this change?

This change moves `GuAutoScalingGroup` to use `LaunchTemplates` as `LaunchConfigurations` [are deprecated](https://aws.amazon.com/blogs/compute/amazon-ec2-auto-scaling-will-no-longer-add-support-for-new-ec2-features-to-launch-configurations/).

The API to the consumer should remain unchanged, but this will results in EC2 instances getting a different `Name` tag in its current implementation. See https://github.com/guardian/cdk/pull/1731/files#diff-b219fec113d015feaadba12ad710f805f4ba8fc1fcf3c270be34c8fd31b67c0fR101 for the logic that generates the `Name`.

> **Note**
> This change removes tests for `Name` tag on an `AutoScalingGroup` as these are not generated or set by GuCDK and moves from the ASG as Tags to `TagSpecifications` on `LaunchTemplate`.

## How to test

See https://github.com/guardian/cdk-playground/pull/344 for a test on a real-world application.

## Checklist

~- [ ] I have listed any breaking changes, along with a migration path [^1]~
~- [ ] I have updated the documentation as required for the described changes [^2]~

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
