### PR TITLE
feat: support automatic configuration of lambda functions

### DIFF
--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -192,4 +192,28 @@ describe("The GuLambdaFunction class", () => {
       },
     });
   });
+
+  it("should read config from SSM when enabled", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      fileName: "my-app.zip",
+      bucketNamePath: "/example-parameter-path", // the override
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+      app: "testing",
+      config: {
+        enabled: true,
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          AWS_LAMBDA_EXEC_WRAPPER: "/opt/ssm-to-env.sh",
+          SSM_PATH_PREFIX: "/TEST/test-stack/testing",
+        },
+      },
+    });
+  });
 });

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -4,7 +4,7 @@ import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Code, Function, LayerVersion, RuntimeFamily } from "aws-cdk-lib/aws-lambda";
 import type { FunctionProps, Runtime } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
-import { CfnParameter, StringParameter } from "aws-cdk-lib/aws-ssm";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { NAMED_SSM_PARAMETER_PATHS } from "../../constants";
 import { GuDistributable } from "../../types";
 import { GuLambdaErrorPercentageAlarm, GuLambdaThrottlingAlarm } from "../cloudwatch";

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -177,6 +177,8 @@ export class GuLambdaFunction extends Function {
       );
 
       const configPrefix = config.ssmPrefix ?? `/${scope.stage}/${scope.stack}/${this.app}`;
+
+      // TODO - guessing this needs to be parameterised by arch?
       const configLayer = LayerVersion.fromLayerVersionArn(
         scope,
         "config-layer",


### PR DESCRIPTION
This PR introduces support for automatic configuration of lambdas via:

via https://github.com/guardian/ssm-to-env.

When`config.enabled = true` in `GuLambdaFunction` props configuration for the lambda is automatically fetched and provided to the lambda as env vars.

Some details:

* configuration is sourced from *all* parameters with a matching `/:STAGE/:stack/:app` prefix
* some transformation of parameter names is done - see the code docs for info here

Note, this is opt-in initially. It is applied to our `GuLambdaFunction` construct, which is used by the following patterns:

* api-lambda
* scheduled-lambda
* sns-lambda (experimental)
* kinesis-lambda (experimental)

TODO:

* [x] write some tests!
* [ ] check with @kenoir for thoughts on if I'm using ssm-via-env right

## For discussion

Should we enable this by default? At the moment it is opt-in but if this is our recommended way to configure Lambdas, which I am keen to argue for, then defaulting it to on would make sense. One caveat is that it will break any users of Lambda Layer wrapper scripts. But these must be quite (very?)  rare. And those impacted can simply use the props to disable this feature if required.