### PR TITLE
feat: Support more than one EC2 app with load balancer access logs enabled in a given stack

### DIFF
--- a/.changeset/gold-maps-give.md
+++ b/.changeset/gold-maps-give.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Support multiple EC2 apps with load balancer access logs enabled

--- a/src/constructs/core/parameters/s3.ts
+++ b/src/constructs/core/parameters/s3.ts
@@ -38,3 +38,27 @@ export class GuPrivateConfigBucketParameter extends GuStringParameter {
     });
   }
 }
+
+/**
+ * Creates a CloudFormation parameter which references the bucket used to store load balancer access logs.
+ * By default, the bucket name is stored in an SSM Parameter called `/account/services/access-logging/bucket`.
+ */
+export class GuAccessLoggingBucketParameter extends GuStringParameter {
+  private static instance: GuAccessLoggingBucketParameter | undefined;
+
+  private constructor(scope: GuStack) {
+    super(scope, "AccessLoggingBucket", {
+      description: NAMED_SSM_PARAMETER_PATHS.AccessLoggingBucket.description,
+      default: NAMED_SSM_PARAMETER_PATHS.AccessLoggingBucket.path,
+      fromSSM: true,
+    });
+  }
+
+  public static getInstance(stack: GuStack): GuAccessLoggingBucketParameter {
+    if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
+      this.instance = new GuAccessLoggingBucketParameter(stack);
+    }
+
+    return this.instance;
+  }
+}

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -934,84 +934,142 @@ describe("the GuEC2App pattern", function () {
         }),
     ).toThrowError("googleAuth.allowedGroups must use the @guardian.co.uk domain.");
   });
-});
 
