### PR TITLE
fix: Upgrade lambda version/runtime

### DIFF
--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -516,7 +516,7 @@ export class GuEc2App extends Construct {
       const authLambda = new GuLambdaFunction(scope, "auth-lambda", {
         app: app,
         memorySize: 128,
-        handler: "devx-cognito-lambda-amd64-v2",
+        handler: "bootstrap",
         runtime: Runtime.GO_1_X,
         fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v2.zip",
         withoutFilePrefix: true,

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -516,9 +516,9 @@ export class GuEc2App extends Construct {
       const authLambda = new GuLambdaFunction(scope, "auth-lambda", {
         app: app,
         memorySize: 128,
-        handler: "devx-cognito-lambda-amd64-v1",
+        handler: "devx-cognito-lambda-amd64-v2",
         runtime: Runtime.GO_1_X,
-        fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v1.zip",
+        fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v2.zip",
         withoutFilePrefix: true,
         withoutArtifactUpload: true,
         bucketNamePath: NAMED_SSM_PARAMETER_PATHS.OrganisationDistributionBucket.path,


### PR DESCRIPTION
## What does this change?
AWS is deprecating the go runtime for lambdas.
This requires

1. not allowing the go binary to use RPC
2. renaming the binary to be called `bootstrap`
3. using the al2 runtime

The lambda code lives in cognito-auth-lambdas, where the renaming and rpc changes have taken place, so we need to change some references here.

## How to test
Create a prerelease of CDK. bump a project to use it, deploy it to code and verify that the preauth lambda still works

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
