### PR TITLE
feat(experimental-ec2-pattern): Pattern to deploy ASGs updates via CloudFormation (`AutoScalingReplacingUpdate`)

### DIFF
--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -1,0 +1,997 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuDistributionBucketParameter",
+      "GuVpcParameter",
+      "GuSubnetListParameter",
+      "GuSubnetListParameter",
+      "GuEc2AppExperimental",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuSsmSshPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuWazuhAccess",
+      "GuAutoScalingGroup",
+      "GuApplicationLoadBalancer",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "LoadBalancerTestguec2appDnsName": {
+      "Description": "DNS entry for LoadBalancerTestguec2app",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerTestguec2appC77A055C",
+          "DNSName",
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "AMITestguec2app": {
+      "Description": "Amazon Machine Image ID for the app test-gu-ec2-app. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "VpcId": {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "testguec2appPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "testguec2appPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+  },
+  "Resources": {
+    "AsgReplacingUpdatePolicy78CF34D5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgReplacingUpdatePolicy78CF34D5",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupTestguec2appASG49EA1878": {
+      "CreationPolicy": {
+        "AutoScalingCreationPolicy": {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": {
+          "Count": 1,
+          "Timeout": "PT5M",
+        },
+      },
+      "Properties": {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestguec2appAA7F41BE",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestguec2appAA7F41BE",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "MaxSize": "2",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+            "Metrics": [
+              "GroupTotalInstances",
+              "GroupInServiceInstances",
+            ],
+          },
+        ],
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupTestguec2app9F67D503",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "testguec2appPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingReplacingUpdate": {
+          "WillReplace": true,
+        },
+        "AutoScalingScheduledAction": {
+          "IgnoreUnmodifiedGroupSizeProperties": true,
+        },
+      },
+    },
+    "CertificateTestguec2app86EE2D42": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "domain-name-for-your-application.example",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Name",
+            "Value": "Test/CertificateTestguec2app",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyTestguec2app6A8D1854": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/test-stack/TEST/test-gu-ec2-app/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyTestguec2app6A8D1854",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupTestguec2appEBD7B195": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupTestguec2appfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C99000A9F74C7B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleTestguec2appC325BE42": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ListenerTestguec2app4FBB034F": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateTestguec2app86EE2D42",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupTestguec2app9F67D503",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerTestguec2appC77A055C",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerTestguec2appC77A055C": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "testguec2appPublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerTestguec2appSecurityGroupCC6F85C1": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB TestLoadBalancerTestguec2app8CD12AE9",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerTestguec2appSecurityGrouptoTestGuHttpsEgressSecurityGroupTestguec2appE5EE51F5900063A5B571": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerTestguec2appSecurityGrouptoTestWazuhSecurityGroup8092AEDC9000720EFF26": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ParameterStoreReadTestguec2app072DCDE1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/test-gu-ec2-app",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/test-gu-ec2-app/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupTestguec2app9F67D503": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "WazuhSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C99000BB163DB4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "teststackTESTtestguec2appAA7F41BE": {
+      "DependsOn": [
+        "InstanceRoleTestguec2appC325BE42",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguec2appProfileC5759753",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestguec2app",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "test-gu-ec2-app",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "test-gu-ec2-app",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupTestguec2appASG49EA1878           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
+mkdir -p $(dirname '/test-gu-ec2-app/test-gu-ec2-app-123.deb')
+aws s3 cp 's3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/test-stack/TEST/test-gu-ec2-app/test-gu-ec2-app-123.deb' '/test-gu-ec2-app/test-gu-ec2-app-123.deb'
+dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
+
+      INSTANCE_ID=$(ec2metadata --instance-id)
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupTestguec2app9F67D503",
+                  },
+                  "         --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupTestguec2app9F67D503",
+                  },
+                  "           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+      ",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "test-gu-ec2-app",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguec2appProfileC5759753": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+  },
+}
+`;

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -916,6 +916,7 @@ aws s3 cp 's3://",
                   },
                   "/test-stack/TEST/test-gu-ec2-app/test-gu-ec2-app-123.deb' '/test-gu-ec2-app/test-gu-ec2-app-123.deb'
 dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
+# GuEc2AppExperimental UserData Start
 
       INSTANCE_ID=$(ec2metadata --instance-id)
 
@@ -942,7 +943,8 @@ dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
                   },
                   "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
       done
-      ",
+      
+# GuEc2AppExperimental UserData End",
                 ],
               ],
             },

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -1,0 +1,147 @@
+import { Duration } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
+import { AccessScope } from "../../constants";
+import { GuUserData } from "../../constructs/autoscaling";
+import type { GuStack } from "../../constructs/core";
+import { simpleGuStackForTesting } from "../../utils/test";
+import type { GuEc2AppExperimentalProps } from "./ec2-app";
+import { GuEc2AppExperimental } from "./ec2-app";
+
+// TODO test User Data includes a build number
+describe("The GuEc2AppExperimental pattern", () => {
+  function initialProps(scope: GuStack): GuEc2AppExperimentalProps {
+    const app = "test-gu-ec2-app";
+    const buildNumber = 123;
+
+    const { userData } = new GuUserData(scope, {
+      app,
+      distributable: {
+        fileName: `${app}-${buildNumber}.deb`,
+        executionStatement: `dpkg -i /${app}/${app}-${buildNumber}.deb`,
+      },
+    });
+
+    return {
+      applicationPort: 9000,
+      app,
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData,
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+    };
+  }
+
+  it("matches the snapshot", () => {
+    const stack = simpleGuStackForTesting();
+    new GuEc2AppExperimental(stack, initialProps(stack));
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+
+  it("should create an ASG with an UpdatePolicy and CreationPolicy", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEc2AppExperimental(stack, initialProps(stack));
+
+    Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      CreationPolicy: {
+        AutoScalingCreationPolicy: {
+          MinSuccessfulInstancesPercent: 100,
+        },
+        ResourceSignal: {
+          Count: 1,
+          Timeout: "PT5M",
+        },
+      },
+      UpdatePolicy: {
+        AutoScalingReplacingUpdate: {
+          WillReplace: true,
+        },
+        AutoScalingScheduledAction: {
+          IgnoreUnmodifiedGroupSizeProperties: true,
+        },
+      },
+    });
+  });
+
+  it("should create an ASG with a resource signal count that matches the min instances", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEc2AppExperimental(stack, { ...initialProps(stack), scaling: { minimumInstances: 5 } });
+
+    Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+      },
+      CreationPolicy: {
+        AutoScalingCreationPolicy: {
+          MinSuccessfulInstancesPercent: 100,
+        },
+        ResourceSignal: {
+          Count: 5,
+          Timeout: "PT5M",
+        },
+      },
+      UpdatePolicy: {
+        AutoScalingReplacingUpdate: {
+          WillReplace: true,
+        },
+        AutoScalingScheduledAction: {
+          IgnoreUnmodifiedGroupSizeProperties: true,
+        },
+      },
+    });
+  });
+
+  it("should create an ASG with the maximum resource signal timeout", () => {
+    const stack = simpleGuStackForTesting();
+
+    const targetGroupHealthcheckTimeout = Duration.minutes(7);
+
+    new GuEc2AppExperimental(stack, {
+      ...initialProps(stack),
+      healthcheck: {
+        timeout: targetGroupHealthcheckTimeout,
+        interval: Duration.seconds(targetGroupHealthcheckTimeout.toSeconds() + 60),
+      },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // The Target Group times out in 7 minutes.
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckTimeoutSeconds: targetGroupHealthcheckTimeout.toSeconds(),
+    });
+
+    // The ASG grace period is 2 minutes, which is less than the Target Group.
+    // Therefore, the resource signal timeout should be 7 minutes.
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        HealthCheckGracePeriod: 120,
+      },
+      CreationPolicy: {
+        AutoScalingCreationPolicy: {
+          MinSuccessfulInstancesPercent: 100,
+        },
+        ResourceSignal: {
+          Count: 1,
+          Timeout: targetGroupHealthcheckTimeout.toIsoString(),
+        },
+      },
+      UpdatePolicy: {
+        AutoScalingReplacingUpdate: {
+          WillReplace: true,
+        },
+        AutoScalingScheduledAction: {
+          IgnoreUnmodifiedGroupSizeProperties: true,
+        },
+      },
+    });
+  });
+});

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -1,6 +1,6 @@
 import { Duration } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
+import { InstanceClass, InstanceSize, InstanceType, UserData } from "aws-cdk-lib/aws-ec2";
 import { AccessScope } from "../../constants";
 import { GuUserData } from "../../constructs/autoscaling";
 import type { GuStack } from "../../constructs/core";
@@ -143,5 +143,29 @@ describe("The GuEc2AppExperimental pattern", () => {
         },
       },
     });
+  });
+
+  it("should add to the end of the user data", () => {
+    const stack = simpleGuStackForTesting();
+
+    const userDataCommand = `echo "Hello there"`;
+    const userData = UserData.forLinux();
+    userData.addCommands(userDataCommand);
+
+    const { autoScalingGroup } = new GuEc2AppExperimental(stack, { ...initialProps(stack), userData });
+
+    const renderedUserData = autoScalingGroup.userData.render();
+    const splitUserData = renderedUserData.split("\n");
+    const totalLines = splitUserData.length;
+
+    const appCommandPosition = splitUserData.indexOf(userDataCommand);
+    const startMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental UserData Start");
+    const endMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental UserData End");
+
+    // Application user data should be before the target group healthcheck polling.
+    expect(appCommandPosition).toBeLessThan(startMarkerPosition);
+
+    // The target group healthcheck polling should be the last thing in the user data.
+    expect(endMarkerPosition).toEqual(totalLines - 1);
   });
 });

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -49,6 +49,7 @@ export class GuEc2AppExperimental extends GuEc2App {
     See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
      */
     userData.addCommands(
+      `# ${GuEc2AppExperimental.name} UserData Start`,
       `
       INSTANCE_ID=$(ec2metadata --instance-id)
 
@@ -68,6 +69,7 @@ export class GuEc2AppExperimental extends GuEc2App {
           --query "TargetHealthDescriptions[0].TargetHealth.State")
       done
       `,
