### PR TITLE
style: Clearer example domain

### DIFF
--- a/src/constructs/acm/__snapshots__/certificate.test.ts.snap
+++ b/src/constructs/acm/__snapshots__/certificate.test.ts.snap
@@ -13,7 +13,7 @@ exports[`The GuCertificate class should create a new certificate (which requires
     "CertificateTesting28FCAC6D": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "code-guardian.com",
+        "DomainName": "domain-name-for-your-application.example",
         "Tags": [
           {
             "Key": "App",
@@ -62,10 +62,10 @@ exports[`The GuCertificate class should create a new certificate when hosted zon
     "CertificateTesting28FCAC6D": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "code-guardian.com",
+        "DomainName": "domain-name-for-your-application.example",
         "DomainValidationOptions": [
           {
-            "DomainName": "code-guardian.com",
+            "DomainName": "domain-name-for-your-application.example",
             "HostedZoneId": "id123",
           },
         ],

--- a/src/constructs/acm/certificate.test.ts
+++ b/src/constructs/acm/certificate.test.ts
@@ -7,7 +7,7 @@ describe("The GuCertificate class", () => {
     const stack = simpleGuStackForTesting();
     new GuCertificate(stack, {
       app: "testing",
-      domainName: "code-guardian.com",
+      domainName: "domain-name-for-your-application.example",
       hostedZoneId: "id123",
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
@@ -17,7 +17,7 @@ describe("The GuCertificate class", () => {
     const stack = simpleGuStackForTesting();
     new GuCertificate(stack, {
       app: "testing",
-      domainName: "code-guardian.com",
+      domainName: "domain-name-for-your-application.example",
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });

--- a/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
+++ b/src/constructs/dns/__snapshots__/dns-records.test.ts.snap
@@ -12,7 +12,7 @@ exports[`The GuCname construct should create the correct resources with minimal 
   "Resources": {
     "TestRecord": {
       "Properties": {
-        "Name": "xyz.code-guardian.com",
+        "Name": "xyz.domain-name-for-your-application.example",
         "RecordType": "CNAME",
         "ResourceRecords": [
           "apple.example.com",

--- a/src/constructs/dns/dns-records.test.ts
+++ b/src/constructs/dns/dns-records.test.ts
@@ -45,7 +45,7 @@ describe("The GuCname construct", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
     new GuCname(stack, "TestRecord", {
-      domainName: "xyz.code-guardian.com",
+      domainName: "xyz.domain-name-for-your-application.example",
       app: "my-test-app",
       resourceRecord: "apple.example.com",
       ttl: Duration.hours(1),

--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -24,7 +24,7 @@ const getLoadBalancer = (stack: GuStack): GuApplicationLoadBalancer => {
 const getCertificate = (stack: GuStack): GuCertificate => {
   return new GuCertificate(stack, {
     ...app,
-    domainName: "code-guardian.com",
+    domainName: "domain-name-for-your-application.example",
   });
 };
 

--- a/src/experimental/constructs/__snapshots__/error-budget-alarm.test.ts.snap
+++ b/src/experimental/constructs/__snapshots__/error-budget-alarm.test.ts.snap
@@ -796,7 +796,7 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "code-guardian.com",
+        "DomainName": "domain-name-for-your-application.example",
         "Tags": [
           {
             "Key": "App",
@@ -2208,7 +2208,7 @@ exports[`The ErrorBudgetAlarmExperimental construct should create the correct re
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "code-guardian.com",
+        "DomainName": "domain-name-for-your-application.example",
         "Tags": [
           {
             "Key": "App",

--- a/src/experimental/constructs/error-budget-alarm.test.ts
+++ b/src/experimental/constructs/error-budget-alarm.test.ts
@@ -30,7 +30,7 @@ describe("The ErrorBudgetAlarmExperimental construct", () => {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -62,7 +62,7 @@ describe("The ErrorBudgetAlarmExperimental construct", () => {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -178,7 +178,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "code-guardian.com",
+        "DomainName": "domain-name-for-your-application.example",
         "Tags": [
           {
             "Key": "App",
@@ -968,7 +968,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
     "CertificateTestguec2app86EE2D42": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "code-guardian.com",
+        "DomainName": "domain-name-for-your-application.example",
         "Tags": [
           {
             "Key": "App",

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -20,7 +20,7 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -39,7 +39,7 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -58,7 +58,7 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -81,7 +81,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -146,7 +146,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -173,7 +173,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -198,7 +198,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -222,7 +222,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [Peer.ipv4("192.168.1.1/32"), Peer.ipv4("8.8.8.8/32")] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -271,7 +271,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -304,7 +304,7 @@ describe("the GuEC2App pattern", function () {
           app: app,
           instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
           certificateProps: {
-            domainName: "code-guardian.com",
+            domainName: "domain-name-for-your-application.example",
           },
           scaling: {
             minimumInstances: 1,
@@ -328,7 +328,7 @@ describe("the GuEC2App pattern", function () {
           app: app,
           instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
           certificateProps: {
-            domainName: "code-guardian.com",
+            domainName: "domain-name-for-your-application.example",
           },
           scaling: {
             minimumInstances: 1,
@@ -350,7 +350,7 @@ describe("the GuEC2App pattern", function () {
       app: app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -437,7 +437,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -464,7 +464,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -503,7 +503,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -602,7 +602,7 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -631,7 +631,7 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -660,7 +660,7 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -690,7 +690,7 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,
@@ -721,7 +721,7 @@ describe("the GuEC2App pattern", function () {
         app,
         instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
         certificateProps: {
-          domainName: "code-guardian.com",
+          domainName: "domain-name-for-your-application.example",
         },
         scaling: {
           minimumInstances: 1,
@@ -735,7 +735,7 @@ describe("the GuEC2App pattern", function () {
       });
     }).toThrowError(
       "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-        "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
+      "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
     );
   });
 
@@ -748,7 +748,7 @@ describe("the GuEC2App pattern", function () {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
       },
       scaling: {
         minimumInstances: 1,

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -735,7 +735,7 @@ describe("the GuEC2App pattern", function () {
       });
     }).toThrowError(
       "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-      "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
+        "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`"
     );
   });
 

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -178,7 +178,7 @@ function restrictedCidrRanges(ranges: IPeer[]) {
  *   access: { scope: AccessScope.PUBLIC },
  *   instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
  *   certificateProps:{
- *     domainName: "prod-guardian.com",
+ *     domainName: "domain-name-for-your-application.example",
  *   },
  *   monitoringConfiguration: {
  *     snsTopicName: "alerts-topic-for-my-team",
@@ -207,7 +207,7 @@ function restrictedCidrRanges(ranges: IPeer[]) {
  *   },
  *   instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
  *   certificateProps:{
- *     domainName: "prod-guardian.com",
+ *     domainName: "domain-name-for-your-application.example",
  *   },
  *   monitoringConfiguration: {
  *     snsTopicName: "alerts-topic-for-my-team",

--- a/src/patterns/ec2-app/framework.test.ts
+++ b/src/patterns/ec2-app/framework.test.ts
@@ -14,7 +14,7 @@ describe("Framework level EC2 app patterns", () => {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
         hostedZoneId: "id123",
       },
       scaling: {
@@ -36,7 +36,7 @@ describe("Framework level EC2 app patterns", () => {
       monitoringConfiguration: { noMonitoring: true },
       userData: "#!/bin/dev foobarbaz",
       certificateProps: {
-        domainName: "code-guardian.com",
+        domainName: "domain-name-for-your-application.example",
         hostedZoneId: "id123",
       },
       scaling: {


### PR DESCRIPTION
## What does this change?

Updates the documentation only. `prod-guardian.com` isn't owned by the Guardian but looks plausibly like it might, can has caused confusion. Let's switch it to something more obviously a placeholder