### PR TITLE
feat(asg): Allow setting the UpdatePolicy on ASGs provisioned by our EC2 patterns

### DIFF
--- a/.changeset/grumpy-experts-divide.md
+++ b/.changeset/grumpy-experts-divide.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(asg): Allow setting the UpdatePolicy on ASGs provisioned by our EC2 patterns

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -94,6 +94,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       vpc,
       withoutImdsv2 = false,
       httpPutResponseHopLimit,
+      updatePolicy,
     } = props;
 
     // Ensure min and max are defined in the same way. Throwing an `Error` when necessary. For example when min is defined via a Mapping, but max is not.
@@ -163,7 +164,9 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
     // A CDK AutoScalingGroup comes with this update policy, whereas the CFN autscaling group
     // leaves it to the default value, which is actually false.
     // { UpdatePolicy: { autoScalingScheduledAction: { IgnoreUnmodifiedGroupSizeProperties: true }}
-    cfnAsg.addDeletionOverride("UpdatePolicy");
+    if (!updatePolicy) {
+      cfnAsg.addDeletionOverride("UpdatePolicy");
+    }
 
     Tags.of(launchTemplate).add("App", app);
   }

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -1,6 +1,6 @@
 /* eslint "@guardian/tsdoc-required/tsdoc-required": 2 -- to begin rolling this out for public APIs. */
 import { Duration, SecretValue, Tags } from "aws-cdk-lib";
-import type { BlockDevice } from "aws-cdk-lib/aws-autoscaling";
+import type { BlockDevice, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
 import { HealthCheck } from "aws-cdk-lib/aws-autoscaling";
 import {
   ProviderAttribute,
@@ -298,6 +298,11 @@ export interface GuEc2AppProps extends AppIdentity {
    * for example when sharing the instance profile with a docker container running on the instance.
    */
   instanceMetadataHopLimit?: number;
+
+  /**
+   * TODO
+   */
+  updatePolicy?: UpdatePolicy;
 }
 
 function restrictedCidrRanges(ranges: IPeer[]) {
@@ -352,6 +357,7 @@ export class GuEc2App extends Construct {
       privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app }),
       publicSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       instanceMetadataHopLimit,
+      updatePolicy,
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
@@ -400,6 +406,7 @@ export class GuEc2App extends Construct {
       ...(blockDevices && { blockDevices }),
       imageRecipe,
       httpPutResponseHopLimit: instanceMetadataHopLimit,
+      updatePolicy,
     });
 
     // This allows automatic shipping of instance Cloud Init logs when using the

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -300,7 +300,12 @@ export interface GuEc2AppProps extends AppIdentity {
   instanceMetadataHopLimit?: number;
 
   /**
-   * TODO
+   * Specify an update policy for the ASG created by this pattern.
+   *
+   * @see https://docs.aws.amazon.com/cdk/api/latest/docs/aws-autoscaling-readme.html#update-policy
+   *
+   * @defaultValue UpdatePolicy.none() - Cloudformation does not attempt to rotate instances in the ASG
+   * and must rely on riffraff to do so.
    */
   updatePolicy?: UpdatePolicy;
 }


### PR DESCRIPTION
## What does this change?

We want to try to replace some of riffraffs scaling behaviour by using UpdatePolicies to rotate instances in an ASG whenever a deployment happens instead of "manually" rotating the instances with RiffRaff.

## How to test

We used `npm link` to test these changes in cdk-playground and found them to work as we expect. We've also added a test to this PR to ensure that the update policy is correctly passed through to the Cloudformed ASG.