### PR TITLE
Default to NPM since this is the recommendation

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -23,12 +23,12 @@ Generally speaking, we've found this to be a good process to follow when migrati
 1. Create a new project specifying the `--yaml-template-location` flag.
 
    ```shell
-   npx @guardian/cdk@latest new --app [app] --stack [stack] --stage [stage] --package-manager [npm|yarn] --yaml-template-location
+   npx @guardian/cdk@latest new --app [app] --stack [stack] --stage [stage] [--package-manager [npm|yarn]] --yaml-template-location
    ```
 
    For example for the app trigr we do
    ```shell
-   npx @guardian/cdk@latest new --app trigr --stack ophan --stage PROD  --package-manager npm --yaml-template-location cloudformation/trigr.cfn.yaml
+   npx @guardian/cdk@latest new --app trigr --stack ophan --stage PROD  --yaml-template-location cloudformation/trigr.cfn.yaml
    ```
 
    See the [new project](setting-up-a-gucdk-project.md) guide for further reading

--- a/docs/setting-up-a-gucdk-project.md
+++ b/docs/setting-up-a-gucdk-project.md
@@ -15,7 +15,7 @@ It will place files within a `cdk` directory at the root of the repository.
 To initialise a new project run the following within your repository:
 
 ```sh
-npx @guardian/cdk@latest new --app [app] --stack [stack] --stage [stage] --package-manager [npm|yarn]
+npx @guardian/cdk@latest new --app [app] --stack [stack] --stage [stage] [--package-manager [npm|yarn]]
 ```
 
 For example, for the app `riff-raff` we'd do:

--- a/script/ci-project-generation
+++ b/script/ci-project-generation
@@ -31,6 +31,5 @@ npm pack --pack-destination $TMP_DIR
     --app integration-test \
     --stack cdk \
     --stage CODE \
-    --stage PROD \
-    --package-manager npm
+    --stage PROD
 )

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -66,7 +66,7 @@ const parseCommandLineArguments = () => {
               description:
                 "The Node package manager to use. Match this to the repository (package-lock.json = npm, yarn.lock = yarn). If the repository has neither file, and there is no strong convention in your team, we recommend npm.",
               choices: ["npm", "yarn"],
-              demandOption: true,
+              default: "npm",
             })
       )
       .version(


### PR DESCRIPTION
## What does this change?

Sets a default value for the argument `package-manager`.  This matches the recommendation and makes the default workflow less verbose.  

If this isn't desired, we should update the riff-raff example to include an explicit `--package-manager` (https://github.com/guardian/cdk/blob/main/docs/setting-up-a-gucdk-project.md?plain=1#L24)