### PR TITLE
feat: Add devx global dist bucket

### DIFF
--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -18,6 +18,7 @@ interface NamedSsmParameterPaths {
   PrimaryVpcPrivateSubnets: SsmParameterPath;
   PrimaryVpcPublicSubnets: SsmParameterPath;
   FastlyCustomerId: SsmParameterPath;
+  DevxGlobalDistBucket: SsmParameterPath;
 }
 
 export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
@@ -57,6 +58,10 @@ export const NAMED_SSM_PARAMETER_PATHS: NamedSsmParameterPaths = {
   PrimaryVpcPublicSubnets: {
     path: `${VPC_SSM_PARAMETER_PREFIX}/primary/subnets/public`,
     description: "A comma-separated list of public subnets",
+  },
+  DevxGlobalDistBucket: {
+    path: "/organisation/services/artifact.bucket",
+    description: "SSM parameter containing the S3 bucket name holding organisation-level DevX artifacts",
   },
   FastlyCustomerId: {
     path: "/account/external/fastly/customer.id",


### PR DESCRIPTION
**Note, interested in what the actual path here should be. Perhaps `/account/external...`? instead of under services?**

Adds global dist bucket so that we can reference it. This bucket contains artifacts that need to be accessilble to all of our AWS accounts.

Once merged, I will raise a PR on aws-account-setup to add this parameter to all of our accounts. There is somewhat of a chicken and egg issue here, but the window of time between being present in CDK and in accounts (via aws-account-setup) is likely to be small and the only users, initially at least, Devx.