### PR TITLE
feat: Allow riff-raff.yaml auto-generation to work with managed lambda deploys

### DIFF
--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -92,6 +92,7 @@ function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
 export class GuLambdaFunction extends Function {
   public readonly app: string;
   public readonly fileName: string;
+  public readonly bucketNamePath: string | undefined;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const { app, fileName, runtime, memorySize, timeout, bucketNamePath, withoutFilePrefix } = props;
@@ -122,6 +123,7 @@ export class GuLambdaFunction extends Function {
 
     this.app = app;
     this.fileName = fileName;
+    this.bucketNamePath = bucketNamePath;
 
     if (props.errorPercentageMonitoring) {
       new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -46,7 +46,7 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
   /**
    * TODO
    */
-  managedDeployment?: boolean
+  managedDeployment?: boolean;
 }
 
 function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
@@ -98,6 +98,7 @@ export class GuLambdaFunction extends Function {
   public readonly fileName: string;
   public readonly bucketNamePath: string | undefined;
   public readonly managedDeployment: boolean;
+  public readonly withoutFilePrefix: boolean;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const { app, fileName, runtime, memorySize, timeout, bucketNamePath, withoutFilePrefix, managedDeployment } = props;
@@ -130,6 +131,7 @@ export class GuLambdaFunction extends Function {
     this.fileName = fileName;
     this.bucketNamePath = bucketNamePath;
     this.managedDeployment = managedDeployment ?? false;
+    this.withoutFilePrefix = withoutFilePrefix ?? false;
 
     if (props.errorPercentageMonitoring) {
       new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -43,6 +43,10 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
    * accounts.
    */
   withoutFilePrefix?: boolean;
+  /**
+   * TODO
+   */
+  managedDeployment?: boolean
 }
 
 function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
@@ -93,9 +97,10 @@ export class GuLambdaFunction extends Function {
   public readonly app: string;
   public readonly fileName: string;
   public readonly bucketNamePath: string | undefined;
+  public readonly managedDeployment: boolean;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
-    const { app, fileName, runtime, memorySize, timeout, bucketNamePath, withoutFilePrefix } = props;
+    const { app, fileName, runtime, memorySize, timeout, bucketNamePath, withoutFilePrefix, managedDeployment } = props;
 
     const bucketName = bucketNamePath
       ? StringParameter.fromStringParameterName(scope, "bucketoverride", bucketNamePath).stringValue
@@ -124,6 +129,7 @@ export class GuLambdaFunction extends Function {
     this.app = app;
     this.fileName = fileName;
     this.bucketNamePath = bucketNamePath;
+    this.managedDeployment = managedDeployment ?? false;
 
     if (props.errorPercentageMonitoring) {
       new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -113,7 +113,7 @@ export class GuLambdaFunction extends Function {
       timeout,
       bucketNamePath,
       withoutFilePrefix = false,
-      withoutArtifactUpload: withoutArtifactUpload = false,
+      withoutArtifactUpload = false,
     } = props;
 
     const bucketName = bucketNamePath

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -101,7 +101,16 @@ export class GuLambdaFunction extends Function {
   public readonly withoutFilePrefix: boolean;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
-    const { app, fileName, runtime, memorySize, timeout, bucketNamePath, withoutFilePrefix, managedDeployment } = props;
+    const {
+      app,
+      fileName,
+      runtime,
+      memorySize,
+      timeout,
+      bucketNamePath,
+      withoutFilePrefix = false,
+      managedDeployment = false,
+    } = props;
 
     const bucketName = bucketNamePath
       ? StringParameter.fromStringParameterName(scope, "bucketoverride", bucketNamePath).stringValue
@@ -130,8 +139,8 @@ export class GuLambdaFunction extends Function {
     this.app = app;
     this.fileName = fileName;
     this.bucketNamePath = bucketNamePath;
-    this.managedDeployment = managedDeployment ?? false;
-    this.withoutFilePrefix = withoutFilePrefix ?? false;
+    this.managedDeployment = managedDeployment;
+    this.withoutFilePrefix = withoutFilePrefix;
 
     if (props.errorPercentageMonitoring) {
       new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -44,7 +44,11 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
    */
   withoutFilePrefix?: boolean;
   /**
-   * TODO
+   * Set to `true` this informs consumers of this function that upload is
+   * managed elsewhere by DevX.
+   *
+   * This is used by RiffRaffYamlFileExperimental to skip generating
+   * an uploadLambda step.
    */
   managedDeployment?: boolean;
 }

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -50,7 +50,7 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
    * This is used by RiffRaffYamlFileExperimental to skip generating
    * an uploadLambda step.
    */
-  managedDeployment?: boolean;
+  withoutArtifactUpload?: boolean;
 }
 
 function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
@@ -101,7 +101,7 @@ export class GuLambdaFunction extends Function {
   public readonly app: string;
   public readonly fileName: string;
   public readonly bucketNamePath: string | undefined;
-  public readonly managedDeployment: boolean;
+  public readonly withoutArtifactUpload: boolean;
   public readonly withoutFilePrefix: boolean;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
@@ -113,7 +113,7 @@ export class GuLambdaFunction extends Function {
       timeout,
       bucketNamePath,
       withoutFilePrefix = false,
-      managedDeployment = false,
+      withoutArtifactUpload: withoutArtifactUpload = false,
     } = props;
 
     const bucketName = bucketNamePath
@@ -143,7 +143,7 @@ export class GuLambdaFunction extends Function {
     this.app = app;
     this.fileName = fileName;
     this.bucketNamePath = bucketNamePath;
-    this.managedDeployment = managedDeployment;
+    this.withoutArtifactUpload = withoutArtifactUpload;
     this.withoutFilePrefix = withoutFilePrefix;
 
     if (props.errorPercentageMonitoring) {

--- a/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
@@ -2,16 +2,31 @@ import type { GuStack } from "../../../constructs/core";
 import type { GuLambdaFunction } from "../../../constructs/lambda";
 import type { RiffRaffDeployment } from "../types";
 
-const bucketProps = (lambda: GuLambdaFunction): {
-  bucketSsmLookup?: boolean,
-  bucketSsmKey?: string
-} => lambda.bucketNamePath === undefined
-  ? {
-      bucketSsmLookup: true,
-    }
-  : {
-      bucketSsmKey: lambda.bucketNamePath,
-    };
+const locationProps = (
+  lambda: GuLambdaFunction
+): {
+  bucketSsmLookup?: boolean;
+  bucketSsmKey?: string;
+  prefixStackToKey?: boolean;
+  prefixAppToKey?: boolean;
+  prefixStageToKey?: boolean;
+} => {
+  const bucketProp =
+    lambda.bucketNamePath === undefined
+      ? {
+          bucketSsmLookup: true,
+        }
+      : {
+          bucketSsmKey: lambda.bucketNamePath,
+        };
+
+  return {
+    ...bucketProp,
+    prefixStackToKey: !lambda.withoutFilePrefix,
+    prefixAppToKey: !lambda.withoutFilePrefix,
+    prefixStageToKey: !lambda.withoutFilePrefix,
+  };
+};
 
 export function uploadLambdaArtifact(lambda: GuLambdaFunction): RiffRaffDeployment {
   const { app, fileName } = lambda;
@@ -26,7 +41,7 @@ export function uploadLambdaArtifact(lambda: GuLambdaFunction): RiffRaffDeployme
       app,
       contentDirectory: app,
       parameters: {
-        ...bucketProps(lambda),
+        ...locationProps(lambda),
         lookupByTags: true,
         fileName,
       },
@@ -51,7 +66,7 @@ export function updateLambdaDeployment(
       app,
       contentDirectory: app,
       parameters: {
-        ...bucketProps(lambda),
+        ...locationProps(lambda),
         lookupByTags: true,
         fileName,
       },

--- a/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
@@ -2,21 +2,20 @@ import type { GuStack } from "../../../constructs/core";
 import type { GuLambdaFunction } from "../../../constructs/lambda";
 import type { RiffRaffDeployment } from "../types";
 
+const bucketProps = (lambda: GuLambdaFunction): {
+  bucketSsmLookup?: boolean,
+  bucketSsmKey?: string
+} => lambda.bucketNamePath === undefined
+  ? {
+      bucketSsmLookup: true,
+    }
+  : {
+      bucketSsmKey: lambda.bucketNamePath,
+    };
+
 export function uploadLambdaArtifact(lambda: GuLambdaFunction): RiffRaffDeployment {
   const { app, fileName } = lambda;
   const { stack, region } = lambda.stack as GuStack;
-
-  const bucketProps: {
-    bucketSsmLookup?: boolean,
-    bucketSsmKey?: string
-  } =
-    lambda.bucketNamePath === undefined
-      ? {
-          bucketSsmLookup: true,
-        }
-      : {
-          bucketSsmKey: lambda.bucketNamePath,
-        };
 
   return {
     name: ["lambda-upload", region, stack, app].join("-"),
@@ -27,7 +26,7 @@ export function uploadLambdaArtifact(lambda: GuLambdaFunction): RiffRaffDeployme
       app,
       contentDirectory: app,
       parameters: {
-        ...bucketProps,
+        ...bucketProps(lambda),
         lookupByTags: true,
         fileName,
       },
@@ -52,7 +51,7 @@ export function updateLambdaDeployment(
       app,
       contentDirectory: app,
       parameters: {
-        bucketSsmLookup: true,
+        ...bucketProps(lambda),
         lookupByTags: true,
         fileName,
       },

--- a/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
@@ -6,6 +6,18 @@ export function uploadLambdaArtifact(lambda: GuLambdaFunction): RiffRaffDeployme
   const { app, fileName } = lambda;
   const { stack, region } = lambda.stack as GuStack;
 
+  const bucketProps: {
+    bucketSsmLookup?: boolean,
+    bucketSsmKey?: string
+  } =
+    lambda.bucketNamePath === undefined
+      ? {
+          bucketSsmLookup: true,
+        }
+      : {
+          bucketSsmKey: lambda.bucketNamePath,
+        };
+
   return {
     name: ["lambda-upload", region, stack, app].join("-"),
     props: {
@@ -15,7 +27,7 @@ export function uploadLambdaArtifact(lambda: GuLambdaFunction): RiffRaffDeployme
       app,
       contentDirectory: app,
       parameters: {
-        bucketSsmLookup: true,
+        ...bucketProps,
         lookupByTags: true,
         fileName,
       },

--- a/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
@@ -2,15 +2,15 @@ import type { GuStack } from "../../../constructs/core";
 import type { GuLambdaFunction } from "../../../constructs/lambda";
 import type { RiffRaffDeployment } from "../types";
 
-const locationProps = (
-  lambda: GuLambdaFunction
-): {
+interface S3LocationProps {
   bucketSsmLookup?: boolean;
   bucketSsmKey?: string;
   prefixStackToKey?: boolean;
   prefixAppToKey?: boolean;
   prefixStageToKey?: boolean;
-} => {
+}
+
+const locationProps = (lambda: GuLambdaFunction): S3LocationProps => {
   const bucketProp =
     lambda.bucketNamePath === undefined
       ? {

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -387,7 +387,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     `);
   });
 
-  it("Should not create an uploadLambda step when managedDeployment is true", () => {
+  it("Should not create an uploadLambda step when withoutArtifactUpload is true", () => {
     const app = new App({ outdir: "/tmp/cdk.out" });
 
     class MyApplicationStack extends GuStack {
@@ -397,7 +397,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
         new GuLambdaFunction(this, "test", {
           app: "my-lambda",
-          managedDeployment: true,
+          withoutArtifactUpload: true,
           runtime: Runtime.NODEJS_16_X,
           fileName: "my-lambda-artifact.zip",
           handler: "handler.main",

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -343,6 +343,9 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda
           parameters:
             bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-artifact.zip
           actions:
@@ -370,6 +373,9 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda
           parameters:
             bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-artifact.zip
           actions:
@@ -535,6 +541,9 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:
@@ -583,6 +592,9 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:
@@ -614,6 +626,9 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:
@@ -662,6 +677,9 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:

--- a/src/experimental/riff-raff-yaml-file/index.ts
+++ b/src/experimental/riff-raff-yaml-file/index.ts
@@ -219,7 +219,7 @@ export class RiffRaffYamlFileExperimental {
           const autoscalingGroups = this.getAutoScalingGroups(stack);
 
           const artifactUploads: RiffRaffDeployment[] = [
-            lambdas.map(uploadLambdaArtifact),
+            lambdas.filter((_) => !_.managedDeployment).map(uploadLambdaArtifact),
             autoscalingGroups.map(uploadAutoscalingArtifact),
           ].flat();
           artifactUploads.forEach(({ name, props }) => deployments.set(name, props));

--- a/src/experimental/riff-raff-yaml-file/index.ts
+++ b/src/experimental/riff-raff-yaml-file/index.ts
@@ -219,7 +219,7 @@ export class RiffRaffYamlFileExperimental {
           const autoscalingGroups = this.getAutoScalingGroups(stack);
 
           const artifactUploads: RiffRaffDeployment[] = [
-            lambdas.filter((_) => !_.managedDeployment).map(uploadLambdaArtifact),
+            lambdas.filter((_) => !_.withoutArtifactUpload).map(uploadLambdaArtifact),
             autoscalingGroups.map(uploadAutoscalingArtifact),
           ].flat();
           artifactUploads.forEach(({ name, props }) => deployments.set(name, props));

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -489,7 +489,7 @@ export class GuEc2App extends Construct {
         runtime: Runtime.GO_1_X,
         fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v1.zip",
         withoutFilePrefix: true,
-        managedDeployment: true,
+        withoutArtifactUpload: true,
         bucketNamePath: NAMED_SSM_PARAMETER_PATHS.OrganisationDistributionBucket.path,
         architecture: Architecture.X86_64,
         environment: {

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -489,6 +489,7 @@ export class GuEc2App extends Construct {
         runtime: Runtime.GO_1_X,
         fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v1.zip",
         withoutFilePrefix: true,
+        managedDeployment: true,
         bucketNamePath: NAMED_SSM_PARAMETER_PATHS.OrganisationDistributionBucket.path,
         architecture: Architecture.X86_64,
         environment: {


### PR DESCRIPTION
## What does this change?

Updates CDK to allow riff-raff.yaml auto-generation to work with managed (not uploaded by the consuming stack) lambda deploys. This is to allow CDK to reference a lambda S3 sources that are managed and uploaded by DevX (for example the [cognito auth lambda](https://github.com/guardian/cdk/blob/main/src/patterns/ec2-app/base.ts#L485)), to deploy successfully from a  generated riff-raff.yaml.

RiffRaff changes are also required to support this: https://github.com/guardian/riff-raff/pull/1129

## How to test

This is being tested by the deployment of https://github.com/guardian/birthdays/pull/75

## How can we measure success?

The `googleAuth` option in the `guEc2App` pattern can be used successfully by non-DevX teams.