### PR TITLE
feat: Add DeployToolsAccountId named SSM parameter

### DIFF
--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -19,6 +19,7 @@ interface NamedSsmParameterPaths {
   PrimaryVpcPublicSubnets: SsmParameterPath;
   FastlyCustomerId: SsmParameterPath;
   OrganisationDistributionBucket: SsmParameterPath;
+  DeployToolsAccountId: SsmParameterPath;
 }
 
 export const VPC_SSM_PARAMETER_PREFIX = "/account/vpc";
@@ -68,6 +69,10 @@ export const NAMED_SSM_PARAMETER_PATHS: NamedSsmParameterPaths = {
     description:
       "SSM parameter containing the Fastly Customer ID. Can be obtained from https://manage.fastly.com/account/company by an admin",
     optional: true,
+  },
+  DeployToolsAccountId: {
+    path: "/organisation/accounts/deployTools",
+    description: "Account ID of the Deploy Tools account. Useful as some shared resources live here.",
   },
 };
 


### PR DESCRIPTION
Adds a new named SSM parameter:

```
DeployToolsAccountId: {
  path: "/organisation/deployTools.account.id",
  description: "Account ID of the Deploy Tools account. Useful as some shared resources live here.",
},
```

Note, unclear what a good path is here - input very welcome!

The initial motivation is to reference a shared Lambda Layer that lives in the Deploy Tools account (see https://github.com/guardian/cdk/pull/1769/files#diff-8a2ab91d886f00c60278a2b34e5ffd1b2b4a3c6eec5ed33ab147d60693ca9a1dR173). But I suspect this will be generally useful given we often locate shared DevX resources here.

An alternative is:

https://github.com/guardian/private-infrastructure-config

But am reluctant to add this as a dependency to all CDK users as it contains private info and requires private repo access.