### PR TITLE
feat: Allow ALB Google auth session length to vary up to 60 minutes

### DIFF
--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -855,7 +855,7 @@ describe("the GuEC2App pattern", function () {
             sessionTimeoutInMinutes: 61,
           },
         })
-    ).toThrowError("googleAuth.sessionTimeoutInMinutes must be smaller than 60!");
+    ).toThrowError("googleAuth.sessionTimeoutInMinutes must be <= 60!");
   });
 
   it("throws when googleAuth.allowedGroups contains groups using non-standard domains", () => {

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -828,6 +828,36 @@ describe("the GuEC2App pattern", function () {
     ).toThrowError("googleAuth.allowedGroups cannot be empty!");
   });
 
+  it("throws when googleAuth.sessionTimeoutInMinutes is > 60", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "app";
+    const domain = "domain-name-for-your-application.example";
+
+    expect(
+      () =>
+        new GuEc2App(stack, {
+          applicationPort: 3000,
+          access: { scope: AccessScope.PUBLIC },
+          app,
+          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+          certificateProps: {
+            domainName: domain,
+          },
+          scaling: {
+            minimumInstances: 1,
+          },
+          monitoringConfiguration: { noMonitoring: true },
+          userData: "",
+          accessLogging: { enabled: false },
+          googleAuth: {
+            enabled: true,
+            domain,
+            sessionTimeoutInMinutes: 61,
+          },
+        })
+    ).toThrowError("googleAuth.sessionTimeoutInMinutes must be smaller than 60!");
+  });
+
   it("throws when googleAuth.allowedGroups contains groups using non-standard domains", () => {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "app";

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -480,7 +480,7 @@ export class GuEc2App extends Construct {
       } = props.googleAuth;
 
       if (sessionTimeoutInMinutes > 60) {
-        throw new Error("googleAuth.sessionTimeoutInMinutes must be smaller than 60!");
+        throw new Error("googleAuth.sessionTimeoutInMinutes must be <= 60!");
       }
 
       if (allowedGroups.length < 1) {


### PR DESCRIPTION
## What does this change?

This change allows the session length if `googleAuth` is set in `GuEc2App` or one of the classes which extend it. The value of 15 minutes set here is a compromise and represents the shortest possible time any service will allow a users access revoked via Cognito will persist.

### Why?

A side effect of using the `googleAuth` configuration is that requests to Cognito domains that this pattern requires will result in CORS errors after the expiry period requiring client apps to deal with this error or require users to refresh their browsers. The cause of this is the ALB redirecting users to the Cognito domain when the expected cookies are missing or expired, resulting in a CORS failure as the Cognito endpoint lacks the appropriate CORS headers.

A longer session length will reduce (but not eliminate) the incidence of users seeing these errors.

## How to test

- Run the tests. 
- Include this version of the CDK via this branch and test locally the correct CF is provisioned. 
  - See: https://github.com/guardian/birthdays/pull/171

## How can we measure success?

Less confused end users who will see errors less when making API requests from browser clients to endpoints authenticated using this pattern.