### PR TITLE
ci: Explicitly grant permissions to updating workflow

### DIFF
--- a/.github/workflows/update-aws-cdk.yaml
+++ b/.github/workflows/update-aws-cdk.yaml
@@ -9,6 +9,11 @@ on:
   workflow_dispatch:
 jobs:
   update-aws-cdk:
+    # See https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      contents: write # Allow pushing of a branch
+      pull-requests: write # Allow raising of a PR
+
     runs-on: ubuntu-latest
     name: Bump CDK versions
     steps:


### PR DESCRIPTION
## What does this change?
The [workflow](https://github.com/guardian/cdk/blob/main/.github/workflows/update-aws-cdk.yaml) to automatically update AWS CDK libraries is [failing](https://github.com/guardian/cdk/actions/workflows/update-aws-cdk.yaml), with a lack of permissions:

![image](https://github.com/guardian/cdk/assets/836140/b342b2cf-ae18-462e-8ed2-78bbcb91747b)

Following a recent GitHub organisational change, we're now required to explicitly list the [permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) needed within a workflow.

This workflow runs on the 10th day of every month, bumping the version of AWS CDK libraries being used. It'll create a PR editing the `package.json` and `package-lock.json` files, therefore, grant these permissions.

## How to test
I've triggered the workflow. It has succeeded, and raised the PR https://github.com/guardian/cdk/pull/1934.

## How can we measure success?
Our automations start working again.

## Have we considered potential risks?
N/A

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