-it("should provides a default healthcheck", function () {
-  const stack = simpleGuStackForTesting();
-  new GuEc2App(stack, {
-    applicationPort: 3000,
-    app: "test-gu-ec2-app",
-    access: { scope: AccessScope.PUBLIC },
-    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-    monitoringConfiguration: { noMonitoring: true },
-    userData: "#!/bin/dev foobarbaz",
-    certificateProps: {
-      domainName: "domain-name-for-your-application.example",
-    },
-    scaling: {
-      minimumInstances: 1,
-    },
-  });
-  Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
-    HealthCheckIntervalSeconds: 10,
-    HealthCheckPath: "/healthcheck",
-    HealthCheckProtocol: "HTTP",
-    HealthCheckTimeoutSeconds: 5,
-    HealthyThresholdCount: 5,
-  });
-});
-
-it("allows a custom healthcheck", function () {
-  const stack = simpleGuStackForTesting();
-  new GuEc2App(stack, {
-    applicationPort: 3000,
-    app: "test-gu-ec2-app",
-    access: { scope: AccessScope.PUBLIC },
-    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-    monitoringConfiguration: { noMonitoring: true },
-    userData: "#!/bin/dev foobarbaz",
-    certificateProps: {
-      domainName: "domain-name-for-your-application.example",
-    },
-    scaling: {
-      minimumInstances: 1,
-    },
-    healthcheck: {
-      path: "/custom-healthcheck",
-    },
-  });
-  Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
-    HealthCheckIntervalSeconds: 10,
-    HealthCheckPath: "/custom-healthcheck",
-    HealthCheckProtocol: "HTTP",
-    HealthCheckTimeoutSeconds: 5,
-    HealthyThresholdCount: 5,
-  });
-});
-
-it("can specify instance metadata hop limit", function () {
-  const stack = simpleGuStackForTesting();
-  new GuEc2App(stack, {
-    applicationPort: 3000,
-    app: "test-gu-ec2-app",
-    access: { scope: AccessScope.PUBLIC },
-    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-    monitoringConfiguration: { noMonitoring: true },
-    userData: "#!/bin/dev foobarbaz",
-    certificateProps: {
-      domainName: "domain-name-for-your-application.example",
-    },
-    scaling: {
-      minimumInstances: 1,
-    },
-    instanceMetadataHopLimit: 2,
-  });
-  Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
-    LaunchTemplateData: {
-      MetadataOptions: {
-        HttpPutResponseHopLimit: 2,
-        HttpTokens: "required",
+  it("should provides a default healthcheck", function () {
+    const stack = simpleGuStackForTesting();
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app",
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "#!/bin/dev foobarbaz",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
       },
-    },
+      scaling: {
+        minimumInstances: 1,
+      },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckIntervalSeconds: 10,
+      HealthCheckPath: "/healthcheck",
+      HealthCheckProtocol: "HTTP",
+      HealthCheckTimeoutSeconds: 5,
+      HealthyThresholdCount: 5,
+    });
+  });
+
+  it("allows a custom healthcheck", function () {
+    const stack = simpleGuStackForTesting();
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app",
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "#!/bin/dev foobarbaz",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      healthcheck: {
+        path: "/custom-healthcheck",
+      },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckIntervalSeconds: 10,
+      HealthCheckPath: "/custom-healthcheck",
+      HealthCheckProtocol: "HTTP",
+      HealthCheckTimeoutSeconds: 5,
+      HealthyThresholdCount: 5,
+    });
+  });
+
+  it("can specify instance metadata hop limit", function () {
+    const stack = simpleGuStackForTesting();
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app",
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "#!/bin/dev foobarbaz",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      instanceMetadataHopLimit: 2,
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
+      LaunchTemplateData: {
+        MetadataOptions: {
+          HttpPutResponseHopLimit: 2,
+          HttpTokens: "required",
+        },
+      },
+    });
+  });
+
+  it("supports more than one EC2 app with load balancer access logs enabled", () => {
+    const stack = simpleGuStackForTesting({
+      env: {
+        region: "test",
+      },
+    });
+
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app-1",
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "#!/bin/dev foobarbaz",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      instanceMetadataHopLimit: 2,
+      accessLogging: {
+        enabled: true,
+        prefix: "test-1",
+      },
+    });
+
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app-2",
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: "#!/bin/dev foobarbaz",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      instanceMetadataHopLimit: 2,
+      accessLogging: {
+        enabled: true,
+        prefix: "test-2",
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      Tags: Match.arrayWith([Match.objectLike({ Key: "App", Value: "test-gu-ec2-app-1" })]),
+      LoadBalancerAttributes: Match.arrayWith([Match.objectLike({ Key: "access_logs.s3.prefix", Value: "test-1" })]),
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      Tags: Match.arrayWith([Match.objectLike({ Key: "App", Value: "test-gu-ec2-app-2" })]),
+      LoadBalancerAttributes: Match.arrayWith([Match.objectLike({ Key: "access_logs.s3.prefix", Value: "test-2" })]),
+    });
   });
 });

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -30,7 +30,7 @@ import {
   GuUnhealthyInstancesAlarm,
 } from "../../constructs/cloudwatch";
 import type { GuStack } from "../../constructs/core";
-import { AppIdentity, GuLoggingStreamNameParameter, GuStringParameter } from "../../constructs/core";
+import { AppIdentity, GuAccessLoggingBucketParameter, GuLoggingStreamNameParameter } from "../../constructs/core";
 import { GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
 import type { GuInstanceRoleProps } from "../../constructs/iam";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../../constructs/iam";
@@ -420,11 +420,7 @@ export class GuEc2App extends Construct {
     });
 
     if (accessLogging.enabled) {
-      const accessLoggingBucket = new GuStringParameter(scope, "AccessLoggingBucket", {
-        description: NAMED_SSM_PARAMETER_PATHS.AccessLoggingBucket.description,
-        default: NAMED_SSM_PARAMETER_PATHS.AccessLoggingBucket.path,
-        fromSSM: true,
-      });
+      const accessLoggingBucket = GuAccessLoggingBucketParameter.getInstance(scope);
 
       loadBalancer.logAccessLogs(
         Bucket.fromBucketName(


### PR DESCRIPTION
## What does this change?
Use a singleton to reference the string parameter that contains the name of the S3 bucket used for load balancer access logs.

## Why?
Previously, a new parameter was created per EC2 instance. This meant that only one EC2 in a given stack could have access logs enabled, as attempting to create another one would result in a synth failure due to a parameter with that name already existing.
This change makes it so a new parameter is only created if it doesn't exist in the stack. Subsequent invocations will reference the existing parameter instead of creating a new one.

## How to test
I've added a new test case where 2 EC2 apps exist in the same stack, both with access logs enabled.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
