### PR TITLE
feat(GuStack): Add a getter for the repository name

### DIFF
--- a/src/constructs/core/stack.test.ts
+++ b/src/constructs/core/stack.test.ts
@@ -54,6 +54,19 @@ describe("The GuStack construct", () => {
     });
   });
 
+  it("should expose the repository information as a property", () => {
+    const stack = new GuStack(
+      new App({ context: { [ContextKeys.REPOSITORY_URL]: "https://github.com/guardian/my-repository" } }),
+      "Test",
+      {
+        stack: "test",
+        stage: "TEST",
+      }
+    );
+
+    expect(stack.repositoryName).toEqual("guardian/my-repository");
+  });
+
   it("can persist the logicalId for any resource (consumer's POV)", () => {
     class MigratingStack extends GuStack {
       // eslint-disable-next-line custom-rules/valid-constructors -- for testing purposes


### PR DESCRIPTION
## What does this change?
Adds a new `repositoryName` field to a `GuStack`, returning the value of the GitHub repository that is already added as a `gu:repo` tag to the stack (see #537).

Initially, this is to address [a TODO in service-catalogue](https://github.com/guardian/service-catalogue/blob/baff2dc75744e847ae3ff437e78c2f5e2f30cfcb/packages/cdk/lib/ecs/task.ts#L90); it feels useful outside of that service, so adding it to GuCDK.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See added test.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Less work for consuming projects to do?

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

N/A

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
