### PR TITLE
chore: Allow CD to comment on PRs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## What does this change?
Extend the [permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) for the CD workflow to allow the ability to comment on PRs.

We use the `semantic-release` tool to publish to NPM. One feature of this tool is it will comment and label PRs to shwo which version it's in. For example:

![image](https://github.com/guardian/cdk/assets/836140/c43c2013-7db6-43cb-8925-413b33d0e5b4)

We've stopped seeing this recently. Checking the CD logs, it appears to related to a lack of permissions.

![image](https://github.com/guardian/cdk/assets/836140/7b42c1d1-35c8-4704-9dec-8f9870ae3541)

Extend the permissions to allow for writing PRs (via https://github.com/orgs/community/discussions/26644).

## How to test
Merge the PR, and check the CD logs.

## How can we measure success?
We reinstate previously helpful features.

## Have we considered potential risks?
N/A

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
