### PR TITLE
feat(lambda): Explicitly configure the log group 

### DIFF
--- a/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/lambda-alarms.test.ts.snap
@@ -38,9 +38,13 @@ exports[`GuLambdaThrottlingAlarm construct should match snapshot 1`] = `
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-testing",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdaloggroup1D59E0A8",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -173,6 +177,19 @@ exports[`GuLambdaThrottlingAlarm construct should match snapshot 1`] = `
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdaloggroup1D59E0A8",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -300,6 +317,37 @@ exports[`GuLambdaThrottlingAlarm construct should match snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "lambdaloggroup1D59E0A8": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-testing",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
 }
 `;
@@ -342,9 +390,13 @@ exports[`The GuLambdaErrorPercentageAlarm construct should create the correct al
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-testing",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdaloggroup1D59E0A8",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -479,6 +531,19 @@ exports[`The GuLambdaErrorPercentageAlarm construct should create the correct al
               ],
             },
             {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdaloggroup1D59E0A8",
+                  "Arn",
+                ],
+              },
+            },
+            {
               "Action": "ssm:GetParametersByPath",
               "Effect": "Allow",
               "Resource": {
@@ -532,6 +597,37 @@ exports[`The GuLambdaErrorPercentageAlarm construct should create the correct al
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "lambdaloggroup1D59E0A8": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-testing",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "mylambdafunction8D341B54": {
       "Properties": {

--- a/src/constructs/lambda/lambda.ts
+++ b/src/constructs/lambda/lambda.ts
@@ -127,19 +127,21 @@ export class GuLambdaFunction extends Function {
       logFormat = LoggingFormat.JSON,
     } = props;
 
-    const bucketName = bucketNamePath
-      ? StringParameter.fromStringParameterName(scope, "bucketoverride", bucketNamePath).stringValue
-      : GuDistributionBucketParameter.getInstance(scope).valueAsString;
+    const { stack, stage } = scope;
 
     const defaultEnvironmentVariables = {
-      STACK: scope.stack,
-      STAGE: scope.stage,
+      STACK: stack,
+      STAGE: stage,
       APP: app,
     };
 
+    const bucketName = bucketNamePath
+      ? StringParameter.fromStringParameterName(scope, "bucketoverride", bucketNamePath).stringValue
+      : GuDistributionBucketParameter.getInstance(scope).valueAsString;
     const bucket = Bucket.fromBucketName(scope, `${id}-bucket`, bucketName);
     const objectKey = withoutFilePrefix ? fileName : GuDistributable.getObjectKey(scope, { app }, { fileName });
     const code = Code.fromBucket(bucket, objectKey);
+
     super(scope, id, {
       ...props,
       logFormat,

--- a/src/experimental/patterns/__snapshots__/kinesis-lambda.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/kinesis-lambda.test.ts.snap
@@ -77,6 +77,9 @@ exports[`The GuKinesisLambda pattern should create the correct resources for a n
         "Handler": "my-lambda/handler",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "mylambdafunctionloggroup37C4E2CC",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -174,6 +177,19 @@ exports[`The GuKinesisLambda pattern should create the correct resources for a n
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "mylambdafunctionloggroup37C4E2CC",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -311,6 +327,37 @@ exports[`The GuKinesisLambda pattern should create the correct resources for a n
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "mylambdafunctionloggroup37C4E2CC": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/my-lambda-function",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/src/experimental/patterns/__snapshots__/sns-lambda.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/sns-lambda.test.ts.snap
@@ -78,6 +78,9 @@ exports[`The GuSnsLambda pattern should create the correct resources for a new s
         "Handler": "my-lambda/handler",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "mylambdafunctionloggroup37C4E2CC",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -173,6 +176,19 @@ exports[`The GuSnsLambda pattern should create the correct resources for a new s
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "mylambdafunctionloggroup37C4E2CC",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -296,6 +312,37 @@ exports[`The GuSnsLambda pattern should create the correct resources for a new s
         },
       },
       "Type": "AWS::SNS::Subscription",
+    },
+    "mylambdafunctionloggroup37C4E2CC": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/my-lambda-function",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -125,9 +125,13 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-testing",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdaloggroup1D59E0A8",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -260,6 +264,19 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdaloggroup1D59E0A8",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -537,7 +554,7 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdaapiDeployment8E95B585b2a6e9ca12f368f15997c85321f29670": {
+    "lambdaapiDeployment8E95B5856bce64b56bb783d190c0255c57e8f7da": {
       "DependsOn": [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -557,7 +574,7 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "lambdaapiDeployment8E95B585b2a6e9ca12f368f15997c85321f29670",
+          "Ref": "lambdaapiDeployment8E95B5856bce64b56bb783d190c0255c57e8f7da",
         },
         "RestApiId": {
           "Ref": "lambdaapiC1812993",
@@ -771,6 +788,37 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
       },
       "Type": "AWS::ApiGateway::Resource",
     },
+    "lambdaloggroup1D59E0A8": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-testing",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
 }
 `;
@@ -840,9 +888,13 @@ exports[`The GuApiLambda pattern should create the correct resources with minima
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-testing",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdaloggroup1D59E0A8",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -975,6 +1027,19 @@ exports[`The GuApiLambda pattern should create the correct resources with minima
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdaloggroup1D59E0A8",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -1252,7 +1317,7 @@ exports[`The GuApiLambda pattern should create the correct resources with minima
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdaapiDeployment8E95B585b2a6e9ca12f368f15997c85321f29670": {
+    "lambdaapiDeployment8E95B5856bce64b56bb783d190c0255c57e8f7da": {
       "DependsOn": [
         "lambdaapiproxyANYA94E968A",
         "lambdaapiproxyB573C729",
@@ -1272,7 +1337,7 @@ exports[`The GuApiLambda pattern should create the correct resources with minima
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "lambdaapiDeployment8E95B585b2a6e9ca12f368f15997c85321f29670",
+          "Ref": "lambdaapiDeployment8E95B5856bce64b56bb783d190c0255c57e8f7da",
         },
         "RestApiId": {
           "Ref": "lambdaapiC1812993",
@@ -1435,6 +1500,37 @@ exports[`The GuApiLambda pattern should create the correct resources with minima
         },
       },
       "Type": "AWS::ApiGateway::Resource",
+    },
+    "lambdaloggroup1D59E0A8": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-testing",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
+++ b/src/patterns/__snapshots__/api-multiple-lambdas.test.ts.snap
@@ -141,7 +141,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "RestApiDeployment180EC50383363c5ced7927aa10a2d324d85bde7b": {
+    "RestApiDeployment180EC5035e9da980ef87cc0d093fe63b083a88c0": {
       "DependsOn": [
         "RestApitestalongpathGET4832AA08",
         "RestApitestalongpath289D7A7A",
@@ -167,7 +167,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "RestApiDeployment180EC50383363c5ced7927aa10a2d324d85bde7b",
+          "Ref": "RestApiDeployment180EC5035e9da980ef87cc0d093fe63b083a88c0",
         },
         "RestApiId": {
           "Ref": "RestApi0C43BF4B",
@@ -740,18 +740,22 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "test-stack/TEST/testing/my-app-4.zip",
+          "S3Key": "test-stack/TEST/lambda-four/lambda-four.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "testing",
+            "APP": "lambda-four",
             "STACK": "test-stack",
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-lambda-four",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdafourloggroup481C2C40",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -764,7 +768,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-four",
           },
           {
             "Key": "gu:cdk:version",
@@ -818,7 +822,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-four",
           },
           {
             "Key": "gu:cdk:version",
@@ -879,11 +883,24 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/test-stack/TEST/testing/my-app-4.zip",
+                      "/test-stack/TEST/lambda-four/lambda-four.zip",
                     ],
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdafourloggroup481C2C40",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -900,7 +917,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing",
+                    ":parameter/TEST/test-stack/lambda-four",
                   ],
                 ],
               },
@@ -923,7 +940,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing/*",
+                    ":parameter/TEST/test-stack/lambda-four/*",
                   ],
                 ],
               },
@@ -940,6 +957,37 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       },
       "Type": "AWS::IAM::Policy",
     },
+    "lambdafourloggroup481C2C40": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-lambda-four",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "lambda-four",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "lambdaoneA536F07A": {
       "DependsOn": [
         "lambdaoneServiceRoleDefaultPolicy8CBB4D33",
@@ -950,18 +998,22 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "test-stack/TEST/testing/my-app-1.zip",
+          "S3Key": "test-stack/TEST/lambda-one/lambda-one.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "testing",
+            "APP": "lambda-one",
             "STACK": "test-stack",
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-lambda-one",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdaoneloggroup970643E1",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -974,7 +1026,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-one",
           },
           {
             "Key": "gu:cdk:version",
@@ -1036,11 +1088,24 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/test-stack/TEST/testing/my-app-1.zip",
+                      "/test-stack/TEST/lambda-one/lambda-one.zip",
                     ],
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdaoneloggroup970643E1",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -1057,7 +1122,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing",
+                    ":parameter/TEST/test-stack/lambda-one",
                   ],
                 ],
               },
@@ -1080,7 +1145,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing/*",
+                    ":parameter/TEST/test-stack/lambda-one/*",
                   ],
                 ],
               },
@@ -1128,7 +1193,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-one",
           },
           {
             "Key": "gu:cdk:version",
@@ -1150,6 +1215,37 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       },
       "Type": "AWS::IAM::Role",
     },
+    "lambdaoneloggroup970643E1": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-lambda-one",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "lambda-one",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "lambdathreeD95CE916": {
       "DependsOn": [
         "lambdathreeServiceRoleDefaultPolicy6BB3377A",
@@ -1160,18 +1256,22 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "test-stack/TEST/testing/my-app-3.zip",
+          "S3Key": "test-stack/TEST/lambda-three/lambda-three.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "testing",
+            "APP": "lambda-three",
             "STACK": "test-stack",
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-lambda-three",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdathreeloggroup2C79ECD3",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -1184,7 +1284,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-three",
           },
           {
             "Key": "gu:cdk:version",
@@ -1238,7 +1338,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-three",
           },
           {
             "Key": "gu:cdk:version",
@@ -1299,11 +1399,24 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/test-stack/TEST/testing/my-app-3.zip",
+                      "/test-stack/TEST/lambda-three/lambda-three.zip",
                     ],
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdathreeloggroup2C79ECD3",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -1320,7 +1433,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing",
+                    ":parameter/TEST/test-stack/lambda-three",
                   ],
                 ],
               },
@@ -1343,7 +1456,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing/*",
+                    ":parameter/TEST/test-stack/lambda-three/*",
                   ],
                 ],
               },
@@ -1360,6 +1473,37 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
       },
       "Type": "AWS::IAM::Policy",
     },
+    "lambdathreeloggroup2C79ECD3": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-lambda-three",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "lambda-three",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "lambdatwoAFC8CEF1": {
       "DependsOn": [
         "lambdatwoServiceRoleDefaultPolicy36A183D7",
@@ -1370,18 +1514,22 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "test-stack/TEST/testing/my-app-2.zip",
+          "S3Key": "test-stack/TEST/lambda-two/lambda-two.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "testing",
+            "APP": "lambda-two",
             "STACK": "test-stack",
             "STAGE": "TEST",
           },
         },
+        "FunctionName": "TEST-test-stack-lambda-two",
         "Handler": "handler.ts",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "lambdatwologgroupBC9FBF92",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -1394,7 +1542,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-two",
           },
           {
             "Key": "gu:cdk:version",
@@ -1448,7 +1596,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         "Tags": [
           {
             "Key": "App",
-            "Value": "testing",
+            "Value": "lambda-two",
           },
           {
             "Key": "gu:cdk:version",
@@ -1509,11 +1657,24 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/test-stack/TEST/testing/my-app-2.zip",
+                      "/test-stack/TEST/lambda-two/lambda-two.zip",
                     ],
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "lambdatwologgroupBC9FBF92",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -1530,7 +1691,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing",
+                    ":parameter/TEST/test-stack/lambda-two",
                   ],
                 ],
               },
@@ -1553,7 +1714,7 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/testing/*",
+                    ":parameter/TEST/test-stack/lambda-two/*",
                   ],
                 ],
               },
@@ -1569,6 +1730,37 @@ exports[`The GuApiGatewayWithLambdaByPath pattern should create the correct reso
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "lambdatwologgroupBC9FBF92": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/TEST-test-stack-lambda-two",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "lambda-two",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -41,6 +41,9 @@ exports[`The GuScheduledLambda pattern should create the correct resources with 
         "Handler": "my-lambda/handler",
         "LoggingConfig": {
           "LogFormat": "JSON",
+          "LogGroup": {
+            "Ref": "mylambdafunctionloggroup37C4E2CC",
+          },
         },
         "MemorySize": 512,
         "Role": {
@@ -120,6 +123,19 @@ exports[`The GuScheduledLambda pattern should create the correct resources with 
                   ],
                 },
               ],
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "mylambdafunctionloggroup37C4E2CC",
+                  "Arn",
+                ],
+              },
             },
             {
               "Action": "ssm:GetParametersByPath",
@@ -228,6 +244,37 @@ exports[`The GuScheduledLambda pattern should create the correct resources with 
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "mylambdafunctionloggroup37C4E2CC": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/my-lambda-function",
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "mylambdafunctionmylambdafunctionrate1minute06AD0015D": {
       "Properties": {

--- a/src/patterns/api-multiple-lambdas.test.ts
+++ b/src/patterns/api-multiple-lambdas.test.ts
@@ -7,26 +7,30 @@ import { GuApiGatewayWithLambdaByPath } from "./api-multiple-lambdas";
 describe("The GuApiGatewayWithLambdaByPath pattern", () => {
   it("should create the correct resources with minimal config", () => {
     const stack = simpleGuStackForTesting();
-    const defaultProps = {
+
+    const lambdaOne = new GuLambdaFunction(stack, "lambda-one", {
       handler: "handler.ts",
       runtime: Runtime.NODEJS_14_X,
-      app: "testing",
-    };
-    const lambdaOne = new GuLambdaFunction(stack, "lambda-one", {
-      ...defaultProps,
-      fileName: "my-app-1.zip",
+      app: "lambda-one",
+      fileName: "lambda-one.zip",
     });
     const lambdaTwo = new GuLambdaFunction(stack, "lambda-two", {
-      ...defaultProps,
-      fileName: "my-app-2.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_14_X,
+      app: "lambda-two",
+      fileName: "lambda-two.zip",
     });
     const lambdaThree = new GuLambdaFunction(stack, "lambda-three", {
-      ...defaultProps,
-      fileName: "my-app-3.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_14_X,
+      app: "lambda-three",
+      fileName: "lambda-three.zip",
     });
     const lambdaFour = new GuLambdaFunction(stack, "lambda-four", {
-      ...defaultProps,
-      fileName: "my-app-4.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_14_X,
+      app: "lambda-four",
+      fileName: "lambda-four.zip",
     });
     new GuApiGatewayWithLambdaByPath(stack, {
       app: "testing",


### PR DESCRIPTION
When creating a `AWS::Lambda::Function` without an explicit [`LoggingConfig.LogGroup`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-loggingconfig) property, AWS [implicitly creates a log group](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-loggingconfig.html#cfn-lambda-function-loggingconfig-loggroup). This implicitly created log group is named `/aws/lambda/<function name>`, and does not have any tags applied to it.

Log groups created with CloudFormation can now be tagged. See also https://github.com/guardian/cloudwatch-logs-management/issues/19.

## What does this change?
In this change, an explicit [`AWS::Logs::LogGroup`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html) is created, and the `GuLambdaFunction` is configured to log to it. As we're now creating the log group, we can also apply tags to it 🎉.

> [!CAUTION]
> Two breaking changes are introduced:
> 1. A `GuLambdaFunction` now defaults the `functionName` property to `<stage>-<stack>-<app>`. Previously, it was `undefined` allowing AWS to [auto-generate a name](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname). This default can still be overridden.
> 2. Consequently, the `stack`, `stage`, and `app` triple for lambdas must be unique within a region.

This log group's name mimics the naming scheme of AWS: `/aws/lambda/<function name>`. Omitting the name results in AWS auto-generating one. However tools such as [cloudwatch-logs-management](https://github.com/guardian/cloudwatch-logs-management) are looking for groups prefixed `/aws/lambda`, so explicitly naming allows these tools to continue to work.

Looking at [the data](https://metrics.gutools.co.uk/goto/neHpkVUIR?orgId=1), this naming change would impact a large number of lambdas. However, it looks like most of them constitute part of a step function, and haven't been explicitly tagged in their CloudFormation template, for example [elasticsearch-node-rotation](https://github.com/guardian/elasticsearch-node-rotation/blob/f7a1516c89a62627f688e4a9b7ebdce33daae46b/cloudformation.yaml#L200-L217).
## Alternative solutions
Here are some alternative solutions to lessen the breaking changes. I think the last one (generate a random log name) is the most feasible.
### Remove log groups from the tagging obligation
The tagging obligation requires that resources are tagged correctly. That is, an option is to decide log groups do not require tagging.
### Mutate the implicit log group
 https://github.com/guardian/cloudwatch-logs-management already does some mutation, including setting the retention time, and creating a subscription. Could it be updated to also apply tags?
### Omit log group name
Instead of providing an explicit name, we could opt to add an additional tag to the log group. This will result in AWS auto-generating a name, and the log group will not have the `/aws/lambda` prefix.

To allow `cloudwatch-logs-management` to continue to work, it would need updating to look at the tags of log groups.
### Only explicitly name the log group
The log group name needs to start `/aws/lambda` for `cloudwatch-logs-management` to work. Instead of setting the name of the lambda and the log group, we could set the log group's name only: `/aws/lambda/<stage>-<stack>-<app>`.

Theoretically, this has fewer breaking changes. However, it does not remove the need for each lambda in a stack to have a unique `stack`, `stage`, and `app` triple. Else we'd be attempting to create multiple log groups with the same name, which will not deploy.
### Generate a random log name
The breaking changes above are a consequence of needing the `/aws/lambda` prefix.

Theoretically, we could `Ref` the lambda function to make the log group name dynamic. However this creates a cyclical dependency: the lambda requires the log group to be created, and the log group requires the lambda to be created. Further more, this error is first seen at deployment time, which can be confusing.

To meet the above requirement, the log group could be named `/aws/lambda/<guid>`. The GUID cannot be truly random, as that would make snapshot testing tricky. Instead, the randomness should be seeded; [AWS CDK's `Names` class](https://github.com/aws/aws-cdk/blob/665396fa8485ab642c27acf30df85f2b023acde4/packages/aws-cdk-lib/core/lib/names.ts#L69-L91) can be used here.
## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->
TBD.
## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
More resources defined using infrastructure as code, and more resources with tags.
## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Yes, there are breaking changes. See above.
## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
