### PR TITLE
fix: refactor org dist bucket naming for clarity

### DIFF
--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -18,7 +18,7 @@ interface NamedSsmParameterPaths {
   PrimaryVpcPrivateSubnets: SsmParameterPath;
   PrimaryVpcPublicSubnets: SsmParameterPath;
   FastlyCustomerId: SsmParameterPath;
-  DevxGlobalDistBucket: SsmParameterPath;
+  OrganisationDistributionBucket: SsmParameterPath;
 }
 
 export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
@@ -59,7 +59,7 @@ export const NAMED_SSM_PARAMETER_PATHS: NamedSsmParameterPaths = {
     path: `${VPC_SSM_PARAMETER_PREFIX}/primary/subnets/public`,
     description: "A comma-separated list of public subnets",
   },
-  DevxGlobalDistBucket: {
+  OrganisationDistributionBucket: {
     path: "/organisation/services/artifact.bucket",
     description: "SSM parameter containing the S3 bucket name holding organisation-level DevX artifacts",
   },


### PR DESCRIPTION
Small fix to https://github.com/guardian/cdk/pull/1789 to align parameter name with the path.

Note, no one is using this yet so should be safe to change.

BREAKING CHANGE: the SSM paramter path is changed. To update: DevxGlobalDistBucket -> OrganisationDistributionBucket.
