### PR TITLE
feat: add Lambda versioning support

### DIFF
--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -192,4 +192,33 @@ describe("The GuLambdaFunction class", () => {
       },
     });
   });
+
+  it("should not create an alias or version if the enableVersioning prop is unset", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      fileName: "my-app.jar",
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+      app: "testing",
+    });
+
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::Version", 0);
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::Alias", 0);
+  });
+
+  it("should create a function version and alias if the enableVersioning prop is set to true", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      enableVersioning: true,
+      fileName: "build123.jar",
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_8,
+      app: "testing",
+    });
+
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::Version", 1);
+    Template.fromStack(stack).resourceCountIs("AWS::Lambda::Alias", 1);
+  });
 });

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -1,18 +1,27 @@
 /* eslint "@guardian/tsdoc-required/tsdoc-required": 2 -- to begin rolling this out for public APIs. */
 import { Duration } from "aws-cdk-lib";
 import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { Code, Function, RuntimeFamily } from "aws-cdk-lib/aws-lambda";
 import type { FunctionProps, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Alias, Code, Function, RuntimeFamily } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { GuDistributable } from "../../types";
-import { GuLambdaErrorPercentageAlarm, GuLambdaThrottlingAlarm } from "../cloudwatch";
 import type { GuLambdaErrorPercentageMonitoringProps, GuLambdaThrottlingMonitoringProps } from "../cloudwatch";
+import { GuLambdaErrorPercentageAlarm, GuLambdaThrottlingAlarm } from "../cloudwatch";
 import type { GuStack } from "../core";
 import { AppIdentity, GuDistributionBucketParameter } from "../core";
 import { ReadParametersByName, ReadParametersByPath } from "../iam";
 
 export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code">, AppIdentity {
+  /**
+   * Create a new Lambda version and alias. This is only necessary if you want to use features which rely
+   * on versioning (e.g. SnapStart or Provisioned Concurrency).
+   *
+   * If you enable versioning you must ensure that your Lambda function is updated whenever a new build is deployed via
+   * CloudFormation. The simplest way to do this is to include the build number in the `fileName` prop.
+   */
+  enableVersioning?: boolean;
+
   /**
    * Alarm if error percentage exceeds a threshold.
    */
