### PR TITLE
Ensure non-empty arrays for CIDR ranges

### DIFF
--- a/.changeset/cuddly-carrots-lay.md
+++ b/.changeset/cuddly-carrots-lay.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": major
+---
+
+Users must now provide at least one valid CIDR range when using the restricted and internal access scopes

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -135,9 +135,11 @@ export interface GuEc2AppProps extends AppIdentity {
   /**
    * Network access restrictions for your load balancer.
    *
-   * Note, this merely provides defence in depth; you should, for example, limit
-   * access to the VPN and then treat that as sufficient. Instead, use Google
-   * Auth for human access, or a suitable machine auth mechanism.
+   * **Note:** this merely provides defence in depth.
+   *
+   * You should, for example, use Google Auth for human access,
+   * or a suitable machine auth mechanism, rather treating an
+   * access limited to the VPN as sufficient.
    */
   access: AppAccess;
   /**

--- a/src/types/access.ts
+++ b/src/types/access.ts
@@ -34,7 +34,7 @@ export interface PublicAccess extends Access {
  */
 export interface RestrictedAccess extends Access {
   scope: AccessScope.RESTRICTED;
-  cidrRanges: IPeer[];
+  cidrRanges: [IPeer, ...IPeer[]];
 }
 
 /**
@@ -53,7 +53,7 @@ export interface RestrictedAccess extends Access {
  */
 export interface InternalAccess extends Access {
   scope: AccessScope.INTERNAL;
-  cidrRanges: IPeer[];
+  cidrRanges: [IPeer, ...IPeer[]];
 }
 
 export type AppAccess = PublicAccess | RestrictedAccess | InternalAccess;


### PR DESCRIPTION
## What does this change?

Ensure that Internal and Restricted access provide at least one CIDR range.

This is technically a breaking change, as some consumers may currently provide empty arrays.

## How to test

[`type NonEmptyArray<T> = [T, ...T[]]`](https://www.typescriptlang.org/play?#code/C4TwDgpgBAcg9gOwKIFsygIICcsEMRQC8UA2gM7BYCWCA5gDRQB0LF1dJAupwFA8DGiClFoRgAGQh1gACyJQAFLhz4AXLESp0IbHhABKIgD4oyvUwA2U2rL6iJ12Qq76A3FAD0HqAGU4AVyx+aBlcMigABigIKxQpYAUyQwAjf2AoYGV7KCwIAEd-KlzwgEYmRQAmAGYAFgBWfR57SWkZZwByRAh2zjcmsRabNpJOhG7GduAAdzgevqA)

## How can we measure success?

More type safety.

## Have we considered potential risks?

Some consumers might start getting type errors.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
