### PR TITLE
feat!: Update GuLambdaErrorPercentageAlarm

### DIFF
--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -11,7 +11,8 @@ export interface GuLambdaErrorPercentageMonitoringProps
     "metric" | "threshold" | "comparisonOperator" | "evaluationPeriods" | "treatMissingData" | "app"
   > {
   toleratedErrorPercentage: number;
-  numberOfMinutesAboveThresholdBeforeAlarm?: number;
+  lengthOfEvaluationPeriod?: Duration;
+  numberOfEvaluationPeriodsAboveThresholdBeforeAlarm?: number;
   noMonitoring?: false;
 }
 
@@ -28,7 +29,7 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
       expression: "100*m1/m2",
       usingMetrics: { m1: props.lambda.metricErrors(), m2: props.lambda.metricInvocations() },
       label: `Error % of ${props.lambda.functionName}`,
-      period: Duration.minutes(1),
+      period: props.lengthOfEvaluationPeriod ?? Duration.minutes(1),
     });
     const defaultAlarmName = `High error % from ${props.lambda.functionName} lambda in ${scope.stage}`;
     const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
@@ -39,7 +40,7 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
       treatMissingData: TreatMissingData.NOT_BREACHING,
       threshold: props.toleratedErrorPercentage,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: props.numberOfMinutesAboveThresholdBeforeAlarm ?? 1,
+      evaluationPeriods: props.numberOfEvaluationPeriodsAboveThresholdBeforeAlarm ?? 1,
       alarmName: props.alarmName ?? defaultAlarmName,
       alarmDescription: props.alarmDescription ?? defaultDescription,
     };


### PR DESCRIPTION
## What does this change?

Adds props for `lengthOfEvaluationPeriod` and replaces `numberOfMinutesAboveThresholdBeforeAlarm` with `numberOfEvaluationPeriodsAboveThresholdBeforeAlarm`.

This allows `GuLambdaErrorPercentageAlarm` to monitor scheduled lambdas more effectively by taking into account the cadence with which the lambda runs.

For example, in this case for a lambda that runs every 15 minutes we want to know if it fails on twice concurrent runs, we would set:

```ts
const alarmProps = {
        toleratedErrorPercentage: 1,
	lengthOfEvaluationPeriod: Duration.minutes(15),
        numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 2,
}
```

See https://github.com/guardian/pressreader/pull/42 for an example of where overriding the current behaviour was required to monitor effectively.

We may also be able to do this specifically for scheduled lambdas, however my attempts to make that change in CDK result in having to reach from constructs into patterns, and required (for me) tricky fiddling with inheritance which arguably adds unnecessary complexity. Changing the prop name instead flags to consumers more clearly how the alarm is functioning.

## How to test

- [X] Run the tests. 
- [x] Include this version of the CDK via this branch and test locally the correct CF is provisioned. 

See https://github.com/guardian/pressreader/pull/45 for an example of use locally before merge.

## How can we measure success?

Better monitoring of scheduled lambdas.

## Have we considered potential risks?

This is a breaking change as it renames an existing prop to be clearer about its purpose.

The migration path is to update references to `numberOfMinutesAboveThresholdBeforeAlarm` -> `numberOfEvaluationPeriodsAboveThresholdBeforeAlarm`.

## Checklist

- [X] I have listed any breaking changes, along with a migration path [^1]
- [x] ~I have updated the documentation as required for the described changes [^2]~

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
