### PR TITLE
chore: Forgo keeping version in package.json up to date (attempt 2)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,17 +21,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./script/cd
-
-      # Only performed if `main` is updated
-      # See https://docs.github.com/en/actions/reference/environment-variables#determining-when-to-use-default-environment-variables-or-contexts
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        name: post-release
-        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
-        with:
-          # This action will raise a PR to edit package.json.
-          # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI,
-          # so we need to provide a different token.
-          # This is a PAT for the guardian-ci user.
-          # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
-          github-token: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
-          npm-lockfile-version: 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,15 +26,3 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
       - run: ./script/ci
-  approve-and-merge:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    needs: [CI]
-    steps:
-      - name: Validate, approve and merge release PRs
-        uses: guardian/actions-merge-release-changes-to-protected-branch@v1.2.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          npm-lockfile-version: 2

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -141,5 +141,5 @@ To release a new version:
 1. Wait for the robots to:
    - Use your structured commit to automatically determine the next version
      number (following [semantic versioning](https://semver.org/)).
-   - Release a new version to npm and update `package.json`.
+   - Release a new version to npm.
 1. Enjoy a comment on your PR to inform you that your change has been released.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/cdk",
-  "version": "50.6.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/cdk",
-      "version": "50.6.0",
+      "version": "0.0.0",
       "dependencies": {
         "@oclif/core": "2.8.5",
         "aws-cdk-lib": "2.78.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/cdk",
   "description": "Generic Guardian flavoured AWS CDK components",
-  "version": "50.6.0",
+  "version": "0.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/typedoc.js
+++ b/typedoc.js
@@ -23,6 +23,5 @@ module.exports = {
     ...getEntryPointsFromSubdirectories(utilsDir),
   ],
   out: "target",
-  includeVersion: true,
   readme: "README.md",
 };


### PR DESCRIPTION
## What does this change?
A redo of https://github.com/guardian/cdk/pull/1006, with an additional change to the TypeDoc configuration to drop [`includeVersion`](https://typedoc.org/options/input/#includeversion).

Though #1006 was reverted in #1027, the recent [permissions changes to GitHub workflows](https://github.com/guardian/cdk/pull/1876#issuecomment-1564529731) has prompted taking another look at this.

#1006 was originally reverted due to a concern that the value in `package.json` was used within `LibraryInfo`, however it looks like [this comment](https://github.com/guardian/cdk/pull/1027#pullrequestreview-844630521) is correct. To demonstrate this, I've [published this branch to `beta`](https://github.com/guardian/cdk/releases/tag/v50.6.1-beta.1). We can use this beta version to confirm everything is still working:

```bash
# Initialise a new project
➜ npx @guardian/cdk@50.6.1-beta.1 new --app testing --stage TEST --stack playground --package-manager npm

# check content of synthed template
➜ cat cdk/cdk.out/Testing-TEST.template.json

# check installed version of GuCDK
➜ cat cdk/package.json | jq '.devDependencies."@guardian/cdk"'
```

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

See the steps above.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Fewer steps needed to release a new version of this library.

https://github.com/guardian/actions-merge-release-changes-to-protected-branch hasn't seen an update in a while. As [usage is quite low](https://github.com/search?q=org%3Aguardian+actions-merge-release-changes-to-protected-branch++NOT+is%3Aarchived+language%3AYAML&type=code&l=YAML), we could consider deprecating this action and archiving the repository.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

N/A

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
