### PR TITLE
cd: Fix env var reference

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -49,5 +49,5 @@ jobs:
       - name: Release docs
         if: (github.ref == 'refs/heads/main')
         run: |
-          git remote set-url origin https://git:${{secrets.GITHUB_TOKEN}}@github.com/${{vars.GITHUB_REPOSITORY}}.git
+          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           npm run release:docs


### PR DESCRIPTION
## What does this change?
Following the changes in #2071, the release of the GitHub Pages site during CD has broken:

![image](https://github.com/guardian/cdk/assets/836140/96d16d45-741e-409b-9a7a-64826454f81c)

This change updates how `GITHUB_REPOSITORY` is referenced to fix the build. https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api used for inspiration.

## How to test
It's a bit difficult to test as this part of the workflow has a condition to only run on the main branch. The real test will happen upon merge.

I've run the workflow manually to ensure the syntax is valid.

## How can we measure success?
CD works again.

## Have we considered potential risks?
N/A

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
