### PR TITLE
feat: Add GuEmailIdentity

### DIFF
--- a/src/constructs/ses/index.test.ts
+++ b/src/constructs/ses/index.test.ts
@@ -1,0 +1,44 @@
+import { Template } from "aws-cdk-lib/assertions";
+import { simpleGuStackForTesting } from "../../utils/test";
+import { GuEmailIdentity } from "./index";
+
+describe("The GuEmailIdentity construct", () => {
+  it("should create an EmailIdentity for the specified domain", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEmailIdentity(stack, "MyEmailIdentity", {
+      domainName: "my-service.gutools.co.uk",
+      app: "test",
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::SES::EmailIdentity", {
+      EmailIdentity: "my-service.gutools.co.uk",
+    });
+  });
+
+  it("only creates this construct for domains ending gutools.co.uk", () => {
+    const stack = simpleGuStackForTesting();
+
+    expect(() => {
+      new GuEmailIdentity(stack, "MyEmailIdentity", {
+        domainName: "my-service.theguardian.com",
+        app: "test",
+      });
+    }).toThrowError(
+      "Auto verification is only supported for gutools.co.uk domains. my-service.theguardian.com is not a gutools.co.uk domain."
+    );
+  });
+
+  it("should create DKIM CNAME records as required to verify the EmailIdentity", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEmailIdentity(stack, "MyEmailIdentity", {
+      domainName: "my-service.gutools.co.uk",
+      app: "test",
+    });
+
+    Template.fromStack(stack).hasResourceProperties("Guardian::DNS::RecordSet", {
+      RecordType: "CNAME",
+    });
+  });
+});

--- a/src/constructs/ses/index.test.ts
+++ b/src/constructs/ses/index.test.ts
@@ -16,8 +16,17 @@ describe("The GuEmailIdentity construct", () => {
     });
   });
 
