### PR TITLE
fix: Don't set prefix settings if using default values in `riff-raff.yml`

### DIFF
--- a/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
+++ b/src/experimental/riff-raff-yaml-file/deployments/lambda.ts
@@ -20,11 +20,22 @@ const locationProps = (lambda: GuLambdaFunction): S3LocationProps => {
           bucketSsmKey: lambda.bucketNamePath,
         };
 
+  /**
+   * If the lambda has a file prefix, we don't want to prefix the key with the stack, app or stage.
+   * The default value for these properties is `true`, so we don't need to set them explicitly if
+   * we *do* want to add the prefixes (and RiffRaff will complain if we add them).
+   */
+  const prefixProps = lambda.withoutFilePrefix
+    ? {
+        prefixStackToKey: false,
+        prefixAppToKey: false,
+        prefixStageToKey: false,
+      }
+    : {};
+
   return {
     ...bucketProp,
-    prefixStackToKey: !lambda.withoutFilePrefix,
-    prefixAppToKey: !lambda.withoutFilePrefix,
-    prefixStageToKey: !lambda.withoutFilePrefix,
+    ...prefixProps,
   };
 };
 

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -344,9 +344,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-artifact.zip
           actions:
@@ -374,9 +371,88 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
+            lookupByTags: true
+            fileName: my-lambda-artifact.zip
+          actions:
+            - updateLambda
+          dependencies:
+            - cfn-eu-west-1-test-my-application-stack
+      "
+    `);
+  });
+
+  it("Should omit default prefix values in lambda deployments if `withoutFilePrefix` is `true`", () => {
+    const app = new App({ outdir: "/tmp/cdk.out" });
+
+    class MyApplicationStack extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- unit testing
+      constructor(app: App, id: string, props: GuStackProps) {
+        super(app, id, props);
+
+        new GuScheduledLambda(this, "test", {
+          app: "my-lambda",
+          runtime: Runtime.NODEJS_16_X,
+          fileName: "my-lambda-artifact.zip",
+          handler: "handler.main",
+          rules: [{ schedule: Schedule.rate(Duration.hours(1)) }],
+          monitoringConfiguration: { noMonitoring: true },
+          timeout: Duration.minutes(1),
+          withoutFilePrefix: true,
+        });
+      }
+    }
+
+    new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
+
+    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+
+    expect(actual).toMatchInlineSnapshot(`
+      "allowedStages:
+        - TEST
+      deployments:
+        lambda-upload-eu-west-1-test-my-lambda:
+          type: aws-lambda
+          stacks:
+            - test
+          regions:
+            - eu-west-1
+          app: my-lambda
+          contentDirectory: my-lambda
+          parameters:
+            bucketSsmLookup: true
+            prefixStackToKey: false
+            prefixAppToKey: false
+            prefixStageToKey: false
+            lookupByTags: true
+            fileName: my-lambda-artifact.zip
+          actions:
+            - uploadLambda
+        cfn-eu-west-1-test-my-application-stack:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-application-stack
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              TEST: test-stack.template.json
+          dependencies:
+            - lambda-upload-eu-west-1-test-my-lambda
+        lambda-update-eu-west-1-test-my-lambda:
+          type: aws-lambda
+          stacks:
+            - test
+          regions:
+            - eu-west-1
+          app: my-lambda
+          contentDirectory: my-lambda
+          parameters:
+            bucketSsmLookup: true
+            prefixStackToKey: false
+            prefixAppToKey: false
+            prefixStageToKey: false
             lookupByTags: true
             fileName: my-lambda-artifact.zip
           actions:
@@ -435,9 +511,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-artifact.zip
           actions:
@@ -487,9 +560,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-artifact.zip
           actions:
@@ -666,9 +736,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:
@@ -717,9 +784,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:
@@ -751,9 +815,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:
@@ -802,9 +863,6 @@ describe("The RiffRaffYamlFileExperimental class", () => {
           contentDirectory: my-lambda-app
           parameters:
             bucketSsmLookup: true
-            prefixStackToKey: true
-            prefixAppToKey: true
-            prefixStageToKey: true
             lookupByTags: true
             fileName: my-lambda-app.zip
           actions:


### PR DESCRIPTION
## What does this change?

Only sets an explicit value for `prefixStackToKey`, `prefixAppToKey`, and `prefixStageToKey` if they are set to false (as `true` is the default) in `riff-raff.yml`. RiffRaff complains if you explicitly set these with the default values.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
I've edited the unit tests, and added a specific test case to check the behaviour.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

## How can we measure success?
Less noise when deploying auto-generated `riff-raff.yml`.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
