### PR TITLE
fix: Remove percent sign from default alarm names

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/api-gateway-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/api-gateway-alarms.test.ts.snap
@@ -60,7 +60,7 @@ exports[`The GuApiGateway5xxPercentageAlarm construct should create the correct 
           },
         ],
         "AlarmDescription": "testing exceeded 1% error rate",
-        "AlarmName": "High 5XX error % from testing (ApiGateway) in TEST",
+        "AlarmName": "High 5XX error percentage from testing (ApiGateway) in TEST",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -128,7 +128,7 @@ exports[`The GuAlb5xxPercentageAlarm construct should create the correct alarm r
           },
         ],
         "AlarmDescription": "testing exceeded 1% error rate",
-        "AlarmName": "High 5XX error % from testing in TEST",
+        "AlarmName": "High 5XX error percentage from testing in TEST",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 1,
         "Metrics": [

--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -545,7 +545,7 @@ exports[`The GuLambdaErrorPercentageAlarm construct should create the correct al
           "Fn::Join": [
             "",
             [
-              "High error % from ",
+              "High error percentage from ",
               {
                 "Ref": "lambda8B5974B5",
               },

--- a/src/constructs/cloudwatch/api-gateway-alarms.ts
+++ b/src/constructs/cloudwatch/api-gateway-alarms.ts
@@ -28,7 +28,7 @@ export class GuApiGateway5xxPercentageAlarm extends GuAlarm {
       label: `% of 5XX responses served for ${props.app}`,
       period: Duration.minutes(1),
     });
-    const defaultAlarmName = `High 5XX error % from ${props.app} (ApiGateway) in ${scope.stage}`;
+    const defaultAlarmName = `High 5XX error percentage from ${props.app} (ApiGateway) in ${scope.stage}`;
     const defaultDescription = `${props.app} exceeded ${props.tolerated5xxPercentage}% error rate`;
     const alarmProps = {
       ...props,

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -31,7 +31,7 @@ export class GuAlb5xxPercentageAlarm extends GuAlarm {
       label: `% of 5XX responses served for ${props.app} (load balancer and instances combined)`,
       period: Duration.minutes(1),
     });
-    const defaultAlarmName = `High 5XX error % from ${props.app} in ${scope.stage}`;
+    const defaultAlarmName = `High 5XX error percentage from ${props.app} in ${scope.stage}`;
     const defaultDescription = `${props.app} exceeded ${props.tolerated5xxPercentage}% error rate`;
     const alarmProps = {
       ...props,

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -31,7 +31,7 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
       label: `Error % of ${props.lambda.functionName}`,
       period: props.lengthOfEvaluationPeriod ?? Duration.minutes(1),
     });
-    const defaultAlarmName = `High error % from ${props.lambda.functionName} lambda in ${scope.stage}`;
+    const defaultAlarmName = `High error percentage from ${props.lambda.functionName} lambda in ${scope.stage}`;
     const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
     const alarmProps: GuAlarmProps = {
       ...props,


### PR DESCRIPTION
## What does this change?

In the email we receive when these alarms happen, there is a link to the alarm. In that link, the percent sign is correctly url-escaped, but the search doesn’t appear to work.

For example, following [this link](https://eu-west-1.console.aws.amazon.com/cloudwatch/deeplink.js?region=eu-west-1#alarmsV2:alarm/High%205XX%20error%20%25%20from%20support-reminders%20%28ApiGateway%29%20in%20PROD) from a recent email shows an error with the following text:

> The alarm "High 5XX error %25 from support-reminders (ApiGateway) in PROD" was not found

Replacing the percent sign should fix this error, allowing easy navigation from the email to the alarm. However, the change does make the alarm name longer, which may mean it’s truncated sooner in the email subject lines, potentially obscuring the stage.

## Checklist

- [X] I have listed any breaking changes, along with a migration path [^1]
- [X] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?