### PR TITLE
feat: Various ECS task improvements

### DIFF
--- a/.changeset/brown-starfishes-grin.md
+++ b/.changeset/brown-starfishes-grin.md
@@ -1,0 +1,9 @@
+---
+"@guardian/cdk": minor
+---
+
+- Add `readonlyRootFilesystem` prop to specify whether the container is given read-only access to its root file system
+
+- Add `containerInsights` prop to enable CloudWatch insights
+
+- Replace deprecated state machine definition

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -202,6 +202,12 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
     "testecstaskecstestClusterCBD4036C": {
       "Properties": {
         "ClusterName": "ecs-test-cluster-TEST",
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": "disabled",
+          },
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -546,6 +552,7 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
             },
             "Memory": 1024,
             "Name": "test-ecs-task-ecs-test-TaskContainer",
+            "ReadonlyRootFilesystem": true,
           },
         ],
         "Cpu": "1024",


### PR DESCRIPTION
## What does this change?

Adds a few improvements to the ECS task pattern to address some Security Hub warnings.

- Add `readonlyRootFilesystem` prop to specify whether the container is given read-only access to its root file system

- Add `containerInsights` prop to enable CloudWatch insights

- Replace deprecated state machine definition. This removes the warning:
```
      [WARNING] aws-cdk-lib.aws_stepfunctions.StateMachineProps#definition is deprecated.
        use definitionBody: DefinitionBody.fromChainable()
        This API will be removed in the next major release.
```

## Have we considered potential risks?
The GuCDK defaults for the new props mirror the CDK defaults to preserve backward compatibility.  

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
