### PR TITLE
Remove reference to non-existent diff script from migration guide

### DIFF
--- a/docs/migration-guide-ec2.md
+++ b/docs/migration-guide-ec2.md
@@ -190,7 +190,10 @@ in your original CFN template._
 
 6. Update your riff-raff.yaml to use the correct `amiParameter` (this will be `AMI<Appname>`)
 
-7. Preview the CloudFormation update (via ./script/diff)
+7. Preview the CloudFormation update. A change set can be generated via the
+   `Change sets` tab in the CloudFormation console, and will also be generated
+   as part of manually deploying a new template via the AWS console, and can be
+   reviewed before confirming the update.
 
    It should largely comprise of resource removals. It should also modify the
    new ASG (due to the tag removal)


### PR DESCRIPTION
- Update migration guide to remove reference to a diff script that no longer exists
- Provide alternative guidance on viewing cfn change sets

Would close #2192 

## Testing

- Are the new instructions clear?
- Do they represent the recommended way to check a cfn diff with cdk?
  - There is `npm run diff`, as defined in the cdk template's package.json, which is a possible alternative. But I haven't been able to get this to work yet, myself.[^1]

## Changesets

This is purely a documentation change, and shouldn't require a new release of the cdk package, so I haven't added a changset.

[^1]: I get an error: `Unable to resolve AWS account to use. It must be either configured when you define your CDK Stack, or through the environment`. I've tried exporting an `AWS_PROFILE` variable before running `npm run diff` but this hasn't fixed the problem.