### PR TITLE
docs(setup): fix link to node versions

### DIFF
--- a/docs/setting-up-a-gucdk-project.md
+++ b/docs/setting-up-a-gucdk-project.md
@@ -6,7 +6,7 @@ Requirements:
     Match this to the repository. A `package-lock.json` file means `npm` is used, a `yarn.lock` file means `yarn` is used.
     If the repository has neither file, and there is no strong convention in your team, we recommend npm.
   - Familiarity with the repository's CI process.
-  - Use of a recent version of Node. We recommend the [latest LTS version](https://nodejs.org/en/about/releases/).
+  - Use of a recent version of Node. We recommend the [latest LTS version](https://nodejs.org/en/about/previous-releases).
 
 ## Creating a new project
 GuCDK provides a CLI tool to create a new project.


### PR DESCRIPTION
## What does this change?

Link to the correct URL on the Node.js website: https://nodejs.org/en/about/previous-releases

Reminders that “[Cool URIs don’t change](https://www.w3.org/Provider/Style/URI)”

## How to test

Clickity-click the linkity-link!

## How can we measure success?

Prevent linkrot.

## Have we considered potential risks?

N/A

## Checklist

- [X] I have listed any breaking changes, along with a migration path [^1]
- [X] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
