### PR TITLE
Add Dynamodb construct with default deletion protection and mandatory opt-in/opt-out setting for DevX-backup

### DIFF
--- a/.changeset/grumpy-socks-divide.md
+++ b/.changeset/grumpy-socks-divide.md
@@ -1,5 +1,5 @@
 ---
-"@guardian/cdk": patch
+"@guardian/cdk": minor
 ---
 
 Add Dynamodb construct with default deletion protection and mandatory opt-in/opt-out setting for DevX-backup.

--- a/.changeset/grumpy-socks-divide.md
+++ b/.changeset/grumpy-socks-divide.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Add Dynamodb construct with default deletion protection and mandatory opt-in/opt-out setting for DevX-backup.

--- a/src/constructs/dynamodb/dynamodb.test.ts
+++ b/src/constructs/dynamodb/dynamodb.test.ts
@@ -1,0 +1,60 @@
+import { Template } from "aws-cdk-lib/assertions";
+import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
+import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
+import { GuDynamoTable } from "./dynamodb";
+
+describe("The GUDynamoTable class", () => {
+  const partitionKey = {
+    name: "partitionKey",
+    type: AttributeType.STRING,
+  };
+
+  test("adds the correct tag if the user opts-in to DevX Backups", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDynamoTable(stack, "OptInDynamoDB", {
+      partitionKey: partitionKey,
+      devXBackups: { enabled: true },
+    });
+
+    GuTemplate.fromStack(stack).hasResourceWithTag("AWS::DynamoDB::Table", {
+      Key: "devx-backup-enabled",
+      Value: "true",
+    });
+  });
+
+  test("adds the correct tag if the user opts-out of DevX Backups", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDynamoTable(stack, "OptOutDynamoDB", {
+      partitionKey: partitionKey,
+      devXBackups: { enabled: false, optOutReason: "Test opt-out reason" },
+    });
+
+    GuTemplate.fromStack(stack).hasResourceWithTag("AWS::DynamoDB::Table", {
+      Key: "devx-backup-enabled",
+      Value: "false",
+    });
+  });
+
+  test("adds 'DeletionProtectionEnabled: true' by default to DynamoDB Table", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDynamoTable(stack, "OptOutReasonDynamoDB", {
+      partitionKey: partitionKey,
+      devXBackups: { enabled: false, optOutReason: "Test opt-out reason" },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+      DeletionProtectionEnabled: true,
+    });
+  });
+
+  test("DeletionProtectionEnabled can be set to false by user", () => {
+    const stack = simpleGuStackForTesting();
+    new GuDynamoTable(stack, "OptOutReasonDynamoDB", {
+      partitionKey: partitionKey,
+      deletionProtection: false,
+      devXBackups: { enabled: false, optOutReason: "Test opt-out reason" },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::DynamoDB::Table", {
+      DeletionProtectionEnabled: false,
+    });
+  });
+});

--- a/src/constructs/dynamodb/dynamodb.ts
+++ b/src/constructs/dynamodb/dynamodb.ts
@@ -25,13 +25,12 @@ export interface GuDynamoTableProps extends TableProps {
   devXBackups: OptIn | OptOut;
 }
 
