### PR TITLE
cd: Use the `guardian-ci` user to author automatic PRs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -43,7 +43,11 @@ jobs:
           commit: "Bump package version"
 
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This action will raise a PR to edit package.json and package-lock.json.
+          # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI, so we need to provide a different token.
+          # This is a PAT for the guardian-ci user.
+          # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+          GITHUB_TOKEN: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Release docs


### PR DESCRIPTION
## What does this change?
PRs raised by the standard GitHub Actions user do not have their workflows run (see https://github.com/guardian/cdk/pull/2084#issuecomment-1786770078). Therefore we need to use our own token to have CI run on PRs from changesets.

This is inspired by https://github.com/guardian/cdk/pull/1512.

## How to test
N/A

## How can we measure success?
Changeset PRs are mergeable.

## Have we considered potential risks?
N/A

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
