### PR TITLE
ci: Set permissions for auto-merge job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
           cache: npm
       - run: ./script/ci
   approve-and-merge:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: [CI]
     steps:


### PR DESCRIPTION
Explicitly list permissions for the approve and merge job, hoping to fix the failure in https://github.com/guardian/cdk/pull/1875.
