### PR TITLE
Add detailed monitoring option to GuEC2App pattern

### DIFF
--- a/.changeset/fresh-icons-vanish.md
+++ b/.changeset/fresh-icons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+: feat(asg): Allow setting the detailedMonitoring option on launch templates provisioned by our EC2 patterns

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -50,6 +50,7 @@ export interface GuAutoScalingGroupProps
   targetGroup?: ApplicationTargetGroup;
   withoutImdsv2?: boolean;
   httpPutResponseHopLimit?: number;
+  enabledDetailedInstanceMonitoring?: boolean;
 }
 
 /**
@@ -95,6 +96,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       withoutImdsv2 = false,
       httpPutResponseHopLimit,
       updatePolicy,
+      enabledDetailedInstanceMonitoring,
     } = props;
 
     // Ensure min and max are defined in the same way. Throwing an `Error` when necessary. For example when min is defined via a Mapping, but max is not.
@@ -108,6 +110,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
     const launchTemplateId = `${scope.stack}-${scope.stage}-${app}`;
     const launchTemplate = new LaunchTemplate(scope, launchTemplateId, {
       blockDevices,
+      detailedMonitoring: enabledDetailedInstanceMonitoring,
       instanceType,
       machineImage: {
         getImage: (): MachineImageConfig => {

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -1123,4 +1123,32 @@ UserData from accessed construct`);
       },
     });
   });
+
+  it("set detailed monitoring on the ASG launch template when set", function () {
+    const stack = simpleGuStackForTesting();
+    new GuEc2App(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app",
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData: UserData.forLinux(),
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+      enabledDetailedInstanceMonitoring: true,
+    });
+    Template.fromStack(stack).hasResource("AWS::EC2::LaunchTemplate", {
+      Properties: {
+        LaunchTemplateData: {
+          Monitoring: {
+            Enabled: true,
+          },
+        },
+      },
+    });
+  });
 });

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -308,6 +308,13 @@ export interface GuEc2AppProps extends AppIdentity {
    * and must rely on riffraff to do so.
    */
   updatePolicy?: UpdatePolicy;
+
+  /**
+   * This setting configures the launch template to enable or disable detailed monitoring on instances.
+   *
+   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-monitoring.html
+   */
+  enabledDetailedInstanceMonitoring?: boolean;
 }
 
 function restrictedCidrRanges(ranges: IPeer[]) {
@@ -363,6 +370,7 @@ export class GuEc2App extends Construct {
       publicSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       instanceMetadataHopLimit,
       updatePolicy,
+      enabledDetailedInstanceMonitoring,
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
@@ -414,6 +422,7 @@ export class GuEc2App extends Construct {
       imageRecipe,
       httpPutResponseHopLimit: instanceMetadataHopLimit,
       updatePolicy,
+      enabledDetailedInstanceMonitoring,
     });
 
     // This allows automatic shipping of instance Cloud Init logs when using the


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR adds the ability to set the `detailedMonitoring` attribute on an auto scaling group's launch template when either creating one directly or via the Gu EC2 App pattern.

This option provides greater levels of metric gathering: 

> All metrics, including status check metrics, are available in 1-minute periods. To get this level of data, you must specifically enable it for the instance. For the instances where you've enabled detailed monitoring, you can also get aggregated data across groups of similar instances.

This was motivated by a requirement in Ophan to have certain metrics at a higher granularity to facilitate scaling policies. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->
I've added a unit test for this case, let me know if anything else would be useful. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
We can have CPU Utilisation at a minute interval for scaling policies in Ophan.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
