### PR TITLE
fix(GuStack): Set app value 

### DIFF
--- a/.changeset/soft-bears-drum.md
+++ b/.changeset/soft-bears-drum.md
@@ -1,0 +1,7 @@
+---
+"@guardian/cdk": patch
+---
+
+Fixes a bug where `this.app` on a `GuStack` is always `undefined`, as it is never set.
+
+See https://github.com/guardian/cdk/pull/1497#issuecomment-1480997050.

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -18,6 +18,10 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
    */
   stack: string;
 
+  /**
+   * The stage being used (as defined in your riff-raff.yaml).
+   * This will be applied as a tag to all of your resources.
+   */
   stage: string;
 
   /**

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -81,30 +81,15 @@ export interface GuStackProps extends Omit<StackProps, "stackName"> {
  * ```
  */
 export class GuStack extends Stack implements StackStageIdentity {
-  private readonly _stack: string;
-  private readonly _stage: string;
-  private readonly _app?: string;
-  private readonly _repositoryName?: string;
-
-  get stage(): string {
-    return this._stage;
-  }
-
-  get stack(): string {
-    return this._stack;
-  }
-
-  get app(): string | undefined {
-    return this._app;
-  }
+  public readonly stack: string;
+  public readonly stage: string;
+  public readonly app: string | undefined;
 
   /**
    * The repository name, if it can be determined from the context or the git remote origin url.
    * If it cannot be determined from either of these sources, it will be `undefined`.
    */
-  get repositoryName(): string | undefined {
-    return this._repositoryName;
-  }
+  public readonly repositoryName: string | undefined;
 
   /**
    * A helper function to add a tag to all resources in a stack.
@@ -154,10 +139,10 @@ export class GuStack extends Stack implements StackStageIdentity {
       synthesizer: new LegacyStackSynthesizer(),
     });
 
-    this._stack = stack;
-    this._stage = stage.toUpperCase();
-    this._app = app;
-    this._repositoryName = this.tryGetRepositoryTag();
+    this.stack = stack;
+    this.stage = stage.toUpperCase();
+    this.app = app;
+    this.repositoryName = this.tryGetRepositoryTag();
 
     if (!withoutTags) {
       this.addTag(TrackingTag.Key, TrackingTag.Value);

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -140,6 +140,7 @@ export class GuStack extends Stack implements StackStageIdentity {
       cloudFormationStackName = process.env.GU_CFN_STACK_NAME,
       stack,
       stage,
+      app,
       withoutTags,
       withBackup = false,
     } = props;
@@ -155,6 +156,7 @@ export class GuStack extends Stack implements StackStageIdentity {
 
     this._stack = stack;
     this._stage = stage.toUpperCase();
+    this._app = app;
     this._repositoryName = this.tryGetRepositoryTag();
 
     if (!withoutTags) {


### PR DESCRIPTION
## What does this change?
Fixes a bug where `this.app` on a `GuStack` is always undefined, as it is never set. See https://github.com/guardian/cdk/pull/1497#issuecomment-1480997050.

Also included, is a refactor to reduce complexity - private properties and public getters are replaced with public properties.