### PR TITLE
feat(riff-raff.yaml): Support user-added deployment types

### DIFF
--- a/src/experimental/riff-raff-yaml-file/README.md
+++ b/src/experimental/riff-raff-yaml-file/README.md
@@ -14,6 +14,8 @@ Currently, it supports the following Riff-Raff deployment types:
 - `aws-lambda` (for each `GuLambdaFunction` used)
 - `autoscaling` (for each `GuAutoScalingGroup` used)
 
+To add additional deployment types for your stack, see [Advanced usage](#advanced-usage) below.
+
 ## Usage
 Usage should require minimal changes to a GuCDK project:
 
@@ -37,6 +39,46 @@ const app = new GuRootExperimental();
 
 new MyStack(app, "my-stack-CODE", {});
 new MyStack(app, "my-stack-PROD", {});
+```
+
+### Advanced usage
+As noted above, only specific deployment types are currently supported.
+
+If you want to add additional deployment types, you can do so by instantiating `RiffRaffYamlFileExperimental` directly:
+
+```ts
+import { App } from "aws-cdk-lib";
+import { RiffRaffYamlFileExperimental } from "@guardian/cdk/lib/experimental/riff-raff-yaml-file";
+
+const app = new App();
+
+const { stack, region } = new MyStack(app, "my-stack", {
+  stack: "playground",
+  stage: "PROD",
+  env: { region: "eu-west-1" },
+});
+
+const riffRaff = new RiffRaffYamlFileExperimental(app);
+const { riffRaffYaml: { deployments } } = riffRaff;
+
+deployments.set("upload-my-static-files", {
+  actions: ["uploadStaticFiles"],
+  app: "my-static-site",
+  contentDirectory: "my-static-site",
+  dependencies: [],
+  parameters: {
+    bucketSsmKey: `/${stack}/my-static-site-origin`,
+    publicReadAcl: false,
+    cacheControl: "public, max-age=315360000, immutable",
+  },
+  regions: new Set([region]),
+  stacks: new Set([stack]),
+  type: "aws-s3",
+});
+
+// Write the riff-raff.yaml file to the output directory.
+// Must be explicitly called.
+riffRaff.synth();
 ```
 
 When the CDK stack is synthesized, a `riff-raff.yaml` file will be created in the output directory, typically `/<repo-root>/cdk/cdk.out`.

--- a/src/experimental/riff-raff-yaml-file/index.test.ts
+++ b/src/experimental/riff-raff-yaml-file/index.test.ts
@@ -1141,10 +1141,8 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     const riffraff = new RiffRaffYamlFileExperimental(app);
 
     riffraff.riffRaffYaml.deployments.set("upload-my-static-files", {
-      actions: ["uploadStaticFiles"],
       app: "my-static-site",
       contentDirectory: "my-static-site",
-      dependencies: [],
       parameters: {
         bucketSsmKey: `/${stack}/my-static-site-origin`,
         publicReadAcl: false,
@@ -1173,11 +1171,8 @@ describe("The RiffRaffYamlFileExperimental class", () => {
             templateStagePaths:
               PROD: App-PROD-deploy.template.json
         upload-my-static-files:
-          actions:
-            - uploadStaticFiles
           app: my-static-site
           contentDirectory: my-static-site
-          dependencies: []
           parameters:
             bucketSsmKey: /deploy/my-static-site-origin
             publicReadAcl: false

--- a/src/experimental/riff-raff-yaml-file/index.ts
+++ b/src/experimental/riff-raff-yaml-file/index.ts
@@ -69,9 +69,20 @@ export class RiffRaffYamlFileExperimental {
   private readonly allStackTags: StackTag[];
   private readonly allStageTags: StageTag[];
   private readonly allRegions: Region[];
-
-  private readonly riffRaffYaml: RiffRaffYaml;
   private readonly outdir: string;
+
+  /**
+   * The `riff-raff.yaml` file as an object.
+   *
+   * It is useful for specifying additional deployment types that GuCDK does not support.
+   * Consider raising an issue or pull request if you think it should be supported.
+   *
+   * In most cases, you shouldn't need to access this.
+   * No validation is performed on the parameters you provide, so you might get deployment errors.
+   *
+   * @see https://riffraff.gutools.co.uk/docs/magenta-lib/types
+   */
+  public readonly riffRaffYaml: RiffRaffYaml;
 
   private isCdkStackPresent(expectedStack: StackTag, expectedStage: StageTag): boolean {
     const matches = this.allCdkStacks.find((cdkStack) => {


### PR DESCRIPTION
> **Note**
> This code change is negligible (changing `private` to `public`), so mainly looking for feedback on the docs and the resulting DX.

## What does this change?
As an alternative to #1657, this change makes the `riffRaffYaml` property of `RiffRaffYamlFileExperimental` public. This means we can supply additional deployment types, if needed. This is more flexible than #1657.

The typical use-case is adding an `aws-s3` deployment type, which `RiffRaffYamlFileExperimental` does not currently support.

No validation is performed[^1] on the parameters you provide, so you might get deployment errors due to an invalid `riff-raff.yaml` file. For example, if an unrecognised parameter or deployment type is provided, an invalid `riff-raff.yaml` file will be created.

Usage of this feature should be uncommon. For this reason, usage is a bit fiddly:

```ts
// bin/cdk.ts
import { App } from "aws-cdk-lib";
import { RiffRaffYamlFileExperimental } from "@guardian/cdk/lib/experimental/riff-raff-yaml-file";

const app = new App();

const { stack, region } = new MyStack(app, "my-stack", {
  stack: "playground",
  stage: "PROD",
  env: { region: "eu-west-1" },
});

const riffRaff = new RiffRaffYamlFileExperimental(app);
const { riffRaffYaml: { deployments } } = riffRaff;

deployments.set("upload-my-static-files", {
  actions: ["uploadStaticFiles"],
  app: "my-static-site",
  contentDirectory: "my-static-site",
  dependencies: [],
  parameters: {
    bucketSsmKey: `/${stack}/my-static-site-origin`,
    publicReadAcl: false,
    cacheControl: "public, max-age=315360000, immutable",
  },
  regions: new Set([region]),
  stacks: new Set([stack]),
  type: "aws-s3",
});

// Write the riff-raff.yaml file to the output directory.
// Must be explicitly called.
riffRaff.synth();
```

## How to test
- Observe CI - the added test should pass.
- Check the docs - do they make sense?

## How can we measure success?
Ultimately, an increase in the number of projects with an auto-generated `riff-raff.yaml` file. For example https://github.com/guardian/pinboard should be able to adopt this now.

## Have we considered potential risks?
The main risk is the lack of validation, and thus no guarentee that a valid `riff-raff.yaml` file will be produced. For example, one could specify an invalid deployment type, or an invalid parameter name.

## Checklist
- [x] I have listed any breaking changes, along with a migration path [^2]
- [x] I have updated the documentation as required for the described changes [^3]

[^1]: There is some [typing](https://github.com/guardian/cdk/blob/b277dda1c5f2e94489716311b32be5f038d07feb/src/experimental/riff-raff-yaml-file/types.ts#L10-L13), but ultimately we're dealing with the `string` type.
[^2]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^3]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
