### PR TITLE
feat: GuLambdaFunction should use JSON logging by default

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -39,6 +39,9 @@ exports[`GuLambdaThrottlingAlarm construct should match snapshot 1`] = `
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
@@ -322,6 +325,9 @@ exports[`The GuLambdaErrorPercentageAlarm construct should create the correct al
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -1,6 +1,6 @@
 import { Duration } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { LoggingFormat, Runtime } from "aws-cdk-lib/aws-lambda";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { GuStack } from "../core";
 import { GuLambdaFunction } from "./lambda";
@@ -194,7 +194,7 @@ describe("The GuLambdaFunction class", () => {
     });
   });
 
-  function hasLoggingFormat(stack: GuStack, logFormat: "JSON" | "Text") {
+  function hasLoggingFormat(stack: GuStack, logFormat: LoggingFormat) {
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       LoggingConfig: {
         LogFormat: logFormat,
@@ -212,7 +212,7 @@ describe("The GuLambdaFunction class", () => {
       app: "testing",
     });
 
-    hasLoggingFormat(stack, "JSON");
+    hasLoggingFormat(stack, LoggingFormat.JSON);
   });
 
   it("should use JSON log formatting when JSON is specified", () => {
@@ -226,7 +226,7 @@ describe("The GuLambdaFunction class", () => {
       logFormat: "JSON",
     });
 
-    hasLoggingFormat(stack, "JSON");
+    hasLoggingFormat(stack, LoggingFormat.JSON);
   });
   it("should use Text log formatting when it is defined", () => {
     const stack = simpleGuStackForTesting();
@@ -239,7 +239,7 @@ describe("The GuLambdaFunction class", () => {
       logFormat: "Text",
     });
 
-    hasLoggingFormat(stack, "Text");
+    hasLoggingFormat(stack, LoggingFormat.TEXT);
   });
 
   it("should not create an alias or version if the enableVersioning prop is unset", () => {

--- a/src/constructs/lambda/lambda.test.ts
+++ b/src/constructs/lambda/lambda.test.ts
@@ -2,6 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { simpleGuStackForTesting } from "../../utils/test";
+import type { GuStack } from "../core";
 import { GuLambdaFunction } from "./lambda";
 
 describe("The GuLambdaFunction class", () => {
@@ -191,6 +192,54 @@ describe("The GuLambdaFunction class", () => {
         },
       },
     });
+  });
+
+  function hasLoggingFormat(stack: GuStack, logFormat: "JSON" | "Text") {
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      LoggingConfig: {
+        LogFormat: logFormat,
+      },
+    });
+  }
+
+  it("should use JSON log formatting by default", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      fileName: "my-app.jar",
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_17,
+      app: "testing",
+    });
+
+    hasLoggingFormat(stack, "JSON");
+  });
+
+  it("should use JSON log formatting when JSON is specified", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      fileName: "my-app.jar",
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_17,
+      app: "testing",
+      logFormat: "JSON",
+    });
+
+    hasLoggingFormat(stack, "JSON");
+  });
+  it("should use Text log formatting when it is defined", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuLambdaFunction(stack, "lambda", {
+      fileName: "my-app.jar",
+      handler: "handler.ts",
+      runtime: Runtime.JAVA_17,
+      app: "testing",
+      logFormat: "Text",
+    });
+
+    hasLoggingFormat(stack, "Text");
   });
 
   it("should not create an alias or version if the enableVersioning prop is unset", () => {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -12,7 +12,7 @@ import type { GuStack } from "../core";
 import { AppIdentity, GuDistributionBucketParameter } from "../core";
 import { ReadParametersByName, ReadParametersByPath } from "../iam";
 
-export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code">, AppIdentity {
+export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code" | "logFormat">, AppIdentity {
   /**
    * Create a new Lambda version and alias. This is only necessary if you want to use features which rely
    * on versioning (e.g. SnapStart or Provisioned Concurrency).
@@ -60,6 +60,12 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
    * an uploadLambda step.
    */
   withoutArtifactUpload?: boolean;
+
+  /**
+   * The format of the Lambda function's logs.
+   * Can be either "JSON" or "Text".
+   */
+  logFormat?: "JSON" | "Text";
 }
 
 function defaultMemorySize(runtime: Runtime, memorySize?: number): number {
@@ -124,6 +130,7 @@ export class GuLambdaFunction extends Function {
       bucketNamePath,
       withoutFilePrefix = false,
       withoutArtifactUpload = false,
+      logFormat,
     } = props;
 
     const bucketName = bucketNamePath
@@ -141,6 +148,7 @@ export class GuLambdaFunction extends Function {
     const code = Code.fromBucket(bucket, objectKey);
     super(scope, id, {
       ...props,
+      logFormat: !logFormat ? "JSON" : logFormat,
       environment: {
         ...props.environment,
         ...defaultEnvironmentVariables,

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -12,7 +12,7 @@ import type { GuStack } from "../core";
 import { AppIdentity, GuDistributionBucketParameter } from "../core";
 import { ReadParametersByName, ReadParametersByPath } from "../iam";
 
-export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code" | "logFormat">, AppIdentity {
+export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "code">, AppIdentity {
   /**
    * Create a new Lambda version and alias. This is only necessary if you want to use features which rely
    * on versioning (e.g. SnapStart or Provisioned Concurrency).
@@ -60,12 +60,6 @@ export interface GuFunctionProps extends GuDistributable, Omit<FunctionProps, "c
    * an uploadLambda step.
    */
   withoutArtifactUpload?: boolean;
-
-  /**
-   * The format of the Lambda function's logs.
-   * Can be either "JSON" or "Text".
-   */
-  logFormat?: "JSON" | "Text";
 }
 
 function defaultMemorySize(runtime: Runtime, memorySize?: number): number {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -2,7 +2,7 @@
 import { Duration } from "aws-cdk-lib";
 import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { FunctionProps, Runtime } from "aws-cdk-lib/aws-lambda";
-import { Alias, Code, Function, RuntimeFamily } from "aws-cdk-lib/aws-lambda";
+import { Alias, Code, Function, LoggingFormat, RuntimeFamily } from "aws-cdk-lib/aws-lambda";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import { GuDistributable } from "../../types";
@@ -124,7 +124,7 @@ export class GuLambdaFunction extends Function {
       bucketNamePath,
       withoutFilePrefix = false,
       withoutArtifactUpload = false,
-      logFormat,
+      logFormat = LoggingFormat.JSON,
     } = props;
 
     const bucketName = bucketNamePath
@@ -142,7 +142,7 @@ export class GuLambdaFunction extends Function {
     const code = Code.fromBucket(bucket, objectKey);
     super(scope, id, {
       ...props,
-      logFormat: !logFormat ? "JSON" : logFormat,
+      logFormat,
       environment: {
         ...props.environment,
         ...defaultEnvironmentVariables,

--- a/src/experimental/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -73,6 +73,9 @@ exports[`The GuKinesisLambda pattern should create the correct resources for a n
         },
         "FunctionName": "my-lambda-function",
         "Handler": "my-lambda/handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [

--- a/src/experimental/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -76,6 +76,9 @@ exports[`The GuSnsLambda pattern should create the correct resources for a new s
         },
         "FunctionName": "my-lambda-function",
         "Handler": "my-lambda/handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -126,6 +126,9 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
@@ -838,6 +841,9 @@ exports[`The GuApiLambda pattern should create the correct resources with minima
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [

--- a/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
+++ b/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
@@ -750,6 +750,9 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
@@ -957,6 +960,9 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
@@ -1164,6 +1170,9 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
@@ -1371,6 +1380,9 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           },
         },
         "Handler": "handler.ts",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -39,6 +39,9 @@ exports[`The GuScheduledLambda pattern should create the correct resources with 
         },
         "FunctionName": "my-lambda-function",
         "Handler": "my-lambda/handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [


### PR DESCRIPTION
## What does this change?

I think JSON log formatting is a more sensible default value.

There are two log formats in AWS Lambda, `Text`, and `JSON`. `Text` is the default (possibly for historical reasons?), but has disadvantages, such as not being as easily machine-readable.

Using `Text` means that any changes made to the ApplicationLogLevel will be flat out ignored (defaulting to `DEBUG` as far as I can tell). Application log filtering **only** works when the log format is `JSON`.

I've verified that Lambdas using this configuration are still compatible with Central ELK. [Repocop](https://github.com/guardian/service-catalogue/pull/769) has been using JSON logging for several weeks without issue.

## How to test

- [x] Verify default behaviour of lambdas has changed
- [x] Verify that providing the `Text` value results in the expected snapshot

## How can we measure success?

Teams will be able to filter their application logs by severity level without having to do as much googling/asking around as I had to

## Have we considered potential risks?

This will cause snapshot changes to everyone using a GuLambdaFunction or its descendants. This will be slightly disruptive, but no work is required beyond updating the snapshot tests.

To maintain the previous behaviour, users should add the following to their lambda props

`logFormat: "Text"`

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