-  it("only creates this construct for domains ending gutools.co.uk", () => {
+  it("only creates this construct for valid domains", () => {
     const stack = simpleGuStackForTesting();
+
+    GuEmailIdentity.validDomains.forEach((validDomain, index) => {
+      expect(() => {
+        new GuEmailIdentity(stack, `MyEmailIdentity-${validDomain}`, {
+          domainName: validDomain,
+          app: `test-${index}`,
+        });
+      }).not.toThrowError();
+    });
 
     expect(() => {
       new GuEmailIdentity(stack, "MyEmailIdentity", {
@@ -25,7 +34,7 @@ describe("The GuEmailIdentity construct", () => {
         app: "test",
       });
     }).toThrowError(
-      "Auto verification is only supported for gutools.co.uk domains. my-service.theguardian.com is not a gutools.co.uk domain."
+      "Auto verification is only supported for certain domains. my-service.theguardian.com is not supported."
     );
   });
 

--- a/src/constructs/ses/index.ts
+++ b/src/constructs/ses/index.ts
@@ -1,0 +1,28 @@
+import { Duration } from "aws-cdk-lib";
+import type { EmailIdentityProps } from "aws-cdk-lib/aws-ses";
+import { EmailIdentity, Identity } from "aws-cdk-lib/aws-ses";
+import type { AppIdentity, GuStack } from "../core";
+import { GuCname } from "../dns";
+
+export interface GuEmailIdentityProps extends Omit<EmailIdentityProps, "identity">, AppIdentity {
+  guToolsSubdomain: string;
+}
+
+export class GuEmailIdentity extends EmailIdentity {
+  constructor(scope: GuStack, id: string, props: GuEmailIdentityProps) {
+    super(scope, id, {
+      // Auto verification is only supported for gutools.co.uk domains
+      identity: Identity.domain(`${props.guToolsSubdomain}.gutools.co.uk`),
+      ...props,
+    });
+
+    this.dkimRecords.forEach(({ name, value }, index) => {
+      new GuCname(scope, `EmailIdentityDkim${index}`, {
+        app: props.app,
+        domainName: name,
+        resourceRecord: value,
+        ttl: Duration.hours(1),
+      });
+    });
+  }
+}

--- a/src/constructs/ses/index.ts
+++ b/src/constructs/ses/index.ts
@@ -1,6 +1,7 @@
 import { Duration } from "aws-cdk-lib";
 import type { EmailIdentityProps } from "aws-cdk-lib/aws-ses";
 import { EmailIdentity, Identity } from "aws-cdk-lib/aws-ses";
+import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { AppIdentity, GuStack } from "../core";
 import { GuCname } from "../dns";
 
@@ -8,9 +9,27 @@ export interface GuEmailIdentityProps extends Omit<EmailIdentityProps, "identity
   domainName: string;
 }
 
-export class GuEmailIdentity extends EmailIdentity {
+/**
+ * A construct to create an SES email identity.
+ * It also creates the required DNS records to verify the identity.
+ * @see https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html
+ * @see https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-identity.html
+ *
+ * @example
+ * new GuEmailIdentity(stack, "MyEmailIdentity", {
+ *  domainName: "my-service.gutools.co.uk",
+ *  app: "test",
+ * });
+ **/
+export class GuEmailIdentity extends GuAppAwareConstruct(EmailIdentity) {
   constructor(scope: GuStack, id: string, props: GuEmailIdentityProps) {
     const { app, domainName } = props;
+    if (!domainName.endsWith("gutools.co.uk")) {
+      throw new Error(
+        `Auto verification is only supported for gutools.co.uk domains. ${domainName} is not a gutools.co.uk domain.`
+      );
+    }
+
     super(scope, id, {
       identity: Identity.domain(domainName),
       ...props,

--- a/src/constructs/ses/index.ts
+++ b/src/constructs/ses/index.ts
@@ -5,20 +5,20 @@ import type { AppIdentity, GuStack } from "../core";
 import { GuCname } from "../dns";
 
 export interface GuEmailIdentityProps extends Omit<EmailIdentityProps, "identity">, AppIdentity {
-  guToolsSubdomain: string;
+  domainName: string;
 }
 
 export class GuEmailIdentity extends EmailIdentity {
   constructor(scope: GuStack, id: string, props: GuEmailIdentityProps) {
+    const { app, domainName } = props;
     super(scope, id, {
-      // Auto verification is only supported for gutools.co.uk domains
-      identity: Identity.domain(`${props.guToolsSubdomain}.gutools.co.uk`),
+      identity: Identity.domain(domainName),
       ...props,
     });
 
     this.dkimRecords.forEach(({ name, value }, index) => {
       new GuCname(scope, `EmailIdentityDkim${index}`, {
-        app: props.app,
+        app,
         domainName: name,
         resourceRecord: value,
         ttl: Duration.hours(1),

--- a/src/constructs/ses/index.ts
+++ b/src/constructs/ses/index.ts
@@ -5,9 +5,24 @@ import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { AppIdentity, GuStack } from "../core";
 import { GuCname } from "../dns";
 
+/**
+ * Properties for the GuEmailIdentity construct
+ * domainName: The domain name to use for this identity
+ * The domain name must be one of GuEmailIdentity.validDomains
+ * @see https://github.com/guardian/dns-validation-lambda/blob/main/README.md
+ */
 export interface GuEmailIdentityProps extends Omit<EmailIdentityProps, "identity">, AppIdentity {
   domainName: string;
 }
+
+// TODO: Expand this list as we add more domains
+const validDomains = [
+  "gutools.co.uk",
+  "dev-gutools.co.uk",
+  "guardianapis.com",
+  "dev-guardianapis.com",
+  "guardianapps.co.uk",
+];
 
 /**
  * A construct to create an SES email identity.
@@ -24,10 +39,9 @@ export interface GuEmailIdentityProps extends Omit<EmailIdentityProps, "identity
 export class GuEmailIdentity extends GuAppAwareConstruct(EmailIdentity) {
   constructor(scope: GuStack, id: string, props: GuEmailIdentityProps) {
     const { app, domainName } = props;
-    if (!domainName.endsWith("gutools.co.uk")) {
-      throw new Error(
-        `Auto verification is only supported for gutools.co.uk domains. ${domainName} is not a gutools.co.uk domain.`
-      );
+
+    if (!validDomains.some((validDomain) => domainName.endsWith(validDomain))) {
+      throw new Error(`Auto verification is only supported for certain domains. ${domainName} is not supported.`);
     }
 
     super(scope, id, {
@@ -36,12 +50,16 @@ export class GuEmailIdentity extends GuAppAwareConstruct(EmailIdentity) {
     });
 
     this.dkimRecords.forEach(({ name, value }, index) => {
-      new GuCname(scope, `EmailIdentityDkim${index}`, {
+      new GuCname(scope, `EmailIdentityDkim-${app}-${index}`, {
         app,
         domainName: name,
         resourceRecord: value,
         ttl: Duration.hours(1),
       });
     });
+  }
+
+  static get validDomains(): string[] {
+    return validDomains;
   }
 }


### PR DESCRIPTION
## What does this change?

This change adds a `GuEmailIdentity` construct to encode how to set up a [SES verified identity](https://docs.aws.amazon.com/ses/latest/dg/verify-addresses-and-domains.html) for a `gutools.co.uk` domain.

## How to test

- [X] Run the tests. 
- [X] Include this version of the CDK via this branch and test locally the correct CF is provisioned. 

See https://github.com/guardian/image-syndication/pull/19/commits/0093e299b8c9d5c514c529e487792085342597fd for testing before merge.

## How can we measure success?

This is usable in our projects, simplifying configuration where consumers need to send emails via SNS.

## Checklist

- [X] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