+      `# ${GuEc2AppExperimental.name} UserData End`,
     );
 
     userData.addOnExitCommands(

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -1,0 +1,99 @@
+import { Duration } from "aws-cdk-lib";
+import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { GuStack } from "../../constructs/core";
+import type { GuEc2AppProps } from "../../patterns";
+import { GuEc2App } from "../../patterns";
+
+export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePolicy"> {}
+
+export class GuEc2AppExperimental extends GuEc2App {
+  constructor(scope: GuStack, props: GuEc2AppExperimentalProps) {
+    super(scope, { ...props, updatePolicy: UpdatePolicy.replacingUpdate() });
+
+    const { applicationPort } = props;
+    const { minimumInstances } = props.scaling;
+    const { region, stackId } = scope;
+    const { autoScalingGroup, targetGroup } = this;
+    const { userData, role } = autoScalingGroup;
+    const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+
+    new Policy(scope, "AsgReplacingUpdatePolicy", {
+      statements: [
+        // Allow usage of command `cfn-signal`.
+        new PolicyStatement({
+          actions: ["cloudformation:SignalResource"],
+          effect: Effect.ALLOW,
+          resources: [stackId],
+        }),
+
+        /*
+        Allow usage of command `aws elbv2 describe-target-health`.
+        AWS Elastic Load Balancing does not support resource based policies, so the resource has to be `*` (any) here.
+        See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html
+         */
+        new PolicyStatement({
+          actions: ["elasticloadbalancing:DescribeTargetHealth"],
+          effect: Effect.ALLOW,
+          resources: ["*"],
+        }),
+      ],
+    }).attachToRole(role);
+
+    /*
+    `ec2metadata` is available via `cloud-utils` installed on all Canonical Ubuntu AMIs.
+    See https://github.com/canonical/cloud-utils.
+
+    `aws` is available via AMIgo baked AMIs.
+    See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
+     */
+    userData.addCommands(
+      `
+      INSTANCE_ID=$(ec2metadata --instance-id)
+
+      STATE=$(aws elbv2 describe-target-health \
+        --target-group-arn ${targetGroup.targetGroupArn} \
+        --region ${region} \
+        --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+        --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health \
+          --target-group-arn ${targetGroup.targetGroupArn} \
+          --region ${region} \
+          --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+          --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+      `,
+    );
+
+    userData.addOnExitCommands(
+      `
+        cfn-signal --stack ${stackId} \
+          --resource ${cfnAutoScalingGroup.logicalId} \
+          --region ${region} \
+          --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        `,
+    );
+
+    // TODO are these sensible values?
+    const signalTimeoutSeconds = Math.max(
+      targetGroup.healthCheck.timeout?.toSeconds() ?? 0,
+      cfnAutoScalingGroup.healthCheckGracePeriod ?? 0,
+      Duration.minutes(5).toSeconds(),
+    );
+
+    cfnAutoScalingGroup.cfnOptions.creationPolicy = {
+      autoScalingCreationPolicy: {
+        minSuccessfulInstancesPercent: 100,
+      },
+      resourceSignal: {
+        count: minimumInstances,
+        timeout: Duration.seconds(signalTimeoutSeconds).toIsoString(),
+      },
+    };
+  }
+}

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -8,6 +8,37 @@ import { GuEc2App } from "../../patterns";
 
 export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePolicy"> {}
 
+/**
+ * An experimental pattern to instantiate an EC2 application that is updated entirely via CloudFormation.
+ *
+ * NOTE: The "autoscaling" deployment type in Riff-Raff is not valid with this pattern.
+ * Please remove it from any manually created `riff-raff.yaml` file.
+ *
+ * This pattern sets the update policy of the `AWS::AutoScaling::AutoScalingGroup` to `AutoScalingReplacingUpdate`.
+ * When a CloudFormation update is applied, a SECOND autoscaling group is created alongside the current one.
+ * Once all instances in the new ASG are healthy in the target group, CloudFormation will remove the current ASG,
+ * leaving one ASG provisioned.
+ *
+ * This pattern also updates the User Data, running some commands AFTER yours.
+ * These changes are wrapped in start and end marking comments.
+ *
+ * This pattern should improve the reliability of scaling events triggered during a deployment.
+ * Unlike in Riff-Raff's "autoscaling" deployment, scaling alarms are never suspended.
+ * TODO test scaling alarm behaviour.
+ *
+ * To update the application's code, a CloudFormation update must be triggered.
+ * The best way to do this is to include the build number in the application artifact.
+ * TODO test User Data includes a build number.
+ *
+ * NOTE: This pattern:
+ *  - Is NOT compatible with the "autoscaling" Riff-Raff deployment type.
+ *  - Your application should include a build number in its filename.
+ *    This value will change across builds, and therefore create a CloudFormation template difference to be deployed.
+ *  - Requires the AWS CLI and `cfn-signal` binaries to be available on the instance, and on the `PATH`.
+ *    AMIgo adds these via the `aws-tools` role.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html
+ */
 export class GuEc2AppExperimental extends GuEc2App {
   constructor(scope: GuStack, props: GuEc2AppExperimentalProps) {
     super(scope, { ...props, updatePolicy: UpdatePolicy.replacingUpdate() });

--- a/src/riff-raff-yaml-file/index.test.ts
+++ b/src/riff-raff-yaml-file/index.test.ts
@@ -7,6 +7,7 @@ import { AccessScope } from "../constants";
 import type { GuStackProps } from "../constructs/core";
 import { GuStack } from "../constructs/core";
 import { GuLambdaFunction } from "../constructs/lambda";
+import { GuEc2AppExperimental } from "../experimental/patterns/ec2-app";
 import { GuEc2App, GuNodeApp, GuPlayApp, GuScheduledLambda } from "../patterns";
 import { RiffRaffYamlFile } from "./index";
 
@@ -1287,6 +1288,83 @@ describe("The RiffRaffYamlFile class", () => {
           applicationPort: 9000,
           imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
           updatePolicy: UpdatePolicy.replacingUpdate(),
+        });
+      }
+    }
+
+    new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
+
+    const actual = new RiffRaffYamlFile(app).toYAML();
+
+    expect(actual).toMatchInlineSnapshot(`
+      "allowedStages:
+        - TEST
+      deployments:
+        asg-upload-eu-west-1-test-my-app:
+          type: autoscaling
+          actions:
+            - uploadArtifacts
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-app
+          parameters:
+            bucketSsmLookup: true
+            prefixApp: true
+          contentDirectory: my-app
+        cfn-eu-west-1-test-my-application-stack:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-application-stack
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              TEST: test-stack.template.json
+            amiParametersToTags:
+              AMIMyapp:
+                BuiltBy: amigo
+                AmigoStage: PROD
+                Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
+          dependencies:
+            - asg-upload-eu-west-1-test-my-app
+      "
+    `);
+  });
+
+  it("Should only upload artifacts for a GuEc2AppExperimental", () => {
+    const app = new App({ outdir: "/tmp/cdk.out" });
+
+    class MyApplicationStack extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- unit testing
+      constructor(app: App, id: string, props: GuStackProps) {
+        super(app, id, props);
+
+        const appName = "my-app";
+
+        new GuEc2AppExperimental(this, {
+          app: appName,
+          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+          access: { scope: AccessScope.PUBLIC },
+          userData: {
+            distributable: {
+              fileName: `${appName}.deb`,
+              executionStatement: `dpkg -i /${appName}/${appName}.deb`,
+            },
+          },
+          certificateProps: {
+            domainName: "rip.gu.com",
+          },
+          monitoringConfiguration: { noMonitoring: true },
+          scaling: {
+            minimumInstances: 1,
+          },
+          applicationPort: 9000,
+          imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
         });
       }
     }


### PR DESCRIPTION
> [!NOTE]
> This is an alternative take of https://github.com/guardian/cdk/pull/2379, differing mostly in the creation of an [experimental](https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/005-x01-package-structure.md) pattern. The intention is to provide a strong signal that this feature is not yet considered ready for use on high-profile services.
> 
> Another point of difference is usage tracking via the [`Metadata` Aspect](https://github.com/guardian/cdk/blob/main/src/aspects/metadata.ts)  rather than tags. The Aspect updates the stack's `Metadata` section with a list of GuCDK constructs being used.

## What does this change?
This change adds a new [experimental](https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/005-x01-package-structure.md) pattern `GuEc2AppExperimental` for provisioning an EC2 based service deployed entirely via CloudFormation updates. This is achieved by setting the `UpdatePolicy` attribute of the ASG, specifically [`AutoScalingReplaceUpdate`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-replacingupdate) is employed.

With an `AutoScalingReplaceUpdate` policy, a CloudFormation update will create a second ASG, and:

> After successfully creating the new Auto Scaling group, CloudFormation deletes the old Auto Scaling group during the cleanup process.
> – https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-replacingupdate

The CloudFormation update remains `IN_PROGRESS` until the instances in the ASG report healthy. By default this is defined as instance health (did the instance boot correctly), whereas we want an instance to be healthy only once the target group can see it. For this reason, we implement some custom logic in the user-data.

The resulting user-data works like this:
1. Perform the user-data commands provided by the service (i.e. download the artifact, and run it).
2. Start polling the target group for the health of the current instance.
3. Once the instance is healthy, send a [signal](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-signal.html) to indicate success.

On success, the CloudFormation update status moves to `UPDATE_COMPLETE`, and the deployment succeeds. The final state is one ASG, running the new version of the service.

If the target group is unable to report the instance as healthy, then a signal is sent indicating this. The CloudFormation update status moves to `UPDATE_FAILED`, and the changes are rolled back. The final state is one ASG, running the current version of the service.

Updating a service via this mechanism differs from Riff-Raff's `autoscaling` deployment in one key way: the current ASG can continue to scale if needed. In Riff-Raff's [process](https://github.com/guardian/riff-raff/blob/424bff5c2c3e8a37f8546c4f4cee3e31eb3a25b1/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala#L169-L217), scaling alarms are disabled before doubling the desired capacity of the ASG, and enabled again once the capacity has been halved (technically after the halving _request_ has been made).

The `GuEc2AppExperimental` pattern is not compatible with Riff-Raff's `autoscaling` deployment type too. As a pre-flight check, Riff-Raff checks there is exactly one ASG matching the tagging specification. As we're creating a second, this check will fail. Consequently, the `riff-raff.yaml` generator has been updated to omit the `autoscaling` deployment.

### Why `experimental`?
There are a few requirements for this approach:
- The AWS CLI, and `cfn-signal` binaries need to be available and on the `PATH` (this is added via the [AMIgo role `aws-tools`](https://github.com/guardian/amigo/tree/main/roles/aws-tools))
- The service's artifact should include a build number, as this is the most reliable way to create a difference with the running CloudFormation template, and thus trigger an update.

We're not (yet) validating these are met as its tricky.

There are also a few of unknowns about this approach:
- What is the best signal timeout value?
- If the current ASG scales mid-deployment, how does this impact the new ASG? Is the desired mirrored?

For this reason, the rollout plan looks something like this:
1. Dogfood on some DevX services.
2. Test on a service within the department.
3. Move the pattern to stable, as a breaking change, with communication on the migration path, etc.

## How to test
For a real-world test, I've been using the pattern (and the update to the generated `riff-raff.yaml` file) within `guardian/cdk-playground` - https://github.com/guardian/cdk-playground/pull/496.

Additional testing has been done via unit tests.

## How can we measure success?
ASGs can scale _during_ deployment.

## Have we considered potential risks?
As noted above, there are some unknowns. Any service that starts using this pattern in its `experimental` form implicitly accepts the risk of these unknowns.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
