### PR TITLE
feat: Cognito for Google auth

### DIFF
--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -35,6 +35,14 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
    * @defaultValue  [[`GuDistributionBucketParameter`]]
    */
   bucketNamePath?: string;
+  /**
+   * Set to `true` to use the filename *without* the stage/stack/app prefix.
+   *
+   * Typically you should not override this but you may need to if, for example,
+   * you are referencing a file that is shared across many apps and/or AWS
+   * accounts.
+   */
+  withoutFilePrefix?: boolean;
 }
 
 function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
@@ -86,7 +94,7 @@ export class GuLambdaFunction extends Function {
   public readonly fileName: string;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
-    const { app, fileName, runtime, memorySize, timeout, bucketNamePath } = props;
+    const { app, fileName, runtime, memorySize, timeout, bucketNamePath, withoutFilePrefix } = props;
 
     const bucketName = bucketNamePath
       ? StringParameter.fromStringParameterName(scope, "bucketoverride", bucketNamePath).stringValue
@@ -99,7 +107,7 @@ export class GuLambdaFunction extends Function {
     };
 
     const bucket = Bucket.fromBucketName(scope, `${id}-bucket`, bucketName);
-    const objectKey = GuDistributable.getObjectKey(scope, { app }, { fileName });
+    const objectKey = withoutFilePrefix ? fileName : GuDistributable.getObjectKey(scope, { app }, { fileName });
     const code = Code.fromBucket(bucket, objectKey);
     super(scope, id, {
       ...props,

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -758,4 +758,103 @@ describe("the GuEC2App pattern", function () {
       additionalTags: [{ Key: MetadataKeys.LOG_KINESIS_STREAM_NAME, Value: { Ref: "LoggingStreamName" } }],
     });
   });
+
+  it("supports Google auth at the ALB", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "app";
+    const domain = "domain-name-for-your-application.example";
+
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      access: { scope: AccessScope.PUBLIC },
+      app,
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      certificateProps: {
+        domainName: domain,
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "",
+      accessLogging: { enabled: false },
+      googleAuth: {
+        enabled: true,
+        domain,
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
+      DefaultActions: [
+        {
+          Type: "authenticate-cognito",
+          Order: 1,
+        },
+        {
+          Type: "forward",
+          Order: 2,
+        },
+      ],
+    });
+  });
+
+  it("throws when googleAuth.allowedGroups is empty", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "app";
+    const domain = "domain-name-for-your-application.example";
+
+    expect(
+      () =>
+        new GuEc2App(stack, {
+          applicationPort: 3000,
+          access: { scope: AccessScope.PUBLIC },
+          app,
+          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+          certificateProps: {
+            domainName: domain,
+          },
+          scaling: {
+            minimumInstances: 1,
+          },
+          monitoringConfiguration: { noMonitoring: true },
+          userData: "",
+          accessLogging: { enabled: false },
+          googleAuth: {
+            enabled: true,
+            domain,
+            allowedGroups: [],
+          },
+        })
+    ).toThrowError("googleAuth.allowedGroups cannot be empty!");
+  });
+
+  it("throws when googleAuth.allowedGroups contains groups using non-standard domains", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "app";
+    const domain = "domain-name-for-your-application.example";
+
+    expect(
+      () =>
+        new GuEc2App(stack, {
+          applicationPort: 3000,
+          access: { scope: AccessScope.PUBLIC },
+          app,
+          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+          certificateProps: {
+            domainName: domain,
+          },
+          scaling: {
+            minimumInstances: 1,
+          },
+          monitoringConfiguration: { noMonitoring: true },
+          userData: "",
+          accessLogging: { enabled: false },
+          googleAuth: {
+            enabled: true,
+            domain,
+            allowedGroups: ["apple@guardian.co.uk", "engineering@theguardian.com"],
+          },
+        })
+    ).toThrowError("googleAuth.allowedGroups must use the @guardian.co.uk domain.");
+  });
 });

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -1,10 +1,22 @@
-import { Duration, Tags } from "aws-cdk-lib";
+/* eslint "@guardian/tsdoc-required/tsdoc-required": 2 -- to begin rolling this out for public APIs. */
+import crypto from "crypto";
+import { Duration, SecretValue, Tags } from "aws-cdk-lib";
 import type { BlockDevice } from "aws-cdk-lib/aws-autoscaling";
 import { HealthCheck } from "aws-cdk-lib/aws-autoscaling";
