### PR TITLE
fix: Add explicit permissions to cd.yaml

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   CD:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## What does this change?

This change adds explicit permissions to the CD GitHub workflow in order to fix an issue with the build where these are required (see https://github.com/guardian/cdk/actions/runs/5090361143/jobs/9149327417#step:4:226).

`contents: write`: required to allow pushing the release tag
`id-token: write`: To allow authentication with NPM

## How to test

Merge this to main and the build should be able to release a new version.

## How can we measure success?

People can continue to release and use new versions of `guardian/cdk`.