### PR TITLE
feat!: Add DevX Backups support to RDS instance construct

### DIFF
--- a/.changeset/six-shrimps-jam.md
+++ b/.changeset/six-shrimps-jam.md
@@ -1,0 +1,8 @@
+---
+"@guardian/cdk": major
+---
+
+BREAKING CHANGE:
+
+Users of the GuDatabaseInstance class now need to explicitly opt-in/out of
+DevX Backups via the devXBackups prop.

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -1,8 +1,8 @@
 import { Stack } from "aws-cdk-lib";
-import { Match, Template } from "aws-cdk-lib/assertions";
+import { Template } from "aws-cdk-lib/assertions";
 import { Vpc } from "aws-cdk-lib/aws-ec2";
-import { DatabaseInstanceEngine, ParameterGroup, PostgresEngineVersion } from "aws-cdk-lib/aws-rds";
-import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
+import { DatabaseInstanceEngine, PostgresEngineVersion } from "aws-cdk-lib/aws-rds";
+import { simpleGuStackForTesting } from "../../utils/test";
 import { GuDatabaseInstance } from "./instance";
 
 describe("The GuDatabaseInstance class", () => {
@@ -30,66 +30,6 @@ describe("The GuDatabaseInstance class", () => {
 
     Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
       DBInstanceClass: "db.t3.small",
-    });
-  });
-
-  it("sets the parameter group if passed in", () => {
-    const stack = simpleGuStackForTesting();
-
-    const parameterGroup = new ParameterGroup(stack, "MyParameterGroup", {
-      parameters: { max_connections: "100" },
-      engine: DatabaseInstanceEngine.postgres({
-        version: PostgresEngineVersion.VER_11_8,
-      }),
-    });
-
-    new GuDatabaseInstance(stack, "DatabaseInstance", {
-      vpc,
-      instanceType: "t3.small",
-      engine: DatabaseInstanceEngine.postgres({
-        version: PostgresEngineVersion.VER_11_8,
-      }),
-      parameterGroup,
-      app: "testing",
-    });
-
-    Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
-      DBParameterGroupName: {
-        Ref: Match.stringLikeRegexp("MyParameterGroup[A-Z0-9]+"),
-      },
-    });
-  });
-
-  it("creates a new parameter group if parameters are passed in", () => {
-    const stack = simpleGuStackForTesting();
-    new GuDatabaseInstance(stack, "DatabaseInstance", {
-      vpc,
-      instanceType: "t3.small",
-      engine: DatabaseInstanceEngine.postgres({
-        version: PostgresEngineVersion.VER_11_8,
-      }),
-      parameters: { max_connections: "100" },
-      app: "testing",
-    });
-
-    const template = Template.fromStack(stack);
-
-    template.hasResourceProperties("AWS::RDS::DBInstance", {
-      DBParameterGroupName: {
-        Ref: Match.stringLikeRegexp("DatabaseInstanceTestingParameterGroup[A-Z0-9]+"),
-      },
-    });
-
-    template.hasResourceProperties("AWS::RDS::DBParameterGroup", {
-      Description: "Parameter group for postgres11",
-      Family: "postgres11",
-      Parameters: {
-        max_connections: "100",
-      },
-    });
-
-    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::RDS::DBParameterGroup", {
-      appIdentity: { app: "testing" },
     });
   });
 

