### PR TITLE
feat: Add useful ASG group metrics (`TOTAL_INSTANCES`, etc) by default

### DIFF
--- a/.changeset/nice-cups-study.md
+++ b/.changeset/nice-cups-study.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Add useful ASG group metrics (TOTAL_INSTANCES, etc) by default

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -1,5 +1,5 @@
 import { Tags, Token } from "aws-cdk-lib";
-import { AutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { AutoScalingGroup, GroupMetric, GroupMetrics } from "aws-cdk-lib/aws-autoscaling";
 import type { AutoScalingGroupProps, CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 import { LaunchTemplate, OperatingSystemType, UserData } from "aws-cdk-lib/aws-ec2";
 import type { InstanceType, ISecurityGroup, MachineImageConfig } from "aws-cdk-lib/aws-ec2";
@@ -85,6 +85,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       imageId = new GuAmiParameter(scope, { app }),
       imageRecipe,
       instanceType,
+      groupMetrics = [new GroupMetrics(GroupMetric.TOTAL_INSTANCES, GroupMetric.IN_SERVICE_INSTANCES)],
       minimumInstances,
       maximumInstances,
       role = new GuInstanceRole(scope, { app }),
@@ -139,6 +140,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       launchTemplate,
       maxCapacity: maximumInstances ?? minimumInstances * 2,
       minCapacity: minimumInstances,
+      groupMetrics: groupMetrics,
 
       // Omit userData, instanceType, blockDevices & role from asgProps
       // As this are specified by the LaunchTemplate and must not be duplicated

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -88,6 +88,15 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
           },
         },
         "MaxSize": "2",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+            "Metrics": [
+              "GroupTotalInstances",
+              "GroupInServiceInstances",
+            ],
+          },
+        ],
         "MinSize": "1",
         "Tags": [
           {
@@ -1095,6 +1104,15 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
           },
         },
         "MaxSize": "2",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+            "Metrics": [
+              "GroupTotalInstances",
+              "GroupInServiceInstances",
+            ],
+          },
+        ],
         "MinSize": "1",
         "Tags": [
           {


### PR DESCRIPTION
When diagnosing performance issues with EC2 apps, it's really useful to know the historic context of how many EC2 instances have been present in the Auto-Scaling Group - like, [_"how long have we been running MAPI mobile-fronts with 29 instances?"_](https://github.com/guardian/mobile-apps-api/pull/2865#issuecomment-2000014076) - unfortunately, by default, ASGs don't record these metrics and they need to be explicitly enabled.

There's a cost associated with every CloudWatch metric recorded, and I understand there's always a pressure for costs to be kept down. But it's not really possible to know in advance when we're going to need these metrics, and when we need them, we really do need them - otherwise performance diagnosis is missing crucial parts of the puzzle.

To minimise the cost here, I'm only proposing that we add `TOTAL_INSTANCES` & `IN_SERVICE_INSTANCES` here, rather than [all 8 ASG group metrics](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.GroupMetric.html#properties).

## Cost per ASG with 2 metrics enabled

https://calculator.aws/#/estimate?id=c593ec622774e2167c447f8d797ab4f04f9226be

* per month: $1.48
* per year: $18

There are two costs associated with any ASG metric being stored:

* The cost of the metric itself: $0.30 per month
* The monthly cost of the `PutMetricData` call made 43800 times ([once a minute](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.CfnAutoScalingGroup.MetricsCollectionProperty.html#granularity)): $0.44

## Cost on example AWS account

The `media-service` account is probably above-average in terms of the number of ASGs it has: **40**. If all ASGs in the account had the 2 metrics enabled, this would have a total cost for the account of:

* per month: $59.20 ($1.48 * 40)

The current monthly spend in the `media-service` account is about $16000, with $360 being Cloudwatch spend. From this, my belief is that an additional $59.20 in Cloudwatch spend for these metrics is not excessive.


