### PR TITLE
Support building AMI images via GuCDK

### DIFF
--- a/src/constructs/imagebuilder/ami.builder.ts
+++ b/src/constructs/imagebuilder/ami.builder.ts
@@ -1,0 +1,21 @@
+import { Template } from "aws-cdk-lib/assertions";
+import { simpleGuStackForTesting } from "../../utils/test";
+import { Ami } from "./ami";
+import { Java } from "./components";
+
+describe("The Ami class", () => {
+  it("should create a GuImagePipeline with minimal config", () => {
+    const stack = simpleGuStackForTesting();
+
+    Ami.from(stack, "ami").withComponent(Java.JDK_17).build();
+
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+
+  it("should throw if no components are passed", () => {
+    const stack = simpleGuStackForTesting();
+    expect(() => {
+      Ami.from(stack, "ami").build();
+    }).toThrowError("ImageBuilder expects recipes to have atleast 1 component.");
+  });
+});

--- a/src/constructs/imagebuilder/ami.ts
+++ b/src/constructs/imagebuilder/ami.ts
@@ -1,0 +1,42 @@
+import type { GuStack } from "../core";
+import { GuImagePipeline } from "./pipeline";
+import { GuImageRecipe, type GuRecipeComponentConfiguration } from "./recipe";
+
+export class Ami {
+  private scope: GuStack;
+  private id: string;
+
+  private parentImage?: string;
+  private components: GuRecipeComponentConfiguration[] = [];
+
+  // eslint-disable-next-line custom-rules/valid-constructors -- not a valid
+  constructor(scope: GuStack, id: string) {
+    this.scope = scope;
+    this.id = id;
+  }
+
+  public static from(scope: GuStack, id: string): Ami {
+    return new Ami(scope, id);
+  }
+
+  public withParentImage(parentImage: string): this {
+    this.parentImage = parentImage;
+    return this;
+  }
+
+  public withComponent(component: GuRecipeComponentConfiguration): this {
+    this.components.push(component);
+    return this;
+  }
+
+  public build(): GuImagePipeline {
+    const recipe = new GuImageRecipe(this.scope, `${this.id}Recipe`, {
+      parentImage: this.parentImage,
+      components: this.components,
+    });
+
+    return new GuImagePipeline(this.scope, this.id, {
+      imageRecipe: recipe,
+    });
+  }
+}

--- a/src/constructs/imagebuilder/component.ts
+++ b/src/constructs/imagebuilder/component.ts
@@ -1,9 +1,52 @@
 import type { CfnComponentProps } from "aws-cdk-lib/aws-imagebuilder";
 import { CfnComponent } from "aws-cdk-lib/aws-imagebuilder";
+import { dump } from "js-yaml";
 import type { GuStack } from "../core";
 
+type GuComponentStepBase = {
+  name: string;
+};
+
+type GuComponentStepExecuteBash = GuComponentStepBase & {
+  action: "ExecuteBash";
+  inputs: {
+    commands: string[];
+  };
+};
+
+type GuComponentStepExecuteBinary = GuComponentStepBase & {
+  action: "ExecuteBinary";
+  inputs: {
+    path: string;
+    arguments?: string[];
+  };
+};
+
+type GuComponentStep = GuComponentStepExecuteBash | GuComponentStepExecuteBinary;
+
+type GuComponentPhase = {
+  name: "build" | "validate" | "test";
+  steps: GuComponentStep[];
+};
+
+export type GuComponentProps = CfnComponentProps & {
+  phases: GuComponentPhase[];
+};
+
 export class GuComponent extends CfnComponent {
-  constructor(scope: GuStack, id: string, props: CfnComponentProps) {
-    super(scope, id, props);
+  constructor(scope: GuStack, id: string, props: GuComponentProps) {
+    const { name, description, phases } = props;
+
+    const data = dump({
+      name,
+      description,
+      schemaVersion: 1,
+      phases,
+    });
+
+    super(scope, id, {
+      ...props,
+      data,
+    });
   }
 }

--- a/src/constructs/imagebuilder/component.ts
+++ b/src/constructs/imagebuilder/component.ts
@@ -1,0 +1,9 @@
+import type { CfnComponentProps } from "aws-cdk-lib/aws-imagebuilder";
+import { CfnComponent } from "aws-cdk-lib/aws-imagebuilder";
+import type { GuStack } from "../core";
+
+export class GuComponent extends CfnComponent {
+  constructor(scope: GuStack, id: string, props: CfnComponentProps) {
+    super(scope, id, props);
+  }
+}

--- a/src/constructs/imagebuilder/components/apt.ts
+++ b/src/constructs/imagebuilder/components/apt.ts
@@ -1,0 +1,99 @@
+import type { GuStack } from "../../core";
+import { GuComponent } from "../component";
+
+export class GuComponentAptUpdate extends GuComponent {
+  constructor(scope: GuStack) {
+    const id = `${scope.stack}-${scope.stage}-${scope.app}-apt-update`;
+
+    super(scope, id, {
+      name: id,
+      platform: "Linux",
+      version: "1.0.0",
+      phases: [
+        {
+          name: "build",
+          steps: [
+            {
+              name: "UpdateApt",
+              action: "ExecuteBash",
+              inputs: {
+                commands: ["sudo apt-get update"],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }
+}
+
+export type GuComponentAptInstallProps = {
+  signingKeysFromUrls?: string[];
+  aptRepositories?: Array<{
+    type: "deb" | "deb-src";
+    url: string;
+    distribution?: string;
+    component: string;
+  }>;
+  packages: string[];
+};
+
+export class GuComponentAptInstall extends GuComponent {
+  constructor(scope: GuStack, props: GuComponentAptInstallProps) {
+    const id = `${scope.stack}-${scope.stage}-${scope.app}-apt-install`;
+
+    super(scope, id, {
+      name: id,
+      platform: "Linux",
+      version: "1.0.0",
+      phases: [
+        {
+          name: "build",
+          steps: [
+            ...(props.signingKeysFromUrls
+              ? [
+                  {
+                    name: "AddAptKeys",
+                    action: "ExecuteBash" as const,
+                    inputs: {
+                      commands: props.signingKeysFromUrls.map((key) => `wget -qO - ${key}| sudo apt-key add -`),
+                    },
+                  },
+                ]
+              : []),
+
+            ...(props.aptRepositories
+              ? [
+                  {
+                    name: "AddAptRepositories",
+                    action: "ExecuteBash" as const,
+                    inputs: {
+                      commands: props.aptRepositories.map(
+                        (repo) =>
+                          `echo "${repo.type} ${repo.url} ${repo.distribution ?? "$(lsb_release -cs)"} ${repo.component}" | sudo tee -a /etc/apt/sources.list`,
+                      ),
+                    },
+                  },
+                  {
+                    name: "UpdateApt",
+                    action: "ExecuteBash" as const,
+                    inputs: {
+                      commands: ["sudo apt-get update"],
+                    },
+                  },
+                ]
+              : []),
+
+            {
+              name: "InstallAptPackages",
+              action: "ExecuteBash",
+              inputs: {
+                commands: [`sudo apt-get install -y ${props.packages.join(" ")}`],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }
+}

--- a/src/constructs/imagebuilder/components/aws.ts
+++ b/src/constructs/imagebuilder/components/aws.ts
@@ -1,0 +1,23 @@
+export const Java = {
+  JRE_8: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-8-jre/1.0.0",
+  },
+  JDK_8: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-8-jdk/1.0.0",
+  },
+  JRE_AND_JDK_11: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-11/1.0.1/1",
+  },
+  JRE_17: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-17-jre/1.0.0",
+  },
+  JDK_17: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-17-jdk/1.0.0",
+  },
+  JRE_21: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-21-jre/1.0.0",
+  },
+  JDK_21: {
+    componentArn: "arn:aws:imagebuilder:eu-west-1:aws:component/amazon-corretto-21-jdk/1.0.0",
+  },
+} as const;

--- a/src/constructs/imagebuilder/components/guardian.ts
+++ b/src/constructs/imagebuilder/components/guardian.ts
@@ -1,0 +1,11 @@
+import type { GuStack } from "../../core";
+import { GuComponent } from "../component";
+
+export const DevX = {
+  LOGGING: (scope: GuStack, id: string) =>
+    new GuComponent(scope, id, {
+      platform: "Linux",
+      version: "1.0.0",
+      name: `${scope.stack}-${scope.stage}-${scope.app}-logging`,
+    }),
+};

--- a/src/constructs/imagebuilder/components/guardian.ts
+++ b/src/constructs/imagebuilder/components/guardian.ts
@@ -2,10 +2,25 @@ import type { GuStack } from "../../core";
 import { GuComponent } from "../component";
 
 export const DevX = {
-  LOGGING: (scope: GuStack, id: string) =>
-    new GuComponent(scope, id, {
+  NGINX: (scope: GuStack) => ({
+    component: new GuComponent(scope, `NginxInstallStep`, {
       platform: "Linux",
       version: "1.0.0",
-      name: `${scope.stack}-${scope.stage}-${scope.app}-logging`,
+      name: `${scope.stack}-${scope.stage}-${scope.app}-nginx`,
+      phases: [
+        {
+          name: "build",
+          steps: [
+            {
+              name: "InstallNginx",
+              action: "ExecuteBash",
+              inputs: {
+                commands: ["apt-get install nginx -y"],
+              },
+            },
+          ],
+        },
+      ],
     }),
+  }),
 };

--- a/src/constructs/imagebuilder/components/index.ts
+++ b/src/constructs/imagebuilder/components/index.ts
@@ -1,0 +1,2 @@
+export * from "./aws";
+export * from "./guardian";

--- a/src/constructs/imagebuilder/components/java.ts
+++ b/src/constructs/imagebuilder/components/java.ts
@@ -1,0 +1,23 @@
+import type { GuStack } from "../../core";
+import { GuComponentAptInstall } from "./apt";
+
+type GuComponentJavaProps = {
+  version: 8 | 11 | 17 | 21 | 22;
+};
+
+export class GuComponentJavaCorretto extends GuComponentAptInstall {
+  constructor(scope: GuStack, props: GuComponentJavaProps) {
+    super(scope, {
+      packages: [`java-${props.version}-amazon-corretto-jdk`],
+      signingKeysFromUrls: ["https://apt.corretto.aws/corretto.key"],
+      aptRepositories: [
+        {
+          type: "deb",
+          url: "https://apt.corretto.aws",
+          distribution: "stable",
+          component: "main",
+        },
+      ],
+    });
+  }
+}

--- a/src/constructs/imagebuilder/distribution.ts
+++ b/src/constructs/imagebuilder/distribution.ts
@@ -22,6 +22,7 @@ export class GuDistributionConfiguration extends CfnDistributionConfiguration {
       distributions: props.distributions ?? [
         {
           region: scope.region,
+          amiDistributionConfiguration: {},
         },
       ],
     });

--- a/src/constructs/imagebuilder/distribution.ts
+++ b/src/constructs/imagebuilder/distribution.ts
@@ -1,0 +1,29 @@
+import type { CfnDistributionConfigurationProps } from "aws-cdk-lib/aws-imagebuilder";
+import { CfnDistributionConfiguration } from "aws-cdk-lib/aws-imagebuilder";
+import type { GuStack } from "../core";
+
+export type GuDistributionConfigurationProps = Omit<CfnDistributionConfigurationProps, "name" | "distributions"> & {
+  /**
+   * The name of the distribution configuration. If not provided, a name will be generated.
+   */
+  name?: string;
+
+  /**
+   * The distributions to create. If not provided, a single distribution in the current region will be created.
+   */
+  distributions?: CfnDistributionConfiguration.DistributionProperty[];
+};
+
+export class GuDistributionConfiguration extends CfnDistributionConfiguration {
+  constructor(scope: GuStack, id: string, props: GuDistributionConfigurationProps) {
+    super(scope, id, {
+      ...props,
+      name: props.name ?? `${scope.stack}-${scope.stage}-${scope.app ?? "unknown"}`,
+      distributions: props.distributions ?? [
+        {
+          region: scope.region,
+        },
+      ],
+    });
+  }
+}

--- a/src/constructs/imagebuilder/index.ts
+++ b/src/constructs/imagebuilder/index.ts
@@ -1,0 +1,6 @@
+export * from "./ami";
+export * from "./pipeline";
+export * from "./recipe";
+export * from "./infrastructure";
+export * from "./distribution";
+export * from "./component";

--- a/src/constructs/imagebuilder/infrastructure.ts
+++ b/src/constructs/imagebuilder/infrastructure.ts
@@ -1,0 +1,42 @@
+import { InstanceProfile, ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import type { CfnInfrastructureConfigurationProps } from "aws-cdk-lib/aws-imagebuilder";
+import { CfnInfrastructureConfiguration } from "aws-cdk-lib/aws-imagebuilder";
+import { type GuStack } from "../core";
+
+export type GuInfrastructureConfigProps = Partial<CfnInfrastructureConfigurationProps> & {
+  profile?: InstanceProfile;
+};
+
+export class GuInfrastructureConfig extends CfnInfrastructureConfiguration {
+  constructor(scope: GuStack, id: string, props: GuInfrastructureConfigProps) {
+    super(scope, id, {
+      ...props,
+      name: props.name ?? `${scope.stack}-${scope.stage}-${scope.app ?? "unknown"}`,
+      instanceProfileName:
+        props.profile?.instanceProfileName ??
+        GuInfrastructureConfig.defaultInstanceProfile(scope, id).instanceProfileName,
+      // Build on our most common instance type by default
+      instanceTypes: props.instanceTypes ?? ["t4g.micro"],
+      resourceTags: {
+        Stack: scope.stack,
+        Stage: scope.stage,
+        App: scope.app ?? "unknown",
+        "gu:repo": scope.repositoryName ?? "unknown",
+        ...props.resourceTags,
+      },
+    });
+  }
+
+  static defaultInstanceProfile = (scope: GuStack, id: string) => {
+    return new InstanceProfile(scope, `${id}InstanceProfile`, {
+      role: new Role(scope, `${id}InstanceProfileRole`, {
+        assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+        managedPolicies: [
+          ManagedPolicy.fromAwsManagedPolicyName("EC2InstanceProfileForImageBuilder"),
+          // TODO: This policy is quite permissive. Can we restrict it a bit?
+          ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore"),
+        ],
+      }),
+    });
+  };
+}

--- a/src/constructs/imagebuilder/pipeline.test.ts
+++ b/src/constructs/imagebuilder/pipeline.test.ts
@@ -1,0 +1,23 @@
+import { Template } from "aws-cdk-lib/assertions";
+import { simpleGuStackForTesting } from "../../utils/test";
+import { GuComponentJavaCorretto } from "./components";
+import { GuImagePipeline } from "./pipeline";
+import { GuImageRecipe } from "./recipe";
+
+describe("The Ami class", () => {
+  it("should create a GuImagePipeline with minimal config", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuImagePipeline(stack, "ami", {
+      imageRecipe: new GuImageRecipe(stack, "recipe", {
+        components: [
+          new GuComponentJavaCorretto(stack, {
+            version: 17,
+          }),
+        ],
+      }),
+    });
+
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/constructs/imagebuilder/pipeline.ts
+++ b/src/constructs/imagebuilder/pipeline.ts
@@ -1,0 +1,34 @@
+import type { CfnImagePipelineProps, CfnInfrastructureConfiguration } from "aws-cdk-lib/aws-imagebuilder";
+import { CfnImagePipeline } from "aws-cdk-lib/aws-imagebuilder";
+import type { GuStack } from "../core";
+import { GuDistributionConfiguration } from "./distribution";
+import { GuInfrastructureConfig } from "./infrastructure";
+import type { GuImageRecipe } from "./recipe";
+
+export type GuImagePipelneProps = Omit<
+  Partial<CfnImagePipelineProps>,
+  "imageRecipeArn" | "infrastructureConfigurationArn" | "distributionConfigurationArn"
+> & {
+  infrastructureConfig?: CfnInfrastructureConfiguration;
+  imageRecipe: GuImageRecipe;
+  distributionConfiguration?: GuDistributionConfiguration;
+};
+
+export class GuImagePipeline extends CfnImagePipeline {
+  constructor(scope: GuStack, id: string, props: GuImagePipelneProps) {
+    const name = props.name ?? `${scope.stack}-${scope.stage}-${scope.app ?? "unknown"}`;
+
+    const infrastructureConfig =
+      props.infrastructureConfig ?? new GuInfrastructureConfig(scope, `${id}InfrastructureConfig`, {});
+    const distributionConfig =
+      props.distributionConfiguration ?? new GuDistributionConfiguration(scope, `${id}DistributionConfig`, {});
+
+    super(scope, id, {
+      ...props,
+      name,
+      infrastructureConfigurationArn: infrastructureConfig.attrArn,
+      imageRecipeArn: props.imageRecipe.attrArn,
+      distributionConfigurationArn: distributionConfig.attrArn,
+    });
+  }
+}

--- a/src/constructs/imagebuilder/recipe.ts
+++ b/src/constructs/imagebuilder/recipe.ts
@@ -74,7 +74,10 @@ export class GuImageRecipe extends CfnImageRecipe {
       parentImage: props.parentImage ?? "arn:aws:imagebuilder:eu-west-1:aws:image/ubuntu-server-22-lts-arm64/x.x.x",
       name,
       version: props.version ?? "1.0.0",
-      components,
+      components: components.map(({ componentArn, parameters }) => ({
+        componentArn,
+        parameters,
+      })),
     });
   }
 }

--- a/src/constructs/imagebuilder/recipe.ts
+++ b/src/constructs/imagebuilder/recipe.ts
@@ -71,7 +71,7 @@ export class GuImageRecipe extends CfnImageRecipe {
 
     super(scope, id, {
       ...props,
-      parentImage: props.parentImage ?? "arn:aws:imagebuilder:eu-west-1:aws:image/amazon-linux-2023-arm64/2024.6.7",
+      parentImage: props.parentImage ?? "arn:aws:imagebuilder:eu-west-1:aws:image/ubuntu-server-22-lts-arm64/x.x.x",
       name,
       version: props.version ?? "1.0.0",
       components,

--- a/src/constructs/imagebuilder/recipe.ts
+++ b/src/constructs/imagebuilder/recipe.ts
@@ -1,0 +1,80 @@
+import type { CfnImageRecipeProps } from "aws-cdk-lib/aws-imagebuilder";
+import { CfnImageRecipe } from "aws-cdk-lib/aws-imagebuilder";
+import type { GuStack } from "../core";
+import type { GuComponent } from "./component";
+
+export type GuRecipeComponentConfiguration =
+  | CfnImageRecipe.ComponentConfigurationProperty
+  | GuComponent
+  | ((scope: GuStack) => GuComponentConfigurationProperty);
+
+export type GuComponentConfigurationProperty = Omit<CfnImageRecipe.ComponentConfigurationProperty, "componentArn"> & {
+  component: GuComponent;
+};
+
+type GuImageRecipeProps = Omit<CfnImageRecipeProps, "components" | "version" | "name" | "parentImage"> & {
+  /**
+   * The name of the recipe. If not provided, a name will be generated.
+   */
+  name?: string;
+
+  /**
+   * The version of the recipe. Defaults to "1.0.0".
+   */
+  version?: string;
+
+  /**
+   * The parent image of the recipe. Defaults to Amazon Linux 2023 ARM if not provided.
+   */
+  parentImage?: string;
+
+  /**
+   * The components to include in the recipe.
+   */
+  components: GuRecipeComponentConfiguration[];
+};
+
+const isComponentConfigurationProperty = (obj: unknown): obj is CfnImageRecipe.ComponentConfigurationProperty =>
+  typeof obj === "object" && obj !== null && "componentArn" in obj;
+
+const isGuComponentConfigurationProperty = (obj: unknown): obj is GuComponentConfigurationProperty =>
+  typeof obj === "object" && obj !== null && "component" in obj;
+
+const isFunction = (obj: unknown): obj is (stack: GuStack) => GuComponentConfigurationProperty =>
+  typeof obj === "function";
+
+export class GuImageRecipe extends CfnImageRecipe {
+  constructor(scope: GuStack, id: string, props: GuImageRecipeProps) {
+    const name = props.name ?? `${scope.stack}-${scope.stage}-${scope.app ?? "unknown"}`;
+
+    const components = [
+      // Support inbuilt amazon components
+      ...props.components.filter(isComponentConfigurationProperty),
+      // Support custom Guardian components
+      ...props.components.filter(isGuComponentConfigurationProperty).map((component) => ({
+        ...component,
+        componentArn: component.component.attrArn,
+      })),
+      // Support inbuilt custom GuCDK components
+      ...props.components
+        .filter(isFunction)
+        .map((func) => func(scope))
+        .map((component) => ({
+          ...component,
+          componentArn: component.component.attrArn,
+        })),
+    ];
+
+    if (components.length === 0) {
+      throw new Error("ImageBuilder expects recipes to have atleast 1 component.");
+    }
+
+    super(scope, id, {
+      ...props,
+      parentImage: props.parentImage ?? "arn:aws:imagebuilder:eu-west-1:aws:image/amazon-linux-2023-arm64/2024.6.7",
+      name,
+      version: props.version ?? "1.0.0",
+      components,
+    });
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds L2 constructs for ImageBuilder to facilitate building AMI images for our EC2 applications.

These L2 constructs provide a number of optional defaults that I considered sensible such as:

- Unless specified AMIs will use Amazon Linux 2023 as their base image.
- Recipes default to version 1.0.0, versioning recipes isn't really compatible with our "pick the latest AMI" deployment model.
- Most names follow the format of `STACK-STAGE-APP`, haven't tested to see if imagebuilder cares if theres 2 recipes with the same name, I imagine it does, and this could cause issues if we have more than 1 image per app. I'd like to include a random identifier at the end of names but I can't figure out how to do that with CDK!

### Why

If we can get ImageBuilder working correctly it allows us to sunset Amigo meaning:

 - **Reduced infra cost**, ImageBuilder will spin up an instance to build the AMI and then spin back down again. This has the added benefit that ImageBuilder scales so we'll no longer have that issue where too many Amigo builds are happening at once causing some to fail. 
 - **Reduced maintenance burden**, we won't need to maintain a play app and all the multi account infrastructure that goes along with it.
 - **Progress towards next quarter OKRs** Easier to setup new AWS accounts as we won't need to deploy a bunch of Amigo infrastructure for each new account.

### Issues

#### Can't deploy both AMI and Infra at the same time

Like Amigo it won't really be possible to build AMIs at deployment time due to the long time it takes to build an AMI. This will mean 2 things:

- New stacks will need to deploy and build their AMI first before they can deploy an EC2 app
- Some parts of your CDK won't exactly match production, your non AMI infra will be updated immediately, whereas your AMI infra might not get updated until the next deployment.

#### Cloudformation file size limits

Custom components (aka "roles" in Amigoland) are limited to 64KB of YAML which could potentially limit how complex each component can be, haven't done any baselines to figure out how limiting this is. In any case, AWS allows requesting a larger limit if this does prove to be too small.

What could be more problematic is the Cloudformation YAML limit, assuming 2 image pipelines per app (CODE & PROD) and maybe 2-3 custom components, this might result in quite a lot of YAML, again, haven't tested this yet so it may be a non issue.


### Usage

```js

import { Ami } from "@guardian/cdk/lib/constructs/imagebuilder"
import { Java } from "@guardian/cdk/lib/constructs/imagebuilder/components"

...

const ami = Ami.from(stack, "AMI")
    .withParentImage("arn:aws:imagebuilder:eu-west-1:aws:image/amazon-linux-2023-arm64/2024.6.7")
    .withComponent(Java.JRE_11)
    .build()


...

// TODO: Not implemented yet.
new GuPlayApp(stack, "App", {
   ...
   imageRecipe: ami.recipeName
   ...
});
```


### TODO (maybe not this PR)

- [ ] Schedule AMI builds
  - [ ] By default build once per day
  - [ ] Additionally, have riffraff trigger a build on deploy
  - [ ] Aditional additionally, have riffraff wait for an AMI build to complete before updating a stacks AMI parameter
- [ ] Support Encrypted AMIs
  - [ ] Provision KMS Keypairs per AMI/Recipe
  - [ ] Apply "Encrypted" tag to resulting image
- [ ] Support DevX logging 
- [ ] Build in support for commonly used roles:
  - [ ] Node
  - [ ] Java (non-aws)
  - [ ] apt
- [ ] Integrate into our EC2 patterns
- [ ] Documentation

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
