### PR TITLE
docs: Add missing `--package-manager` to example

### DIFF
--- a/docs/setting-up-a-gucdk-project.md
+++ b/docs/setting-up-a-gucdk-project.md
@@ -25,7 +25,8 @@ npx @guardian/cdk@latest new \
   --app riff-raff \
   --stack deploy \
   --stage CODE \
-  --stage PROD
+  --stage PROD \
+  --package-manager npm
 ```
 
 > Tip: Run `npx @guardian/cdk@latest new --help` to find out more about the available flags,


### PR DESCRIPTION
## What does this change?

Update docs to include a `--package-manager` so that users don't think this is an optional argument