### PR TITLE
Switch from using `INFRA` stage of cognito-lambda to using `PROD` and allow users to optionally use `CODE`

### DIFF
--- a/.changeset/gentle-cups-dress.md
+++ b/.changeset/gentle-cups-dress.md
@@ -1,0 +1,9 @@
+---
+"@guardian/cdk": major
+---
+
+Use PROD version of cognito-auth-lambdas instead of INFRA.
+
+We no longer update/use the INFRA version of cognito-auth-lambdas, although we won't be making any breaking changes to these lambdas there may be a situation if a user of CDK does not update for a long while, when they switch from INFRA to PROD they will suddenly receive a lot of updates to their lambdas.
+
+Users should take care to verify that any applications use Google Auth are still functional.

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -276,6 +276,15 @@ export interface GuEc2AppProps extends AppIdentity {
      * @defaultValue /:STAGE/:stack/:app/google-auth-credentials
      */
     credentialsSecretsManagerPath?: string;
+
+    /**
+     * When using Auth in the ALB, which stage of cognito-lambda to use.
+     *
+     * For most applications this should always be PROD, even in the CODE environments.
+     *
+     * @defaultValue PROD
+     */
+    cognitoAuthStage?: "PROD" | "CODE";
   };
 
   /**
@@ -518,10 +527,12 @@ export class GuEc2App extends Construct {
         NAMED_SSM_PARAMETER_PATHS.DeployToolsAccountId.path,
       );
 
+      const cognitoAuthStage = props.googleAuth.cognitoAuthStage ?? "PROD";
+
       // See https://github.com/guardian/cognito-auth-lambdas for the source
       // code here. ARN format is:
       // arn:aws:lambda:aws-region:acct-id:function:helloworld.
-      const gatekeeperFunctionArn = `arn:aws:lambda:eu-west-1:${deployToolsAccountId.stringValue}:function:deploy-PROD-gatekeeper-lambda`;
+      const gatekeeperFunctionArn = `arn:aws:lambda:eu-west-1:${deployToolsAccountId.stringValue}:function:deploy-${cognitoAuthStage}-gatekeeper-lambda`;
 
       // Note, handler and filename must match here:
       // https://github.com/guardian/cognito-auth-lambdas.
@@ -530,7 +541,7 @@ export class GuEc2App extends Construct {
         memorySize: 128,
         handler: "bootstrap",
         runtime: Runtime.PROVIDED_AL2,
-        fileName: "deploy/INFRA/cognito-lambda/devx-cognito-lambda-amd64-v2.zip",
+        fileName: `deploy/${cognitoAuthStage}/cognito-lambda/devx-cognito-lambda-amd64-v2.zip`,
         withoutFilePrefix: true,
         withoutArtifactUpload: true,
         bucketNamePath: NAMED_SSM_PARAMETER_PATHS.OrganisationDistributionBucket.path,

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -284,7 +284,7 @@ export interface GuEc2AppProps extends AppIdentity {
      *
      * @defaultValue PROD
      */
-    cognitoAuthStage?: "PROD" | "CODE";
+    cognitoAuthStage?: string;
   };
 
   /**


### PR DESCRIPTION
## What does this change?

- Switch hardcode `INFRA` stage in Cognito lambda config to use `PROD`
- Allow users to optionally use the `CODE` Cognito lambda environment.

## How to test

Still figuring that out.

## Have we considered potential risks?

We've started merging dependabot PRs again for cognito-auth lambda, the problem with switching from INFRA to PROD is that users still on INFRA will start to slowly become more and more out of date. 

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
