### PR TITLE
Only set an SSL policy on HTTPS application listeners

### DIFF
--- a/.changeset/perfect-hats-allow.md
+++ b/.changeset/perfect-hats-allow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Only set an SSL policy on HTTPS application listeners

--- a/src/constructs/loadbalancing/alb/application-listener.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.ts
@@ -52,7 +52,7 @@ export class GuHttpsApplicationListener extends GuAppAwareConstruct(ApplicationL
     const mergedProps: GuApplicationListenerProps = {
       port: certificate ? 443 : 8080,
       protocol: certificate ? ApplicationProtocol.HTTPS : ApplicationProtocol.HTTP,
-      sslPolicy: SslPolicy.RECOMMENDED_TLS,
+      sslPolicy: certificate ? SslPolicy.RECOMMENDED_TLS : undefined,
       ...props,
       certificates: certificate
         ? [


### PR DESCRIPTION

## What does this change?

SslPolicy is not valid on HTTP listeners, and if set causes deploy to fail - see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html#cfn-elasticloadbalancingv2-listener-sslpolicy

Uses the same condition as the protocol switcher to disable the sslPolicy if a certificate isn't defined, meaning we're building an HTTP listener.

## How to test

Create and deploy a stack using an HTTP listener is now possible