--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -1,8 +1,8 @@
-import { Stack } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { Vpc } from "aws-cdk-lib/aws-ec2";
 import { DatabaseInstanceEngine, PostgresEngineVersion } from "aws-cdk-lib/aws-rds";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
 import { GuDatabaseInstance } from "./instance";
 
 describe("The GuDatabaseInstance class", () => {
@@ -26,6 +26,7 @@ describe("The GuDatabaseInstance class", () => {
         version: PostgresEngineVersion.VER_11_8,
       }),
       app: "testing",
+      devXBackups: { enabled: true },
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
@@ -42,10 +43,118 @@ describe("The GuDatabaseInstance class", () => {
         version: PostgresEngineVersion.VER_11_8,
       }),
       app: "testing",
+      devXBackups: { enabled: true },
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
       DeletionProtection: true,
+    });
+  });
+
+  test("sets DeleteAutomatedBackups to false by default", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_16,
+      }),
+      app: "testing",
+      devXBackups: { enabled: true },
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
+      DeleteAutomatedBackups: false,
+    });
+  });
+
+  test("adds the correct tag if the user opts-in to DevX Backups", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_16,
+      }),
+      app: "testing",
+      devXBackups: { enabled: true },
+    });
+    console.log(JSON.stringify(stack.tags.tagValues()));
+    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::RDS::DBInstance", {
+      appIdentity: { app: "testing" },
+      additionalTags: [
+        {
+          Key: "devx-backup-enabled",
+          Value: "true",
+        },
+      ],
+    });
+  });
+
+  test("adds the correct tag if the user opts-out of DevX Backups", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_16,
+      }),
+      app: "testing",
+      devXBackups: {
+        enabled: false,
+        optOutReason: "This DB is never created in AWS, so it does not need backups.",
+        backupRetention: Duration.days(30),
+        preferredBackupWindow: "00:00-02:00",
+      },
+    });
+    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::RDS::DBInstance", {
+      appIdentity: { app: "testing" },
+      additionalTags: [
+        {
+          Key: "devx-backup-enabled",
+          Value: "false",
+        },
+      ],
+    });
+  });
+
+  test("omits native RDS backup properties if the user opts-in to DevX Backups", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_16,
+      }),
+      app: "testing",
+      devXBackups: { enabled: true },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
+      // DevX Backups (AWS Backup) manages these properties, so they should always be omitted from CFN to avoid conflicts
+      BackupRetentionPeriod: Match.absent(),
+      PreferredBackupWindow: Match.absent(),
+    });
+  });
+
+  test("correctly wires up native RDS backup properties if the user opts-out of DevX Backups", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDatabaseInstance(stack, "DatabaseInstance", {
+      vpc,
+      instanceType: "t3.small",
+      engine: DatabaseInstanceEngine.postgres({
+        version: PostgresEngineVersion.VER_16,
+      }),
+      app: "testing",
+      devXBackups: {
+        enabled: false,
+        optOutReason: "This DB is never created in AWS, so it does not need backups.",
+        backupRetention: Duration.days(30),
+        preferredBackupWindow: "00:00-02:00",
+      },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::RDS::DBInstance", {
+      BackupRetentionPeriod: 30,
+      PreferredBackupWindow: "00:00-02:00",
     });
   });
 });


### PR DESCRIPTION
## What does this change?

This PR adds support for DevX Backups to our RDS instance construct. Users are now forced to opt-in/out of backups when provisioning an RDS instance via this construct. This makes it less likely that we will forget to add protection to important backups. Users who choose to provision an RDS instance via an AWS construct (instead of the GuCDK one) can still currently forget to make this choice (we will improve this in a follow up PR by modifying [this aspect](https://github.com/guardian/cdk/blob/main/src/aspects/aws-backup.ts) to check for the presence of the correct tag).

Additionally, we help to avoid conflicts by preventing users who opt-in to this feature from setting native RDS backup properties that cannot be managed via CloudFormation once AWS Backup is enabled. Users who opt-out of DevX Backups are still able to set these properties as there is no conflict.

The deletion of automated backups (on instance deletion) is now prevented by default (i.e. we override the [CFN default](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html#cfn-rds-dbinstance-deleteautomatedbackups)). This is necessary where DevX Backups are enabled (the lock on these backups will prevent the instance from being deleted otherwise). In cases where users have opted-out of DevX Backups I still consider retaining the automated backups to be a sensible precaution so I have not made this change conditional.

Finally, I've removed some old unit tests that seemed to be testing functionality that is provided via the AWS libraries rather than our own construct: https://github.com/guardian/cdk/pull/2276/commits/c5f348eafbffa03d39ccedc1170eb0fe1f42b0fa.

## How to test

I've added unit tests to cover the new functionality.

## How can we measure success?

Users provisioning new RDS instances via GuCDK will be more likely to remember to opt-in to DevX Backups.

## Have we considered potential risks?
This construct is not widely used and opting-in is an easy change, so I don't think this breaking change poses much of a risk in terms of generating work for teams.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
