### PR TITLE
feat(riff-raff.yaml): Support cross stack dependencies

### DIFF
--- a/.changeset/chatty-rabbits-cry.md
+++ b/.changeset/chatty-rabbits-cry.md
@@ -1,0 +1,19 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(riff-raff.yaml): Support cross stack dependencies
+
+Currently the `riff-raff.yaml` generator is not able to create dependencies between `cloud-formation` deployments. This means each `cloud-formation` deployment could happen at the same time.
+
+This does not work in the scenario where we have:
+- Stack A containing a bucket
+- Stack B CODE containing an app that uses A's bucket
+- Stack B PROD containing an app that uses A's bucket
+
+That is, we can't guarantee Stack A is deployed first.
+
+In this change we add support for the scenario where we have a shared resources stack.
+The generated `riff-raff.yaml` file will describe that Stack B CODE, and Stack B PROD depend on Stack A.
+
+It uses the AWS CDK mechanism https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.Stack.html#addwbrdependencytarget-reason.


### PR DESCRIPTION
## What does this change?
Currently the `riff-raff.yaml` generator is not able to create dependencies between `cloud-formation` deployments. This means each `cloud-formation` deployment could happen at the same time.

This does not work in the scenario where we have:
  - Stack A containing a bucket
  - Stack B CODE containing an app that uses A's bucket
  - Stack B PROD containing an app that uses A's bucket

That is, we can't guarantee Stack A is deployed first.

In this change we add support for the scenario where we have a shared resources stack. The generated `riff-raff.yaml` file will describe that Stack B CODE, and Stack B PROD depend on Stack A.

It uses the AWS CDK mechanism to link CloudFormation stacks:

> Add a dependency between this stack and another stack.
> 
> This can be used to define dependencies between any two stacks within an app, and also supports nested stacks.
> – https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.Stack.html#addwbrdependencytarget-reason

## How to test
- See the added unit test.
- Pass the `riff-raff.yaml` to the [validator](https://riffraff.gutools.co.uk/configuration/validation), and observe the desired dependency graph:
   <img width="1158" alt="image" src="https://github.com/guardian/cdk/assets/836140/eb91c69d-3619-4af6-9d28-d1d7ee7ffc12">

## How can we measure success?
Supports another deployment scenario (though admittedly a rather niche one).

## Have we considered potential risks?
N/A

## Checklist
- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
