### PR TITLE
Add kinesis stream arn ssm param constant

### DIFF
--- a/src/constants/ssm-parameter-paths.ts
+++ b/src/constants/ssm-parameter-paths.ts
@@ -10,6 +10,7 @@ export interface SsmParameterPath {
 
 interface NamedSsmParameterPaths {
   Anghammarad: SsmParameterPath;
+  LoggingStreamArn: SsmParameterPath;
   LoggingStreamName: SsmParameterPath;
   DistributionBucket: SsmParameterPath;
   AccessLoggingBucket: SsmParameterPath;
@@ -29,6 +30,10 @@ export const NAMED_SSM_PARAMETER_PATHS: NamedSsmParameterPaths = {
     path: "/account/services/anghammarad.topic.arn",
     description: "SSM parameter containing the ARN of the Anghammarad SNS topic",
     optional: true,
+  },
+    LoggingStreamArn: {
+    path: "/account/services/logging.stream",
+    description: "SSM parameter containing the ARN on the kinesis stream",
   },
   LoggingStreamName: {
     path: "/account/services/logging.stream.name",


### PR DESCRIPTION
## What does this change?

In order to set up cloudwatch-log-management to set retention and ship to the ELK stack, we need to have the kinesis stream arn set up by aws-account-set up (which was only setting up the Name). aws-account-setup has a dependency on cdk for the ssm parameter path and description. 

Required for these two PRs:
https://github.com/guardian/aws-account-setup/pull/69
https://github.com/guardian/cloudwatch-logs-management/pull/245