@@ -103,6 +112,7 @@ export class GuLambdaFunction extends Function {
   public readonly bucketNamePath: string | undefined;
   public readonly withoutArtifactUpload: boolean;
   public readonly withoutFilePrefix: boolean;
+  public readonly alias?: Alias;
 
   constructor(scope: GuStack, id: string, props: GuFunctionProps) {
     const {
@@ -145,6 +155,13 @@ export class GuLambdaFunction extends Function {
     this.bucketNamePath = bucketNamePath;
     this.withoutArtifactUpload = withoutArtifactUpload;
     this.withoutFilePrefix = withoutFilePrefix;
+
+    if (props.enableVersioning) {
+      this.alias = new Alias(scope, `${id}-AliasForLambda`, {
+        aliasName: scope.stage,
+        version: this.currentVersion,
+      });
+    }
 
     if (props.errorPercentageMonitoring) {
       new GuLambdaErrorPercentageAlarm(scope, `${id}-ErrorPercentageAlarmForLambda`, {

--- a/src/experimental/patterns/kinesis-lambda.ts
+++ b/src/experimental/patterns/kinesis-lambda.ts
@@ -108,6 +108,10 @@ export class GuKinesisLambdaExperimental extends GuLambdaFunction {
       ...props.processingProps,
       ...errorHandlingPropsToAwsProps,
     };
-    this.addEventSource(new KinesisEventSource(this.kinesisStream, eventSourceProps));
+
+    // If we have an alias, use this to ensure that all events are sent to a published Lambda version.
+    // Otherwise, send all events to the latest unpublished version ($LATEST)
+    const eventSourceTarget = this.alias ?? this;
+    eventSourceTarget.addEventSource(new KinesisEventSource(this.kinesisStream, eventSourceProps));
   }
 }

--- a/src/experimental/patterns/sns-lambda.test.ts
+++ b/src/experimental/patterns/sns-lambda.test.ts
@@ -71,4 +71,41 @@ describe("The GuSnsLambda pattern", () => {
     new GuSnsLambdaExperimental(stack, "my-lambda-function", props);
     Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
   });
+
+  it("should send messages to $LATEST (i.e. an unpublished version) if the enableVersioning prop is unset", () => {
+    const stack = simpleGuStackForTesting();
+    const noMonitoring: NoMonitoring = { noMonitoring: true };
+    const props = {
+      fileName: "lambda.zip",
+      functionName: "my-lambda-function",
+      handler: "my-lambda/handler",
+      runtime: Runtime.NODEJS_12_X,
+      monitoringConfiguration: noMonitoring,
+      app: "testing",
+    };
+    new GuSnsLambdaExperimental(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Endpoint: {
+        "Fn::GetAtt": ["mylambdafunction8D341B54", "Arn"],
+      },
+    });
+  });
+
+  it("should send messages to an alias if the enableVersioning prop is set to true", () => {
+    const stack = simpleGuStackForTesting();
+    const noMonitoring: NoMonitoring = { noMonitoring: true };
+    const props = {
+      enableVersioning: true,
+      fileName: "lambda.zip",
+      functionName: "my-lambda-function",
+      handler: "my-lambda/handler",
+      runtime: Runtime.NODEJS_12_X,
+      monitoringConfiguration: noMonitoring,
+      app: "testing",
+    };
+    new GuSnsLambdaExperimental(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::SNS::Subscription", {
+      Endpoint: { Ref: "mylambdafunctionAliasForLambdaF2F98ED5" },
+    });
+  });
 });

--- a/src/experimental/patterns/sns-lambda.ts
+++ b/src/experimental/patterns/sns-lambda.ts
@@ -82,7 +82,10 @@ export class GuSnsLambdaExperimental extends GuLambdaFunction {
         )
       : AppIdentity.taggedConstruct(props, new Topic(scope, "SnsIncomingEventsTopic"));
 
-    this.addEventSource(new SnsEventSource(this.snsTopic));
+    // If we have an alias, use this to ensure that all events are sent to a published Lambda version.
+    // Otherwise, send all events to the latest unpublished version ($LATEST)
+    const eventSourceTarget = this.alias ?? this;
+    eventSourceTarget.addEventSource(new SnsEventSource(this.snsTopic));
     new CfnOutput(this, "TopicName", { value: this.snsTopic.topicName });
   }
 }

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -448,6 +448,69 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     `);
   });
 
+  it("Should drop the updateLambda action if the Lambda uses aliases/versions", () => {
+    const app = new App({ outdir: "/tmp/cdk.out" });
+
+    class MyApplicationStack extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- unit testing
+      constructor(app: App, id: string, props: GuStackProps) {
+        super(app, id, props);
+
+        new GuScheduledLambda(this, "test", {
+          enableVersioning: true, // This is the important prop
+          app: "my-lambda",
+          runtime: Runtime.NODEJS_16_X,
+          fileName: "my-lambda-artifact.zip",
+          handler: "handler.main",
+          rules: [{ schedule: Schedule.rate(Duration.hours(1)) }],
+          monitoringConfiguration: { noMonitoring: true },
+          timeout: Duration.minutes(1),
+        });
+      }
+    }
+
+    new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
+
+    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+
+    expect(actual).toMatchInlineSnapshot(`
+      "allowedStages:
+        - TEST
+      deployments:
+        lambda-upload-eu-west-1-test-my-lambda:
+          type: aws-lambda
+          stacks:
+            - test
+          regions:
+            - eu-west-1
+          app: my-lambda
+          contentDirectory: my-lambda
+          parameters:
+            bucketSsmLookup: true
+            prefixStackToKey: true
+            prefixAppToKey: true
+            prefixStageToKey: true
+            lookupByTags: true
+            fileName: my-lambda-artifact.zip
+          actions:
+            - uploadLambda
+        cfn-eu-west-1-test-my-application-stack:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-application-stack
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              TEST: test-stack.template.json
+          dependencies:
+            - lambda-upload-eu-west-1-test-my-lambda
+      "
+    `);
+  });
+
   it("Should add autoscaling deployments", () => {
     const app = new App({ outdir: "/tmp/cdk.out" });
 

--- a/src/experimental/riff-raff-yaml-file/index.ts
+++ b/src/experimental/riff-raff-yaml-file/index.ts
@@ -227,7 +227,10 @@ export class RiffRaffYamlFileExperimental {
           const cfnDeployment = cloudFormationDeployment(stacks, artifactUploads, this.outdir);
           deployments.set(cfnDeployment.name, cfnDeployment.props);
 
-          lambdas.forEach((lambda) => {
+          const lambdasWithoutAnAlias = lambdas.filter((lambda) => lambda.alias === undefined);
+          // If the Lambda has an alias it is using versioning. When using versioning, there is no need for Riff-Raff
+          // to modify the unpublished version of the function
+          lambdasWithoutAnAlias.forEach((lambda) => {
             const lambdaDeployment = updateLambdaDeployment(lambda, cfnDeployment);
             deployments.set(lambdaDeployment.name, lambdaDeployment.props);
           });

--- a/src/patterns/api-lambda.ts
+++ b/src/patterns/api-lambda.ts
@@ -65,8 +65,12 @@ export class GuApiLambda extends GuLambdaFunction {
       ...props,
     });
 
+    // If we have an alias, use this to ensure that all requests are routed to a published Lambda version.
+    // Otherwise, use the latest unpublished version ($LATEST)
+    const resourceToInvoke = this.alias ?? this;
+
     this.api = new LambdaRestApi(this, props.api.id, {
-      handler: this,
+      handler: resourceToInvoke,
 
       // Override to avoid clashes as default is just api ID, which is often shared across stages.
       restApiName: `${scope.stack}-${scope.stage}-${props.api.id}`,

--- a/src/patterns/api-multiple-lambdas.ts
+++ b/src/patterns/api-multiple-lambdas.ts
@@ -141,7 +141,10 @@ export class GuApiGatewayWithLambdaByPath extends Construct {
     this.api = apiGateway;
     props.targets.map((target) => {
       const resource = apiGateway.root.resourceForPath(target.path);
-      resource.addMethod(target.httpMethod, new LambdaIntegration(target.lambda), {
+      // If we have an alias, use this to ensure that all requests are routed to a published Lambda version.
+      // Otherwise, use the latest unpublished version ($LATEST)
+      const lambdaTarget = target.lambda.alias ?? target.lambda;
+      resource.addMethod(target.httpMethod, new LambdaIntegration(lambdaTarget), {
         apiKeyRequired: target.apiKeyRequired,
       });
     });

--- a/src/patterns/scheduled-lambda.test.ts
+++ b/src/patterns/scheduled-lambda.test.ts
@@ -40,4 +40,49 @@ describe("The GuScheduledLambda pattern", () => {
     new GuScheduledLambda(stack, "my-lambda-function", props);
     Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 1);
   });
+
+  it("should invoke $LATEST (i.e. an unpublished version) if the enableVersioning prop is unset", () => {
+    const stack = simpleGuStackForTesting();
+    const noMonitoring: NoMonitoring = { noMonitoring: true };
+    const props = {
+      fileName: "lambda.zip",
+      functionName: "my-lambda-function",
+      handler: "my-lambda/handler",
+      runtime: Runtime.NODEJS_16_X,
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
+      monitoringConfiguration: noMonitoring,
+      app: "testing",
+    };
+    new GuScheduledLambda(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+      Targets: [
+        {
+          Arn: { "Fn::GetAtt": ["mylambdafunction8D341B54", "Arn"] },
+        },
+      ],
+    });
+  });
+
+  it("should invoke an alias if the enableVersioning prop is set to true", () => {
+    const stack = simpleGuStackForTesting();
+    const noMonitoring: NoMonitoring = { noMonitoring: true };
+    const props = {
+      enableVersioning: true,
+      fileName: "build123.jar",
+      functionName: "my-lambda-function",
+      handler: "my-lambda/handler",
+      runtime: Runtime.NODEJS_16_X,
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
+      monitoringConfiguration: noMonitoring,
+      app: "testing",
+    };
+    new GuScheduledLambda(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", {
+      Targets: [
+        {
+          Arn: { Ref: "mylambdafunctionAliasForLambdaF2F98ED5" },
+        },
+      ],
+    });
+  });
 });

--- a/src/patterns/scheduled-lambda.ts
+++ b/src/patterns/scheduled-lambda.ts
@@ -45,10 +45,12 @@ export class GuScheduledLambda extends GuLambdaFunction {
     super(scope, id, lambdaProps);
 
     props.rules.forEach((rule, index) => {
-      const target = new LambdaFunction(this);
+      // If we have an alias, use this to ensure that all invocations are handled by a published Lambda version.
+      // Otherwise, use the latest unpublished version ($LATEST)
+      const resourceToInvoke = this.alias ?? this;
       new Rule(this, `${id}-${rule.schedule.expressionString}-${index}`, {
         schedule: rule.schedule,
-        targets: [target],
+        targets: [new LambdaFunction(resourceToInvoke)],
         ...(rule.description && { description: rule.description }),
         enabled: true,
       });


### PR DESCRIPTION
## What does this change?

This PR adds support for using Lambda [versions](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html) and [aliases](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html). These features are not currently used at the Guardian, but they are necessary for teams who want to make use of features which rely on versioning (e.g. SnapStart or Provisioned Concurrency).

The primary motivation for this PR is unblocking @tomrf1, who is keen to start using SnapStart after confirming that it [offers very significant performance improvements for his project](https://github.com/guardian/support-frontend/pull/4869). There is some more general background on SnapStart [here](https://docs.google.com/document/d/1ZC9o70gfWoEgfmbd4C0w87SUYqzbMx5CID38EOqf8dA/edit#heading=h.dowx40pffo62).

Because we have never used versions and aliases before, all of our GuCDK patterns currently invoke the [unqualified  function ARN](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html#versioning-versions-using) (i.e. `$LATEST`). `$LATEST` is typically mutated outside of CDK/CloudFormation, via an API call made by Riff-Raff. This PR modifies the Lambda-based patterns so that they invoke an alias (which points to the newest Lambda version) when developers enable versioning via construct/pattern props. 

The new Lambda version (and corresponding alias update) need to be provisioned via CDK/CloudFormation; this can be achieved by modifying the filename used so that AWS understands that the function needs to change.

## How to test

@tomrf1 and I have tested this change for scheduled Lambdas (see https://github.com/guardian/support-frontend/pull/4869 and https://github.com/guardian/elastic-search-monitor/pull/31).

I have also modified all of the other Lambda-based patterns to use the same technique (i.e. invoking the alias instead of `$LATEST`) and have added unit tests for these, but I have not tested these other patterns with real infrastructure.

## How can we measure success?

This should unblock https://github.com/guardian/support-frontend/pull/4869 and allow us to promote this feature more widely.

## Have we considered potential risks?

This is a new approach for the Guardian so any projects which move to this approach should perform thorough testing in `CODE` before deploying to `PROD`.

In addition, this new approach relies on uploading more unique artifacts to S3 (e.g. we upload a new file - i.e. `lambda-v1.jar`, `lambda-v2.jar` etc. - rather than replacing a single artifact - `lambda.jar` - as part of every deployment). In the short-term this should not cause problems (because S3 storage is cheap), but in the longer term we will need to figure out an approach for tidying up old version artifacts.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1] - There are no breaking changes so this should not affect existing projects.
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
