### PR TITLE
feat(ec2): Require explicit `UserData` type instead of `string` in Pattern props.

### DIFF
--- a/.changeset/thick-owls-remain.md
+++ b/.changeset/thick-owls-remain.md
@@ -1,0 +1,32 @@
+---
+"@guardian/cdk": major
+---
+
+GuCDK EC2 patterns now require an explicit `UserData` or `GuUserDataProps` input, instead of a string.
+
+The UserData class comes with helpers that allow us to mutate the user data in our patterns which will be helpful with some of our upcoming work.
+Unfortunately whenever a `string` is passed to our patterns we have to wrap it in a special `CustomUserData` class which disables most of these helpers.
+
+For applications that were already using `GuUserDataProps` no change is required, however applications that used strings will have to make a small change.
+
+```js
+new GuEc2App({
+  userData: `#!/usr/bin/bash echo "hello world"`,
+  ...
+})
+```
+
+becomes
+
+```js
+const userData = UserData.forLinux();
+userData.addCommands(`echo "hello world"`);
+
+new GuEc2App({
+  userData,
+  ...
+})
+```
+
+Note that you no longer need to specify a shebang, by default `UserData` adds one for you. If you need to customize this behaviour you can look at the props accepted by `forLinux`.
+You may also want to look at some of the other methods that UserData has to understand if it may be able to help you in other ways, for example `addS3DownloadCommand` the method helps you write commands to download from S3.

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -167,7 +167,7 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       app: "TestApp",
-      userData: "SomeUserData",
+      userData: UserData.forLinux(),
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       vpc,
       minimumInstances: 1,
@@ -194,7 +194,7 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       app: "TestApp",
-      userData: "UserData",
+      userData: UserData.forLinux(),
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       vpc,
       role: new GuInstanceRole(stack, {
@@ -243,7 +243,7 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       app: "TestApp",
-      userData: "SomeUserData",
+      userData: UserData.forLinux(),
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       vpc,
       minimumInstances: 3,
@@ -260,7 +260,7 @@ describe("The GuAutoScalingGroup", () => {
 
     new GuAutoScalingGroup(stack, "AutoscalingGroup", {
       app: "TestApp",
-      userData: "SomeUserData",
+      userData: UserData.forLinux(),
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       vpc,
       minimumInstances: 2,

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -1,8 +1,8 @@
 import { Tags, Token } from "aws-cdk-lib";
 import { AutoScalingGroup, GroupMetric, GroupMetrics } from "aws-cdk-lib/aws-autoscaling";
 import type { AutoScalingGroupProps, CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
-import { LaunchTemplate, OperatingSystemType, UserData } from "aws-cdk-lib/aws-ec2";
-import type { InstanceType, ISecurityGroup, MachineImageConfig } from "aws-cdk-lib/aws-ec2";
+import { LaunchTemplate, OperatingSystemType } from "aws-cdk-lib/aws-ec2";
+import type { InstanceType, ISecurityGroup, MachineImageConfig, UserData } from "aws-cdk-lib/aws-ec2";
 import type { ApplicationTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import type { GuAsgCapacity } from "../../types";
 import type { AmigoProps } from "../../types/amigo";
@@ -45,7 +45,7 @@ export interface GuAutoScalingGroupProps
    */
   imageRecipe?: string | AmigoProps;
   instanceType: InstanceType;
-  userData: UserData | string;
+  userData: UserData;
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
   withoutImdsv2?: boolean;
@@ -90,7 +90,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       maximumInstances,
       role = new GuInstanceRole(scope, { app }),
       targetGroup,
-      userData: userDataLike,
+      userData,
       vpc,
       withoutImdsv2 = false,
       httpPutResponseHopLimit,
@@ -103,8 +103,6 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
         "minimumInstances is defined via a Mapping, but maximumInstances is not. Create maximumInstances via a Mapping too.",
       );
     }
-
-    const userData = userDataLike instanceof UserData ? userDataLike : UserData.custom(userDataLike);
 
     // Generate an ID unique to this app
     const launchTemplateId = `${scope.stack}-${scope.stage}-${app}`;

--- a/src/constructs/autoscaling/user-data.ts
+++ b/src/constructs/autoscaling/user-data.ts
@@ -22,6 +22,7 @@ export interface GuUserDataProps {
  */
 export class GuUserData {
   private readonly _userData: UserData;
+  readonly configuration?: GuPrivateS3ConfigurationProps;
 
   get userData(): UserData {
     return this._userData;
@@ -64,6 +65,7 @@ export class GuUserData {
 
   constructor(scope: GuStack, props: GuUserDataPropsWithApp) {
     this._userData = UserData.forLinux();
+    this.configuration = props.configuration;
 
     if (props.configuration) {
       this.downloadConfiguration(scope, props.app, props.configuration);

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -966,7 +966,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
             },
           ],
           "UserData": {
-            "Fn::Base64": "#!/bin/dev foobarbaz",
+            "Fn::Base64": "#!/bin/bash",
           },
         },
         "TagSpecifications": [
@@ -1861,7 +1861,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
             },
           ],
           "UserData": {
-            "Fn::Base64": "#!/bin/dev foobarbaz",
+            "Fn::Base64": "#!/bin/bash",
           },
         },
         "TagSpecifications": [

--- a/src/patterns/ec2-app/framework.test.ts
+++ b/src/patterns/ec2-app/framework.test.ts
@@ -1,5 +1,5 @@
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
+import { InstanceClass, InstanceSize, InstanceType, UserData } from "aws-cdk-lib/aws-ec2";
 import { AccessScope } from "../../constants";
 import { simpleGuStackForTesting } from "../../utils/test";
 import { GuNodeApp, GuPlayApp, GuPlayWorkerApp } from "./framework";
@@ -12,7 +12,7 @@ describe("Framework level EC2 app patterns", () => {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
-      userData: "#!/bin/dev foobarbaz",
+      userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
         hostedZoneId: "id123",
@@ -34,7 +34,7 @@ describe("Framework level EC2 app patterns", () => {
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
-      userData: "#!/bin/dev foobarbaz",
+      userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
         hostedZoneId: "id123",
@@ -55,7 +55,7 @@ describe("Framework level EC2 app patterns", () => {
       app: "PlayApp",
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
-      userData: "#!/bin/dev foobarbaz",
+      userData: UserData.forLinux(),
       certificateProps: {
         domainName: "code-guardian.com",
         hostedZoneId: "id123",


### PR DESCRIPTION
## What does this change?

Updates our EC2 Pattern to require an explicit `UserData` prop instead of a `string`. This is part of our work to enable Cloudformation Replace deployments in our ASG.

This is a BREAKING change as applications relying on the type being a `string` will need to make a code change in order to update their GuCDK version.

Details on this change can be found in the included changeset file: [.changeset/thick-owls-remain.md](https://github.com/guardian/cdk/blob/24a6171cfb9e720817bfb2d461bfab5e5f4a4965/.changeset/thick-owls-remain.md)