### PR TITLE
feat: New GuPlayWorkerApp pattern

### DIFF
--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -162,4 +162,30 @@ describe("The GuHttpsApplicationListener class", () => {
       ],
     });
   });
+
+  test("sets the port to 8080 if a certificate is not supplied", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuHttpsApplicationListener(stack, "ApplicationListener", {
+      loadBalancer: getLoadBalancer(stack),
+      targetGroup: getAppTargetGroup(stack),
+      ...app,
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
+      Port: 8080,
+    });
+  });
+
+  test("sets the protocol to http if a certificate is not supplied", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuHttpsApplicationListener(stack, "ApplicationListener", {
+      loadBalancer: getLoadBalancer(stack),
+      targetGroup: getAppTargetGroup(stack),
+      ...app,
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
+      Protocol: "HTTP",
+    });
+  });
 });

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -45,8 +45,8 @@ export class GuHttpsApplicationListener extends GuAppAwareConstruct(ApplicationL
     const { certificate, targetGroup } = props;
 
     const mergedProps: GuApplicationListenerProps = {
-      port: typeof certificate === undefined ? 8080 : 443,
-      protocol: typeof certificate === undefined ? ApplicationProtocol.HTTP : ApplicationProtocol.HTTPS,
+      port: typeof certificate === "undefined" ? 8080 : 443,
+      protocol: typeof certificate === "undefined" ? ApplicationProtocol.HTTP : ApplicationProtocol.HTTPS,
       ...props,
       certificates: typeof certificate === "undefined" ? [] : [
         {

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -46,7 +46,7 @@ export class GuHttpsApplicationListener extends GuAppAwareConstruct(ApplicationL
 
     const mergedProps: GuApplicationListenerProps = {
       port: typeof certificate === undefined ? 8080 : 443,
-      protocol: ApplicationProtocol.HTTPS,
+      protocol: typeof certificate === undefined ? ApplicationProtocol.HTTP : ApplicationProtocol.HTTPS,
       ...props,
       certificates: typeof certificate === "undefined" ? [] : [
         {

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -5,7 +5,7 @@ import type { GuCertificate } from "../../acm";
 import type { AppIdentity, GuStack } from "../../core";
 import type { GuApplicationTargetGroup } from "./application-target-group";
 
-export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity { }
+export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity {}
 
 /**
  * Construct which creates a Listener.
@@ -28,7 +28,7 @@ export class GuApplicationListener extends GuAppAwareConstruct(ApplicationListen
 
 export interface GuHttpsApplicationListenerProps
   extends Omit<GuApplicationListenerProps, "defaultAction" | "certificates">,
-  AppIdentity {
+    AppIdentity {
   targetGroup: GuApplicationTargetGroup;
   certificate?: GuCertificate;
 }
@@ -48,11 +48,14 @@ export class GuHttpsApplicationListener extends GuAppAwareConstruct(ApplicationL
       port: typeof certificate === "undefined" ? 8080 : 443,
       protocol: typeof certificate === "undefined" ? ApplicationProtocol.HTTP : ApplicationProtocol.HTTPS,
       ...props,
-      certificates: typeof certificate === "undefined" ? [] : [
-        {
-          certificateArn: certificate.certificateArn,
-        },
-      ],
+      certificates:
+        typeof certificate === "undefined"
+          ? []
+          : [
+              {
+                certificateArn: certificate.certificateArn,
+              },
+            ],
       defaultAction: ListenerAction.forward([targetGroup]),
     };
 

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -45,17 +45,16 @@ export class GuHttpsApplicationListener extends GuAppAwareConstruct(ApplicationL
     const { certificate, targetGroup } = props;
 
     const mergedProps: GuApplicationListenerProps = {
-      port: typeof certificate === "undefined" ? 8080 : 443,
-      protocol: typeof certificate === "undefined" ? ApplicationProtocol.HTTP : ApplicationProtocol.HTTPS,
+      port: certificate ? 443 : 8080,
+      protocol: certificate ? ApplicationProtocol.HTTPS : ApplicationProtocol.HTTP,
       ...props,
-      certificates:
-        typeof certificate === "undefined"
-          ? []
-          : [
-              {
-                certificateArn: certificate.certificateArn,
-              },
-            ],
+      certificates: certificate
+        ? [
+            {
+              certificateArn: certificate.certificateArn,
+            },
+          ]
+        : [],
       defaultAction: ListenerAction.forward([targetGroup]),
     };
 

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -5,7 +5,7 @@ import type { GuCertificate } from "../../acm";
 import type { AppIdentity, GuStack } from "../../core";
 import type { GuApplicationTargetGroup } from "./application-target-group";
 
-export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity {}
+export interface GuApplicationListenerProps extends ApplicationListenerProps, AppIdentity { }
 
 /**
  * Construct which creates a Listener.
@@ -28,9 +28,9 @@ export class GuApplicationListener extends GuAppAwareConstruct(ApplicationListen
 
 export interface GuHttpsApplicationListenerProps
   extends Omit<GuApplicationListenerProps, "defaultAction" | "certificates">,
-    AppIdentity {
+  AppIdentity {
   targetGroup: GuApplicationTargetGroup;
-  certificate: GuCertificate;
+  certificate?: GuCertificate;
 }
 
 /**
@@ -45,10 +45,10 @@ export class GuHttpsApplicationListener extends GuAppAwareConstruct(ApplicationL
     const { certificate, targetGroup } = props;
 
     const mergedProps: GuApplicationListenerProps = {
-      port: 443,
+      port: typeof certificate === undefined ? 8080 : 443,
       protocol: ApplicationProtocol.HTTPS,
       ...props,
-      certificates: [
+      certificates: typeof certificate === "undefined" ? [] : [
         {
           certificateArn: certificate.certificateArn,
         },

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -141,7 +141,7 @@ export interface GuEc2AppProps extends AppIdentity {
   accessLogging?: AccessLoggingProps;
   blockDevices?: BlockDevice[];
   scaling: GuAsgCapacity;
-  certificateProps: GuDomainName;
+  certificateProps?: GuDomainName;
   withoutImdsv2?: boolean;
   imageRecipe?: string | AmigoProps;
   vpc?: IVpc;
@@ -339,7 +339,7 @@ export class GuEc2App extends Construct {
    * in the short term.
    * */
   public readonly vpc: IVpc;
-  public readonly certificate: GuCertificate;
+  public readonly certificate?: GuCertificate;
   public readonly loadBalancer: GuApplicationLoadBalancer;
   public readonly autoScalingGroup: GuAutoScalingGroup;
   public readonly listener: GuHttpsApplicationListener;
@@ -354,7 +354,7 @@ export class GuEc2App extends Construct {
       applicationLogging = { enabled: false },
       applicationPort,
       blockDevices,
-      certificateProps: { domainName, hostedZoneId },
+      certificateProps,
       instanceType,
       monitoringConfiguration,
       roleConfiguration = { withoutLogShipping: false, additionalPolicies: [] },
@@ -374,17 +374,17 @@ export class GuEc2App extends Construct {
     if (applicationLogging.enabled && roleConfiguration.withoutLogShipping) {
       throw new Error(
         "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-          "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
+        "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
       );
     }
 
     AppAccess.validate(access);
 
-    const certificate = new GuCertificate(scope, {
+    const certificate = typeof certificateProps !== "undefined" ? new GuCertificate(scope, {
       app,
-      domainName,
-      hostedZoneId,
-    });
+      domainName: certificateProps.domainName,
+      hostedZoneId: certificateProps.hostedZoneId,
+    }) : undefined;
 
     const maybePrivateConfigPolicy =
       typeof userData !== "string" && userData.configuration
@@ -468,7 +468,7 @@ export class GuEc2App extends Construct {
       certificate,
       targetGroup,
       // When open=true, AWS will create a security group which allows all inbound traffic over HTTPS
-      open: access.scope === AccessScope.PUBLIC,
+      open: access.scope === AccessScope.PUBLIC && typeof certificate !== undefined,
     });
 
     // Since AWS won't create a security group automatically when open=false, we need to add our own

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -374,17 +374,20 @@ export class GuEc2App extends Construct {
     if (applicationLogging.enabled && roleConfiguration.withoutLogShipping) {
       throw new Error(
         "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-        "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
+          "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
       );
     }
 
     AppAccess.validate(access);
 
-    const certificate = typeof certificateProps !== "undefined" ? new GuCertificate(scope, {
-      app,
-      domainName: certificateProps.domainName,
-      hostedZoneId: certificateProps.hostedZoneId,
-    }) : undefined;
+    const certificate =
+      typeof certificateProps !== "undefined"
+        ? new GuCertificate(scope, {
+            app,
+            domainName: certificateProps.domainName,
+            hostedZoneId: certificateProps.hostedZoneId,
+          })
+        : undefined;
 
     const maybePrivateConfigPolicy =
       typeof userData !== "string" && userData.configuration

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -468,7 +468,7 @@ export class GuEc2App extends Construct {
       certificate,
       targetGroup,
       // When open=true, AWS will create a security group which allows all inbound traffic over HTTPS
-      open: access.scope === AccessScope.PUBLIC && typeof certificate !== undefined,
+      open: access.scope === AccessScope.PUBLIC && typeof certificate !== "undefined",
     });
 
     // Since AWS won't create a security group automatically when open=false, we need to add our own

--- a/src/patterns/ec2-app/framework.test.ts
+++ b/src/patterns/ec2-app/framework.test.ts
@@ -66,11 +66,11 @@ describe("Framework level EC2 app patterns", () => {
     });
 
     Template.fromStack(stack).hasResource("AWS::EC2::SecurityGroup", {
-      "Properties": {
-        "GroupDescription": "Allow restricted ingress from CIDR ranges",
-        "SecurityGroupIngress": Match.absent(),
+      Properties: {
+        GroupDescription: "Allow restricted ingress from CIDR ranges",
+        SecurityGroupIngress: Match.absent(),
       },
-      "Type": "AWS::EC2::SecurityGroup"
+      Type: "AWS::EC2::SecurityGroup",
     });
   });
 });

--- a/src/patterns/ec2-app/framework.test.ts
+++ b/src/patterns/ec2-app/framework.test.ts
@@ -1,4 +1,4 @@
-import { Template, Match } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
 import { AccessScope } from "../../constants";
 import { simpleGuStackForTesting } from "../../utils/test";

--- a/src/patterns/ec2-app/framework.ts
+++ b/src/patterns/ec2-app/framework.ts
@@ -4,7 +4,7 @@ The plan is to sprinkle some framework specific tooling into them.
 For example, a Play app should come with the infrastructure for https://github.com/guardian/play-secret-rotation.
  */
 
-import { AccessScope } from '../../constants';
+import { AccessScope } from "../../constants";
 import type { GuStack } from "../../constructs/core";
 import type { GuDomainName } from "../../types";
 import type { GuEc2AppProps } from "./base";
@@ -22,7 +22,11 @@ export class GuPlayWorkerApp extends GuEc2App {
   static readonly PORT: number = 9000;
 
   constructor(scope: GuStack, props: GuEc2WorkerProps) {
-    super(scope, { ...props, applicationPort: GuPlayApp.PORT, access: { scope: AccessScope.INTERNAL, cidrRanges: [] } });
+    super(scope, {
+      ...props,
+      applicationPort: GuPlayApp.PORT,
+      access: { scope: AccessScope.INTERNAL, cidrRanges: [] },
+    });
   }
 }
 

--- a/src/patterns/ec2-app/framework.ts
+++ b/src/patterns/ec2-app/framework.ts
@@ -24,7 +24,7 @@ export class GuPlayWorkerApp extends GuEc2App {
   constructor(scope: GuStack, props: GuEc2WorkerProps) {
     super(scope, {
       ...props,
-      applicationPort: GuPlayApp.PORT,
+      applicationPort: GuPlayWorkerApp.PORT,
       access: { scope: AccessScope.INTERNAL, cidrRanges: [] },
     });
   }

--- a/src/patterns/ec2-app/framework.ts
+++ b/src/patterns/ec2-app/framework.ts
@@ -4,9 +4,9 @@ The plan is to sprinkle some framework specific tooling into them.
 For example, a Play app should come with the infrastructure for https://github.com/guardian/play-secret-rotation.
  */
 
-import type { GuStack } from "../../constructs/core";
 import { AccessScope } from '../../constants';
-import { GuDomainName } from "../../types";
+import type { GuStack } from "../../constructs/core";
+import type { GuDomainName } from "../../types";
 import type { GuEc2AppProps } from "./base";
 import { GuEc2App } from "./base";
 

--- a/src/patterns/ec2-app/framework.ts
+++ b/src/patterns/ec2-app/framework.ts
@@ -5,10 +5,11 @@ For example, a Play app should come with the infrastructure for https://github.c
  */
 
 import type { GuStack } from "../../constructs/core";
+import { GuDomainName } from "../../types";
 import type { GuEc2AppProps } from "./base";
 import { GuEc2App } from "./base";
 
-type GuEc2FrameworkAppProps = Omit<GuEc2AppProps, "applicationPort">;
+type GuEc2FrameworkAppProps = Omit<GuEc2AppProps, "applicationPort"> & { certificateProps: GuDomainName };
 
 /**
  * Creates an instance of [[`GuEc2App`]], with an application port of 9000.

--- a/src/patterns/ec2-app/framework.ts
+++ b/src/patterns/ec2-app/framework.ts
@@ -5,11 +5,26 @@ For example, a Play app should come with the infrastructure for https://github.c
  */
 
 import type { GuStack } from "../../constructs/core";
+import { AccessScope } from '../../constants';
 import { GuDomainName } from "../../types";
 import type { GuEc2AppProps } from "./base";
 import { GuEc2App } from "./base";
 
 type GuEc2FrameworkAppProps = Omit<GuEc2AppProps, "applicationPort"> & { certificateProps: GuDomainName };
+
+type GuEc2WorkerProps = Omit<GuEc2AppProps, "applicationPort" | "access">;
+
+/**
+ * Creates an instance of [[`GuEc2App`]], with an application port of 9000 and no access to the load balancer.
+ * This is useful for applications that only have an LB for health check purposes
+ */
+export class GuPlayWorkerApp extends GuEc2App {
+  static readonly PORT: number = 9000;
+
+  constructor(scope: GuStack, props: GuEc2WorkerProps) {
+    super(scope, { ...props, applicationPort: GuPlayApp.PORT, access: { scope: AccessScope.INTERNAL, cidrRanges: [] } });
+  }
+}
 
 /**
  * Creates an instance of [[`GuEc2App`]], with an application port of 9000.


### PR DESCRIPTION
## What does this change?

This adds a new EC2 pattern - `GuPlayWorkerApp`. A few teams run Play apps which do useful data processing tasks like consuming queues and pushing data to other queues, or polling web services, but notably do not provide much of a HTTP API themselves apart from a health check.  For these apps, having an ALB is required for healthchecking but the https certificate / domain are not useful.  None of the existing patterns support this requirement.

This change ensures that certificates are still required for regular Play and Node apps.  For services without a certificate the the ALB port to 8080 instead of 80 and sets the ALB as non-open to discourage abusing the change to host browser facing HTTP services.

If this pattern becomes widely used, it might be worth exploring if the ALB could be replaced by a lighter weight (and cheaper) healthchecking lambda. It has never seemed worth the saving to do this for just one project but GuCDK might make it easy to roll out these kinds of cost savings.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
