### PR TITLE
test: add simplified tag assertion

### DIFF
--- a/src/constructs/rds/instance.test.ts
+++ b/src/constructs/rds/instance.test.ts
@@ -80,14 +80,9 @@ describe("The GuDatabaseInstance class", () => {
       devXBackups: { enabled: true },
     });
     console.log(JSON.stringify(stack.tags.tagValues()));
-    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::RDS::DBInstance", {
-      appIdentity: { app: "testing" },
-      additionalTags: [
-        {
-          Key: "devx-backup-enabled",
-          Value: "true",
-        },
-      ],
+    GuTemplate.fromStack(stack).hasResourceWithTag("AWS::RDS::DBInstance", {
+      Key: "devx-backup-enabled",
+      Value: "true",
     });
   });
 
@@ -107,14 +102,9 @@ describe("The GuDatabaseInstance class", () => {
         preferredBackupWindow: "00:00-02:00",
       },
     });
-    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::RDS::DBInstance", {
-      appIdentity: { app: "testing" },
-      additionalTags: [
-        {
-          Key: "devx-backup-enabled",
-          Value: "false",
-        },
-      ],
+    GuTemplate.fromStack(stack).hasResourceWithTag("AWS::RDS::DBInstance", {
+      Key: "devx-backup-enabled",
+      Value: "false",
     });
   });
 

--- a/src/utils/test/assertions.ts
+++ b/src/utils/test/assertions.ts
@@ -1,4 +1,4 @@
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import type { Resource } from "aws-cdk-lib/assertions/lib/private/template";
 import { MetadataKeys, TrackingTag } from "../../constants";
 import type { AppIdentity, GuStack } from "../../constructs/core";
@@ -103,5 +103,11 @@ export class GuTemplate {
     }
 
     this.template.hasResourceProperties(type, { Tags: sortTagsByKey(Array.from(tagMap.values())) });
+  }
+
+  hasResourceWithTag(type: string, tag: Tag) {
+    this.template.hasResourceProperties(type, {
+      Tags: Match.arrayWith([tag]),
+    });
   }
 }


### PR DESCRIPTION
This PR implements a suggestion from https://github.com/guardian/cdk/pull/2276#discussion_r1568537805.

I don't think AWS provides a way to do this, so I've added a helper function to combine [resource property matching](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.assertions-readme.html#resource-matching--retrieval) and [array matching](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.assertions-readme.html#array-matchers) in order to get this working.  

I think this makes the tests added in #2276 easier to follow and hopefully it will make it easier for others to check tag correctness in the future too.