-  /**
-   * DeletionProtection is enabled by default for this Table.
-   * We recommend enabling this enabled for all active DynamoDB tables.
-   * The default can be overridden in the GuDynamoTable instantiation if needed eg: for table deletion.
-   */
-  export class GuDynamoTable extends Table {
-
+/**
+ * DeletionProtection is enabled by default for this Table.
+ * We recommend enabling this enabled for all active DynamoDB tables.
+ * The default can be overridden in the GuDynamoTable instantiation if needed eg: for table deletion.
+ */
+export class GuDynamoTable extends Table {
   constructor(scope: GuStack, id: string, props: GuDynamoTableProps) {
     super(scope, id, { deletionProtection: true, ...props });
     Tags.of(this).add("devx-backup-enabled", String(props.devXBackups.enabled));

--- a/src/constructs/dynamodb/dynamodb.ts
+++ b/src/constructs/dynamodb/dynamodb.ts
@@ -1,0 +1,41 @@
+import { Tags } from "aws-cdk-lib";
+import { Table } from "aws-cdk-lib/aws-dynamodb";
+import type { TableProps } from "aws-cdk-lib/aws-dynamodb";
+import type { GuStack } from "../core";
+
+export interface OptIn {
+  enabled: true;
+}
+
+export interface OptOut {
+  enabled: false;
+  /**
+   * We recommend using DevX Backups where possible. If it is not suitable for your use-case please document
+   * this here so that we can understand why this is switched off when performing security audits.
+   */
+  optOutReason: string;
+}
+
+export interface GuDynamoTableProps extends TableProps {
+  /**
+   * We recommend using DevX Backups to protect your DynamoDB table's backups.
+   * For more details on this feature, see the
+   * [documentation](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit?usp=sharing).
+   */
+  devXBackups: OptIn | OptOut;
+}
+
+/*
+ * D
+ */
+export class GuDynamoTable extends Table {
+  /**
+   * DeletionProtection is enabled by default for this Table.
+   * We recommend enabling this enabled for all active DynamoDB tables.
+   * The default can be overridden in the GuDynamoTable instantiation if needed eg: for table deletion.
+   */
+  constructor(scope: GuStack, id: string, props: GuDynamoTableProps) {
+    super(scope, id, { deletionProtection: true, ...props });
+    Tags.of(this).add("devx-backup-enabled", String(props.devXBackups.enabled));
+  }
+}

--- a/src/constructs/dynamodb/dynamodb.ts
+++ b/src/constructs/dynamodb/dynamodb.ts
@@ -25,15 +25,13 @@ export interface GuDynamoTableProps extends TableProps {
   devXBackups: OptIn | OptOut;
 }
 
-/*
- * D
- */
-export class GuDynamoTable extends Table {
   /**
    * DeletionProtection is enabled by default for this Table.
    * We recommend enabling this enabled for all active DynamoDB tables.
    * The default can be overridden in the GuDynamoTable instantiation if needed eg: for table deletion.
    */
+  export class GuDynamoTable extends Table {
+
   constructor(scope: GuStack, id: string, props: GuDynamoTableProps) {
     super(scope, id, { deletionProtection: true, ...props });
     Tags.of(this).add("devx-backup-enabled", String(props.devXBackups.enabled));

--- a/src/constructs/dynamodb/index.ts
+++ b/src/constructs/dynamodb/index.ts
@@ -1,0 +1,1 @@
+export * from "./dynamodb";


### PR DESCRIPTION
## What does this change?
This PR adds a construct for dynamoDB tables
This construct will enable deletion protection by default.
It also adds a mandatory opt-in/opt-out field for aws backups.
This last forces a decision on whether or not to use the AWS backup vault to protect backup data from accidental or malicious deletion.
This decision should almost always be yes, however there are circumstances in which a team might need to use a different form of storage for their backup. The important thing is that the decision is made explicitly.
If users opt-out, they will need to provide a reason for their decision. This is to allow this information to be captured in security audits.

This is a new construct, so will not be a breaking change.

## How to test
Unit tests added to cover main scenarios.

## How can we measure success?
New stacks created in CDK have deletion protection enabled and a clear decision on whether to opt-in or out of AWS Backups.
It is harder to delete DynamoDB tables by accident.
We do not have a build up of tables whose backup status is unknown and un-tracked.
Our data infrastructure is more secure and more resilient

## Have we considered potential risks?
Currently this construct is not in use.
Only risks are:
 - The construct is not adopted and teams continue to use the native AWS dynamoDB construct
 - As an organisation we suddenly want to switch to a multi-region architecture. This dynamoDB construct uses the original Table construct which does not have as good support for multi-region features - as opposed to the new [TableV2 construct](https://aws.amazon.com/blogs/devops/a-new-and-improved-aws-cdk-construct-for-amazon-dynamodb-tables/).
 This risk is minimal for now as a github search revealed we are using the original Table construct across all our current repositories and the TableV2 is not in use on any of our repos.
This PR has been optimised to maximise adoption by existing teams.

That said a new DynamoDB construct that uses the TableV2 classes would be a useful addition should any teams ever need to adopt a multi-regioin AWS infrastructure.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1] 
- No breaking changes as this is a new construct
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
