### PR TITLE
feat(riff-raff.yaml)!: Promote generator to stable

### DIFF
--- a/docs/setting-up-a-gucdk-project.md
+++ b/docs/setting-up-a-gucdk-project.md
@@ -11,6 +11,7 @@ Requirements:
 ## Creating a new project
 GuCDK provides a CLI tool to create a new project.
 It will place files within a `cdk` directory at the root of the repository.
+It will also generate a `riff-raff.yaml` file.
 
 To initialise a new project run the following within your repository:
 
@@ -78,7 +79,7 @@ This ensures you have a short feedback loop.
 We recommend performing the following steps in CI:
   - `lint` to ensure a common code format
   - `test` to run the snapshot tests to make sure there are no unexpected changes to the generated CFN (see [here](best-practices.md) for more detail)
-  - `synth` to generate your template as JSON to `cdk/cdk.out`
+  - `synth` to generate your template as JSON, and a `riff-raff.yaml` file to `cdk/cdk.out`
 
 These steps are described in the `package.json` file.
 

--- a/script/ci-project-generation
+++ b/script/ci-project-generation
@@ -32,5 +32,7 @@ npm pack --pack-destination $TMP_DIR
     --stack cdk \
     --stage CODE \
     --stage PROD \
+    --region eu-west-1 \
+    --region us-east-1 \
     --package-manager npm
 )

--- a/src/bin/commands/new-project/index.ts
+++ b/src/bin/commands/new-project/index.ts
@@ -21,6 +21,7 @@ interface NewProjectProps {
   app: string;
   stack: string;
   stages: string[];
+  regions: string[];
   yamlTemplateLocation?: string;
   packageManager: PackageManager;
 }
