### PR TITLE
chore(deps): Enable manual AWS CDK update via github.com

### DIFF
--- a/.github/workflows/update-aws-cdk.yaml
+++ b/.github/workflows/update-aws-cdk.yaml
@@ -4,6 +4,9 @@ on:
     # At 10:00 on day-of-month 10.
     # See https://crontab.guru/#0_10_10_*_*
     - cron: '0 10 10 * *'
+
+  # Allows one to update the version of AWS CDK by simply starting the workflow, as opposed to manually running the update-aws-cdk script.
+  workflow_dispatch:
 jobs:
   update-aws-cdk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this change?
In #1512 we automated the process of updating AWS CDK dependencies by creating a schedule that runs on the 10th day of each month.

We sometimes want to perform an update earlier, so allow the GH workflow to be manually invoked.

## How to test
N/A

## How can we measure success?
We can update AWS CDK dependencies via the GitHub UI (or CLI!), rather than the manual process of:
- Locally switching to `main` and updating
- Locally running `./script/update-aws-cdk`