+import {
+  ProviderAttribute,
+  UserPool,
+  UserPoolClientIdentityProvider,
+  UserPoolIdentityProviderGoogle,
+} from "aws-cdk-lib/aws-cognito";
 import type { InstanceType, IPeer, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { Port } from "aws-cdk-lib/aws-ec2";
-import { ApplicationProtocol } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ApplicationProtocol, ListenerAction } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { AuthenticateCognitoAction } from "aws-cdk-lib/aws-elasticloadbalancingv2-actions";
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { Construct } from "constructs";
 import { AccessScope, MetadataKeys, NAMED_SSM_PARAMETER_PATHS } from "../../constants";
 import { GuCertificate } from "../../constructs/acm";
@@ -14,9 +26,10 @@ import type { Http5xxAlarmProps, NoMonitoring } from "../../constructs/cloudwatc
 import { GuAlb5xxPercentageAlarm, GuUnhealthyInstancesAlarm } from "../../constructs/cloudwatch";
 import type { GuStack } from "../../constructs/core";
 import { AppIdentity, GuLoggingStreamNameParameter, GuStringParameter } from "../../constructs/core";
-import { GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
+import { GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
 import type { GuInstanceRoleProps } from "../../constructs/iam";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../../constructs/iam";
+import { GuLambdaFunction } from "../../constructs/lambda";
 import {
   GuApplicationLoadBalancer,
   GuApplicationTargetGroup,
@@ -182,6 +195,69 @@ export interface GuEc2AppProps extends AppIdentity {
    * discouraged) to limit to a subset of the available subnets.
    */
   publicSubnets?: ISubnet[];
+
+  /**
+   * Configure Google Auth.
+   */
+  googleAuth?: {
+    /**
+     * Enables Google Auth (via Cognito). **Additional MANUAL steps required -
+     * see below.**
+     *
+     * Limits access to members of the allowed Google groups.
+     *
+     * Note, this does not currently support simultaneous machine access, so
+     * only set to true if you only require staff access to your service, or are
+     * supporting machine access in some other way.
+     *
+     * MANUAL STEPS: to get this to work, we need a Google Project and
+     * associated credentials. Full instructions can be found here:
+     *
+     * https://docs.google.com/document/d/1_k1FSE52AZHXufWLTiKTI3xy5cGpziyHazSHTKrYfco/edit?usp=sharing
+     *
+     * DevX hope to automate this process in the near future.
+     */
+    enabled: true;
+    /**
+     * The domain users will access your service.
+     *
+     * Set this to the same as for certificateProps.
+     */
+    domain: string;
+    /**
+     * Groups used for membership checks.
+     *
+     * If specified, cannot be empty. Users must be a member of at least one
+     * group to gain access.
+     *
+     * WARNING: groups must be specified with the `guardian.co.uk` domain, even
+     * if that is the non-idiomatic choice for daily use.
+     *
+     * @defaultValue [`engineering@guardian.co.uk`]
+     */
+    allowedGroups?: string[];
+
+    /**
+     * Secrets Manager path containing Google OAuth2 Client credentials.
+     *
+     * NOTE: you do not need to set this value, but you DO need to generate and
+     * store the associated credentials in Secrets Manager.
+     *
+     * Credentials should be stored in Secrets Manager as JSON:
+     *
+     * ```json
+     * {
+     *   "clientId": "my-client-id",
+     *   "clientSecret": "my-client-secret"
+     * }
+     * ```
+     *
+     * @see `googleAuth.enabled` for how to generate.
+     *
+     * @defaultValue /:STAGE/:stack/:app/google-auth-credentials
+     */
+    credentialsSecretsManagerPath?: string;
+  };
 }
 
 function restrictedCidrRanges(ranges: IPeer[]) {
@@ -375,6 +451,135 @@ export class GuEc2App extends Construct {
           snsTopicName,
         });
       }
+    }
+
+    if (props.googleAuth?.enabled) {
+      const prefix = `/${scope.stage}/${scope.stack}/${app}`;
+
+      const {
+        allowedGroups = ["engineering@guardian.co.uk"],
+        credentialsSecretsManagerPath = `${prefix}/google-auth-credentials`,
+      } = props.googleAuth;
+
+      if (allowedGroups.length < 1) {
+        throw new Error("googleAuth.allowedGroups cannot be empty!");
+      }
+
+      if (allowedGroups.find((group) => !group.endsWith("@guardian.co.uk"))) {
+        throw new Error("googleAuth.allowedGroups must use the @guardian.co.uk domain.");
+      }
+
+      const deployToolsAccountId = StringParameter.fromStringParameterName(
+        scope,
+        "deploy-tools-account-id-parameter",
+        NAMED_SSM_PARAMETER_PATHS.DeployToolsAccountId.path
+      );
+
+      // See https://github.com/guardian/cognito-auth-lambdas for the source
+      // code here. ARN format is:
+      // arn:aws:lambda:aws-region:acct-id:function:helloworld.
+      const gatekeeperFunctionArn = `arn:aws:lambda:eu-west-1:${deployToolsAccountId.stringValue}:function:deploy-PROD-gatekeeper-lambda`;
+
+      // Note, handler and filename must match here:
+      // https://github.com/guardian/cognito-auth-lambdas.
+      const authLambda = new GuLambdaFunction(scope, "auth-lambda", {
+        app: app,
+        memorySize: 128,
+        handler: "devx-cognito-lambda-amd64-v1",
+        runtime: Runtime.GO_1_X,
+        fileName: "devx-cognito-lambda-amd64-v1.zip",
+        bucketNamePath: NAMED_SSM_PARAMETER_PATHS.OrganisationDistributionBucket.path,
+        architecture: Architecture.X86_64,
+        environment: {
+          ALLOWED_GROUPS: allowedGroups.join(","),
+          GATEKEEPER_FUNCTION_ARN: gatekeeperFunctionArn,
+        },
+      });
+
+      authLambda.addToRolePolicy(
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["lambda:InvokeFunction"],
+          resources: [gatekeeperFunctionArn],
+        })
+      );
+
+      // Cognito user pool. We require both lambdas: pre-sign-up runs the first
+      // time a user attempts to authenticate (before they exist in the User
+      // Pool); pre-auth runs in subsequent authentication flows.
+      const userPool = new UserPool(this, "user-pool", {
+        lambdaTriggers: {
+          preAuthentication: authLambda,
+          preSignUp: authLambda,
+        },
+      });
+
+      // These help ensure domain is deterministic but also unique. Key
+      // assumption is that app/stack/stage combo are unique within Guardian.
+      const domainPrefix = `com-gu-${app.toLowerCase()}-${scope.stage.toLowerCase()}`;
+      const suffix = crypto.createHash("md5").update(domainPrefix).digest("hex");
+
+      const userPoolDomain = userPool.addDomain("domain", {
+        cognitoDomain: {
+          domainPrefix: `${domainPrefix}-${suffix}`,
+        },
+      });
+
+      const clientId = SecretValue.secretsManager(credentialsSecretsManagerPath, { jsonField: "clientId" });
+      const clientSecret = SecretValue.secretsManager(credentialsSecretsManagerPath, { jsonField: "clientSecret" });
+
+      const userPoolIdp = new UserPoolIdentityProviderGoogle(scope, "google-idp", {
+        userPool: userPool,
+        clientId: clientId.toString(),
+        clientSecret: clientSecret.toString(),
+        attributeMapping: {
+          email: ProviderAttribute.GOOGLE_EMAIL,
+          givenName: ProviderAttribute.GOOGLE_GIVEN_NAME,
+          familyName: ProviderAttribute.GOOGLE_FAMILY_NAME,
+          profilePicture: ProviderAttribute.GOOGLE_PICTURE,
+          custom: {
+            name: ProviderAttribute.GOOGLE_NAME,
+          },
+        },
+        scopes: ["openid", "email", "profile"],
+      });
+
+      const userPoolClient = userPool.addClient("alb-client", {
+        supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
+        generateSecret: true,
+        oAuth: {
+          callbackUrls: [`https://${props.googleAuth.domain}/oauth2/idpresponse`],
+        },
+
+        // Note: id and access validity token validity cannot be less than one
+        // hour (this is the cognito cookie duration). To quickly invalidate
+        // credentials, disable the user in Cognito. It might be that we want to
+        // parameterise these going forward, but that would require Infosec
+        // discussion.
+        idTokenValidity: Duration.hours(1),
+        accessTokenValidity: Duration.hours(1),
+        refreshTokenValidity: Duration.days(7),
+      });
+
+      userPoolClient.node.addDependency(userPoolIdp);
+
+      listener.addAction("CognitoAuth", {
+        action: new AuthenticateCognitoAction({
+          userPool: userPool,
+          userPoolClient: userPoolClient,
+          userPoolDomain: userPoolDomain,
+          next: ListenerAction.forward([targetGroup]),
+          sessionTimeout: Duration.minutes(15),
+        }),
+      });
+
+      // Need to give the ALB outbound access on 443 for the IdP endpoints.
+      const idpEgressSecurityGroup = new GuHttpsEgressSecurityGroup(scope, "ldp-access", {
+        app,
+        vpc,
+      });
+
+      loadBalancer.addSecurityGroup(idpEgressSecurityGroup);
     }
 
     this.vpc = vpc;

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -487,7 +487,8 @@ export class GuEc2App extends Construct {
         memorySize: 128,
         handler: "devx-cognito-lambda-amd64-v1",
         runtime: Runtime.GO_1_X,
-        fileName: "devx-cognito-lambda-amd64-v1.zip",
+        fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v1.zip",
+        withoutFilePrefix: true,
         bucketNamePath: NAMED_SSM_PARAMETER_PATHS.OrganisationDistributionBucket.path,
         architecture: Architecture.X86_64,
         environment: {


### PR DESCRIPTION
Introduce Google auth to EC2 patterns

The aim is to support:

* human authentication
* for EC2-pattern users
* that is *secure* and *easy to adopt*
    
This is achieved by integrating Cognito at the ALB level.
 
In addition to a workspace check - i.e. the user is part of @guardian.co.uk - a group check is also required. When multiple groups are specified a user need only be a member of one to gain access.

It is recommended that people create a specific Google group for their application and use this for the membership check. If broader P+E dev access is required, use `engineering@guardian.co.uk`.

The overall architecture is as follows:

```mermaid
sequenceDiagram
    Note right of ALB: Shaded region is defined in CDK pattern.
    rect rgba(0, 0, 255, .1)
      ALB->>Cognito: Handle authentication for me please...
      Cognito->>Google: Are they part of our org?
      Google-->>Cognito: Looks good!
      Cognito->>Cognito Lambda: Any other checks?
    end
    Cognito Lambda->>Gatekeeper Lambda: Can you check group membership for me?
    Gatekeeper Lambda-->>Cognito Lambda: Looks good!
    rect rgba(0, 0, 255, .1)
      Cognito Lambda-->>Cognito: Looks good!
      Cognito-->>ALB: Looks good!
    end
```

The shaded region is defined in this PR, though both lambdas are defined [here](https://github.com/guardian/cognito-gatekeeper/pull/2).

The Cognito Lambda is triggered by Cognito as at the 'pre-auth' and also 'pre-signup' stages. For more on Cognito Lambda triggers see [here](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html).

For context see:

* [Auth lambda and architecture](https://github.com/guardian/cognito-gatekeeper/pull/2)
* [Teamcity example (inlined)](https://github.com/guardian/deploy-tools-platform/pull/670)
* [Trello card](https://trello.com/c/XiOqsax2/1733-aws-cognito-auth-in-guardian-cdk)
* [Guide to setup Google](https://docs.google.com/document/d/1_k1FSE52AZHXufWLTiKTI3xy5cGpziyHazSHTKrYfco/edit#)
* [Proposal doc for CDK integration](https://docs.google.com/document/d/1SfvjNRIzv1bNYRho7s5i_YZv6YyWadp4j9rNOqvpnJg/edit#)

Note, ideally we will automate the Google side, but that is a follow up.

**TODO: publish to beta and test!**

## Questions

At the moment everything is defined in the EC2 pattern rather than the `GuApplicationLoadBalancer` construct. This is because a lot of the related constructs (`GuApplicationListener` and `GuApplicationTargetGroup`) are *not* defined in the ALB construct. I wonder if medium-term we should integrate these into the `GuApplicationLoadBalancer` pattern? This is probably something to do in any `v2` of the library though. I.e.