@@ -59,7 +60,7 @@ function validateConfig(config: NewProjectConfig): void {
 }
 
 function getConfig(props: NewProjectProps): NewProjectConfig {
-  const { init, app, stack, stages, yamlTemplateLocation, packageManager } = props;
+  const { init, app, stack, stages, regions, yamlTemplateLocation, packageManager } = props;
 
   const rootDir = gitRootOrCwd();
   const cdkDir = join(rootDir, "/cdk");
@@ -73,6 +74,7 @@ function getConfig(props: NewProjectProps): NewProjectConfig {
     init,
     yamlTemplateLocation,
     stages,
+    regions,
     cdkDir,
     appName: {
       kebab: kebabAppName,
@@ -113,6 +115,7 @@ export const newCdkProject = async (props: NewProjectProps): CliCommandResponse 
     stack: config.stackName,
     imports: Imports.newAppImports(config.appName),
     stages: config.stages,
+    regions: config.regions,
   });
 
   // lib directory

--- a/src/bin/commands/new-project/utils/app.ts
+++ b/src/bin/commands/new-project/utils/app.ts
@@ -37,7 +37,7 @@ export class AppBuilder {
 
     imports.render(this.code);
 
-    this.code.line("const app = new App();");
+    this.code.line("const app = new GuRoot();");
 
     stages.forEach((stage) => {
       regions.forEach((region) => {

--- a/src/bin/commands/new-project/utils/app.ts
+++ b/src/bin/commands/new-project/utils/app.ts
@@ -7,6 +7,7 @@ interface AppBuilderProps {
   appName: Name;
   stack: Name;
   stages: string[];
+  regions: string[];
   outputFile: string;
   outputDir: string;
   comment?: string;
@@ -26,7 +27,7 @@ export class AppBuilder {
   }
 
   async constructCdkFile(): Promise<void> {
-    const { comment, outputFile, imports, appName, stack, outputDir, stages } = this.config;
+    const { comment, outputFile, imports, appName, stack, outputDir, stages, regions } = this.config;
 
     this.code.openFile(outputFile);
     if (comment) {
@@ -39,9 +40,12 @@ export class AppBuilder {
     this.code.line("const app = new App();");
 
     stages.forEach((stage) => {
-      this.code.line(
-        `new ${appName.pascal}(app, "${appName.pascal}-${stage}", { stack: "${stack.kebab}", stage: "${stage}" });`,
-      );
+      regions.forEach((region) => {
+        const regionNoHyphen = region.replace("-", "");
+        this.code.line(
+          `new ${appName.pascal}(app, "${appName.pascal}-${regionNoHyphen}-${stage}", { stack: "${stack.kebab}", stage: "${stage}", env: { region: "${region}" } });`,
+        );
+      });
     });
 
     this.code.closeFile(outputFile);

--- a/src/bin/commands/new-project/utils/imports.ts
+++ b/src/bin/commands/new-project/utils/imports.ts
@@ -39,14 +39,14 @@ export class Imports {
 
   public static newAppImports({ kebab, pascal }: Name): Imports {
     return new Imports({
-      "aws-cdk-lib": {
-        types: [],
-        components: ["App"],
-      },
       "source-map-support/register": {
         basic: true,
         types: [],
         components: [],
+      },
+      "@guardian/cdk/lib/constructs/root": {
+        types: [],
+        components: ["GuRoot"],
       },
       [`../lib/${kebab}`]: {
         types: [],

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -62,6 +62,12 @@ const parseCommandLineArguments = () => {
               type: "array",
               demandOption: true,
             })
+            .option("region", {
+              description:
+                "The region(s) for your stack. Can be specified multiple times, e.g. --region eu-west-1 --region us-east-1",
+              type: "array",
+              default: ["eu-west-1"],
+            })
             .option("package-manager", {
               description:
                 "The Node package manager to use. Match this to the repository (package-lock.json = npm, yarn.lock = yarn). If the repository has neither file, and there is no strong convention in your team, we recommend npm.",
@@ -98,15 +104,18 @@ parseCommandLineArguments()
         const stack = argv.stack as string;
         const yamlTemplateLocation = argv["yaml-template-location"] as string | undefined;
         const stage = argv.stage as string[];
+        const regions = argv.region as string[];
         const packageManager = argv["package-manager"] as string;
 
         const stages = stage.map((_) => _.toUpperCase());
+
         return newCdkProject({
           init,
           app,
           stack,
           yamlTemplateLocation,
           stages,
+          regions,
           packageManager: packageManager as PackageManager,
         });
       }

--- a/src/constructs/root.ts
+++ b/src/constructs/root.ts
@@ -1,11 +1,11 @@
 import type { StageSynthesisOptions } from "aws-cdk-lib";
 import { App } from "aws-cdk-lib";
 import type { CloudAssembly } from "aws-cdk-lib/cx-api";
-import { RiffRaffYamlFileExperimental } from "../riff-raff-yaml-file";
+import { RiffRaffYamlFile } from "../riff-raff-yaml-file";
 
 /**
  * A replacement for `App`, sitting at the root of a CDK application.
- * `GuRootExperimental` will synthesise a `riff-raff.yaml` file for a CDK application.
+ * `GuRoot` will synthesise a `riff-raff.yaml` file for a CDK application.
  *
  * Usage is a case of updating `/<repo-root>/cdk/bin/cdk.ts` from:
  *
@@ -20,17 +20,17 @@ import { RiffRaffYamlFileExperimental } from "../riff-raff-yaml-file";
  * To:
  *
  * ```ts
- * import { GuRootExperimental } from "@guardian/cdk/lib/experimental/constructs/root";
+ * import { GuRoot } from "@guardian/cdk/lib/constructs/root";
  *
- * const app = new GuRootExperimental();
+ * const app = new GuRoot();
  *
  * new MyStack(app, "my-stack-CODE", {});
  * new MyStack(app, "my-stack-PROD", {});
  * ```
  */
-export class GuRootExperimental extends App {
+export class GuRoot extends App {
   override synth(options?: StageSynthesisOptions): CloudAssembly {
-    new RiffRaffYamlFileExperimental(this).synth();
+    new RiffRaffYamlFile(this).synth();
     return super.synth(options);
   }
 }

--- a/src/experimental/constructs/index.ts
+++ b/src/experimental/constructs/index.ts
@@ -1,1 +1,0 @@
-export * from "./root";

--- a/src/riff-raff-yaml-file/README.md
+++ b/src/riff-raff-yaml-file/README.md
@@ -1,9 +1,5 @@
-> **Note**
-> The `RiffRaffYamlFile` class is currently experimental.
-> The API is subject to change.
-
 # `riff-raff.yaml` generator
-The `RiffRaffYamlFileExperimental` class can be used to synthesise a `riff-raff.yaml`, so you don't have too!
+The `RiffRaffYamlFile` class can be used to synthesise a `riff-raff.yaml`, so you don't have too!
 
 The aim is to produce a `riff-raff.yaml` file that:
   - Supports provisioning of new services using Riff-Raff, removing the need for manual intervention
@@ -33,9 +29,9 @@ new MyStack(app, "my-stack-PROD", {});
 To:
 
 ```ts
-import { GuRootExperimental } from "@guardian/cdk/lib/experimental/constructs/root";
+import { GuRoot } from "@guardian/cdk/lib/constructs/root";
 
-const app = new GuRootExperimental();
+const app = new GuRoot();
 
 new MyStack(app, "my-stack-CODE", {});
 new MyStack(app, "my-stack-PROD", {});
@@ -44,11 +40,11 @@ new MyStack(app, "my-stack-PROD", {});
 ### Advanced usage
 As noted above, only specific deployment types are currently supported.
 
-If you want to add additional deployment types, you can do so by instantiating `RiffRaffYamlFileExperimental` directly:
+If you want to add additional deployment types, you can do so by instantiating `RiffRaffYamlFile` directly:
 
 ```ts
 import { App } from "aws-cdk-lib";
-import { RiffRaffYamlFileExperimental } from "@guardian/cdk/lib/experimental/riff-raff-yaml-file";
+import { RiffRaffYamlFile } from "@guardian/cdk/lib/riff-raff-yaml-file";
 
 const app = new App();
 
@@ -58,7 +54,7 @@ const { stack, region } = new MyStack(app, "my-stack", {
   env: { region: "eu-west-1" },
 });
 
-const riffRaff = new RiffRaffYamlFileExperimental(app);
+const riffRaff = new RiffRaffYamlFile(app);
 const { riffRaffYaml: { deployments } } = riffRaff;
 
 deployments.set("upload-my-static-files", {

--- a/src/riff-raff-yaml-file/deployments/autoscaling.ts
+++ b/src/riff-raff-yaml-file/deployments/autoscaling.ts
@@ -1,5 +1,5 @@
-import type { GuAutoScalingGroup } from "../../../constructs/autoscaling";
-import type { GuStack } from "../../../constructs/core";
+import type { GuAutoScalingGroup } from "../../constructs/autoscaling";
+import type { GuStack } from "../../constructs/core";
 import type { RiffRaffDeployment } from "../types";
 
 export function uploadAutoscalingArtifact(asg: GuAutoScalingGroup): RiffRaffDeployment {

--- a/src/riff-raff-yaml-file/deployments/cloudformation.ts
+++ b/src/riff-raff-yaml-file/deployments/cloudformation.ts
@@ -1,4 +1,4 @@
-import type { GuAutoScalingGroup } from "../../../constructs/autoscaling";
+import type { GuAutoScalingGroup } from "../../constructs/autoscaling";
 import type { CdkStacksDifferingOnlyByStage, RiffRaffDeployment, RiffRaffDeploymentProps } from "../types";
 
 export function cloudFormationDeployment(

--- a/src/riff-raff-yaml-file/deployments/lambda.ts
+++ b/src/riff-raff-yaml-file/deployments/lambda.ts
@@ -1,5 +1,5 @@
-import type { GuStack } from "../../../constructs/core";
-import type { GuLambdaFunction } from "../../../constructs/lambda";
+import type { GuStack } from "../../constructs/core";
+import type { GuLambdaFunction } from "../../constructs/lambda";
 import type { RiffRaffDeployment } from "../types";
 
 interface S3LocationProps {

--- a/src/riff-raff-yaml-file/group-by.ts
+++ b/src/riff-raff-yaml-file/group-by.ts
@@ -1,5 +1,5 @@
-import type { GuStack } from "../../constructs/core";
-import { groupBy } from "../../utils/array";
+import type { GuStack } from "../constructs/core";
+import { groupBy } from "../utils/array";
 import type { ClassName, GroupedCdkStacks, Region, StackTag, StageTag } from "./types";
 
 function groupByClassName(cdkStacks: GuStack[]): Record<ClassName, GuStack[]> {

--- a/src/riff-raff-yaml-file/index.test.ts
+++ b/src/riff-raff-yaml-file/index.test.ts
@@ -2,14 +2,14 @@ import { App, Duration } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
 import { Schedule } from "aws-cdk-lib/aws-events";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
-import { AccessScope } from "../../constants";
-import type { GuStackProps } from "../../constructs/core";
-import { GuStack } from "../../constructs/core";
-import { GuLambdaFunction } from "../../constructs/lambda";
-import { GuEc2App, GuNodeApp, GuPlayApp, GuScheduledLambda } from "../../patterns";
-import { RiffRaffYamlFileExperimental } from "./index";
+import { AccessScope } from "../constants";
+import type { GuStackProps } from "../constructs/core";
+import { GuStack } from "../constructs/core";
+import { GuLambdaFunction } from "../constructs/lambda";
+import { GuEc2App, GuNodeApp, GuPlayApp, GuScheduledLambda } from "../patterns";
+import { RiffRaffYamlFile } from "./index";
 
-describe("The RiffRaffYamlFileExperimental class", () => {
+describe("The RiffRaffYamlFile class", () => {
   it("Should support deploying different GuStacks to multiple AWS accounts (aka Riff-Raff stacks), and regions", () => {
     const app = new App({ outdir: "/tmp/cdk.out" });
 
@@ -39,7 +39,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
       stage: "CODE",
     });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -110,7 +110,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
       stage: "CODE",
     });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -176,7 +176,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     new MyDatabaseStack(app, "Database-CODE-deploy", { ...region, stack: "deploy", stage: "PROD" });
 
     expect(() => {
-      new RiffRaffYamlFileExperimental(app);
+      new RiffRaffYamlFile(app);
     }).toThrowError("Unable to produce a working riff-raff.yaml file; missing 1 definitions"); // Stack of media-service has no CODE stage
   });
 
@@ -186,7 +186,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     new MyApplicationStack(app, "App-CODE-deploy", { stack: "deploy", stage: "CODE" });
 
     expect(() => {
-      new RiffRaffYamlFileExperimental(app);
+      new RiffRaffYamlFile(app);
     }).toThrowError("Unable to produce a working riff-raff.yaml file; all stacks must have an explicit region set");
   });
 
@@ -195,7 +195,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     class MyApplicationStack extends GuStack {}
     new MyApplicationStack(app, "App-PROD-deploy", { stack: "deploy", stage: "PROD", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     // Not sure why we have the extra `"` characters...they don't appear in the resulting file on disk...
     expect(actual).toMatchInlineSnapshot(`
@@ -223,7 +223,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     new MyApplicationStack(app, "App-PROD-deploy", { stack: "deploy", stage: "PROD", env: { region: "eu-west-1" } });
     new MyApplicationStack(app, "App-CODE-deploy", { stack: "deploy", stage: "CODE", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -271,7 +271,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
       env: { region: "us-east-1" },
     });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -328,7 +328,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -404,7 +404,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -484,7 +484,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -544,7 +544,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -616,7 +616,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -719,7 +719,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
     new MyApplicationStack(app, "test-stack-eu-PROD", { stack: "test", stage: "PROD", env: { region: "eu-west-1" } });
     new MyApplicationStack(app, "test-stack-us-PROD", { stack: "test", stage: "PROD", env: { region: "us-east-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -946,7 +946,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "CODE", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -1072,7 +1072,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
 
     new MyApplicationStack(app, "test-stack", { stack: "test", stage: "CODE", env: { region: "eu-west-1" } });
 
-    const actual = new RiffRaffYamlFileExperimental(app).toYAML();
+    const actual = new RiffRaffYamlFile(app).toYAML();
 
     expect(actual).toMatchInlineSnapshot(`
       "allowedStages:
@@ -1138,7 +1138,7 @@ describe("The RiffRaffYamlFileExperimental class", () => {
       env: { region: "eu-west-1" },
     });
 
-    const riffraff = new RiffRaffYamlFileExperimental(app);
+    const riffraff = new RiffRaffYamlFile(app);
 
     riffraff.riffRaffYaml.deployments.set("upload-my-static-files", {
       app: "my-static-site",

--- a/src/riff-raff-yaml-file/index.ts
+++ b/src/riff-raff-yaml-file/index.ts
@@ -3,9 +3,9 @@ import path from "path";
 import type { App } from "aws-cdk-lib";
 import { Token } from "aws-cdk-lib";
 import { dump } from "js-yaml";
-import { GuAutoScalingGroup } from "../../constructs/autoscaling";
-import { GuStack } from "../../constructs/core";
-import { GuLambdaFunction } from "../../constructs/lambda";
+import { GuAutoScalingGroup } from "../constructs/autoscaling";
+import { GuStack } from "../constructs/core";
+import { GuLambdaFunction } from "../constructs/lambda";
 import { autoscalingDeployment, uploadAutoscalingArtifact } from "./deployments/autoscaling";
 import { addAmiParametersToCloudFormationDeployment, cloudFormationDeployment } from "./deployments/cloudformation";
 import { updateLambdaDeployment, uploadLambdaArtifact } from "./deployments/lambda";
@@ -64,7 +64,7 @@ import type {
  * @see https://riffraff.gutools.co.uk/docs/reference/riff-raff.yaml.md
  * @see https://riffraff.gutools.co.uk/docs/magenta-lib/types
  */
-export class RiffRaffYamlFileExperimental {
+export class RiffRaffYamlFile {
   private readonly allCdkStacks: GuStack[];
   private readonly allStackTags: StackTag[];
   private readonly allStageTags: StageTag[];

--- a/src/riff-raff-yaml-file/types.ts
+++ b/src/riff-raff-yaml-file/types.ts
@@ -1,5 +1,5 @@
 // type aliases to, hopefully, improve readability
-import type { GuStack } from "../../constructs/core";
+import type { GuStack } from "../constructs/core";
 
 export type ClassName = string;
 export type StackTag = string;


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/cdk/pull/2042 GuCDK is now able to support any `riff-raff.yaml` file, and can therefore be considered stable!

This change renames `GuRootExperimental` to `GuRoot`, and `RiffRaffYamlFileExperimental` to `RiffRaffYamlFile`. The import paths have also been updated, removing the `experimental` directory:

From:

```ts
import { GuRootExperimental } from "@guardian/cdk/lib/experimental/constructs/root";
```

To:

```ts
import { GuRoot } from "@guardian/cdk/lib/constructs/root";
```

For this reason, this is deemed a breaking change.

As `GuRoot` is stable, it has been added to the project generator. Generation of a `riff-raff.yaml` file requires knowledge of a `GuStack`'s region. Therefore the project generator has also been updated, adding a `region` flag (defaulted to `eu-west-1`). This flag will the set the [`env` property](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.StackProps.html#env) of a `GuStack`.

## How to test
CI is checking the project generation story, so CI passing should suffice.

## How can we measure success?
Fewer projects getting caught out by the nuances of hand crafting a `riff-raff.yaml` file.

## Have we considered potential risks?
There are a couple of risks:
1. The auto-generation of the `riff-raff.yaml` goes unnoticed, and we continue to hand craft one.
2. The generator has a few requirements. For example the [region must be known](https://github.com/guardian/cdk/blob/aa5f363d30c8600d788bafab6dde8e203f14c0e9/src/experimental/riff-raff-yaml-file/index.ts#L183-L189), and for an ASG the [image recipe must be specified](https://github.com/guardian/cdk/blob/aa5f363d30c8600d788bafab6dde8e203f14c0e9/src/experimental/riff-raff-yaml-file/deployments/cloudformation.ts#L57-L59). Both of these are typed as optional, so it might be surprising to see the exception upon `synth`.

I don't think either are blocking, as:
1. Hand crafting the `riff-raff.yaml` file is still valid (though laboursome)
2. The region requirement has been solved via the changes to the project generator, and the image recipe requirement has a clear message, leading to a fast resolution.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
