### PR TITLE
feat(experimental-ec2-pattern): Pattern to deploy ASG updates w/CFN

### DIFF
--- a/.changeset/happy-badgers-compare.md
+++ b/.changeset/happy-badgers-compare.md
@@ -1,0 +1,43 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(experimental-ec2-pattern): Pattern to deploy ASG updates w/CFN
+
+Included in this update is a new experimental pattern `GuEc2AppExperimental`, which can be used in place of a `GuEc2App`:
+
+```ts
+import { GuEc2AppExperimental } from "@guardian/cdk/lib/experimental/patterns/ec2-app";
+```
+
+This pattern will add an [`AutoScalingRollingUpdate` policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate)
+to the autoscaling group.
+This allows application updates to be performed like a standard CloudFormation update,
+and using the custom logic provided by Riff-Raff's `autoscaling` deployment type is unnecessary.
+
+This experimental pattern has few requirements.
+
+## Add the build number to the application artifact
+This change requires versioned artifacts.
+
+The easiest way to achieve this is by adding the build number to the filename of the artifact:
+
+```ts
+import { UserData } from "aws-cdk-lib/aws-ec2";
+// Use a GitHub Actions provided environment variable
+const buildNumber = process.env.GITHUB_RUN_NUMBER ?? "DEV";
+
+const userData = UserData.forLinux();
+userData.addCommands(`aws s3 cp s3://dist-bucket/path/to/artifact-${buildNumber}.deb /tmp/artifact.deb`);
+userData.addCommands(`dpkg -i /tmp/artifact.dep`);
+```
+
+## `riff-raff.yaml`
+The `riff-raff.yaml` file should remove the `deploy` action of the `autoscaling` deployment type.
+Though including it shouldn't break anything, it would result in a longer deployment time as instance will be rotated by both CloudFormation and Riff-Raff's custom logic.
+
+The `uploadArtifacts` step of the `autoscaling` deployment type should still be included, with the `cloud-formation` deployment type depending on it.
+This step uploads the versioned artifact to S3.
+
+> [!TIP]
+> An [auto-generated `riff-raff.yaml` file](https://github.com/guardian/cdk/blob/main/src/riff-raff-yaml-file/README.md) meets this requirement.

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -110,6 +110,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
         },
       },
       "Properties": {
+        "DesiredCapacity": "1",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -106,7 +106,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
         },
         "ResourceSignal": {
           "Count": 1,
-          "Timeout": "PT5M",
+          "Timeout": "PT2M",
         },
       },
       "Properties": {
@@ -180,7 +180,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           "MaxBatchSize": 2,
           "MinInstancesInService": 1,
           "MinSuccessfulInstancesPercent": 100,
-          "PauseTime": "PT5M",
+          "PauseTime": "PT2M",
           "SuspendProcesses": [
             "AlarmNotification",
           ],

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -920,7 +920,8 @@ aws s3 cp 's3://",
 dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
 # GuEc2AppExperimental UserData Start
 
-      INSTANCE_ID=$(ec2metadata --instance-id)
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
 
       STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
                   {

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -917,6 +917,7 @@ aws s3 cp 's3://",
                   },
                   "/test-stack/TEST/test-gu-ec2-app/test-gu-ec2-app-123.deb' '/test-gu-ec2-app/test-gu-ec2-app-123.deb'
 dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
+# GuEc2AppExperimental UserData Start
 
       INSTANCE_ID=$(ec2metadata --instance-id)
 
@@ -945,7 +946,8 @@ dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
       done
 
       echo "Instance is healthy in target group."
-      ",
+      
+# GuEc2AppExperimental UserData End",
                 ],
               ],
             },

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -71,7 +71,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AsgReplacingUpdatePolicy78CF34D5": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -90,7 +90,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "AsgReplacingUpdatePolicy78CF34D5",
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguec2appC325BE42",

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -1,0 +1,1000 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuDistributionBucketParameter",
+      "GuVpcParameter",
+      "GuSubnetListParameter",
+      "GuSubnetListParameter",
+      "GuEc2AppExperimental",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuSsmSshPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuWazuhAccess",
+      "GuAutoScalingGroup",
+      "GuApplicationLoadBalancer",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "LoadBalancerTestguec2appDnsName": {
+      "Description": "DNS entry for LoadBalancerTestguec2app",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerTestguec2appC77A055C",
+          "DNSName",
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "AMITestguec2app": {
+      "Description": "Amazon Machine Image ID for the app test-gu-ec2-app. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "VpcId": {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "testguec2appPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "testguec2appPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+  },
+  "Resources": {
+    "AsgReplacingUpdatePolicy78CF34D5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgReplacingUpdatePolicy78CF34D5",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupTestguec2appASG49EA1878": {
+      "CreationPolicy": {
+        "AutoScalingCreationPolicy": {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": {
+          "Count": 1,
+          "Timeout": "PT5M",
+        },
+      },
+      "Properties": {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestguec2appAA7F41BE",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestguec2appAA7F41BE",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "MaxSize": "2",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+          },
+        ],
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupTestguec2app9F67D503",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "testguec2appPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MaxBatchSize": 2,
+          "MinInstancesInService": 1,
+          "MinSuccessfulInstancesPercent": 100,
+          "SuspendProcesses": [],
+          "WaitOnResourceSignals": true,
+        },
+        "AutoScalingScheduledAction": {
+          "IgnoreUnmodifiedGroupSizeProperties": true,
+        },
+      },
+    },
+    "CertificateTestguec2app86EE2D42": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "domain-name-for-your-application.example",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Name",
+            "Value": "Test/CertificateTestguec2app",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyTestguec2app6A8D1854": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/test-stack/TEST/test-gu-ec2-app/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyTestguec2app6A8D1854",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupTestguec2appEBD7B195": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupTestguec2appfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C99000A9F74C7B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleTestguec2appC325BE42": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ListenerTestguec2app4FBB034F": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateTestguec2app86EE2D42",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupTestguec2app9F67D503",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerTestguec2appC77A055C",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerTestguec2appC77A055C": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "testguec2appPublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerTestguec2appSecurityGroupCC6F85C1": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB TestLoadBalancerTestguec2app8CD12AE9",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerTestguec2appSecurityGrouptoTestGuHttpsEgressSecurityGroupTestguec2appE5EE51F5900063A5B571": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerTestguec2appSecurityGrouptoTestWazuhSecurityGroup8092AEDC9000720EFF26": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ParameterStoreReadTestguec2app072DCDE1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/test-gu-ec2-app",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/test-gu-ec2-app/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupTestguec2app9F67D503": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu-ec2-app",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "WazuhSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromTestLoadBalancerTestguec2appSecurityGroup5F9E11C99000BB163DB4": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguec2appSecurityGroupCC6F85C1",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "teststackTESTtestguec2appAA7F41BE": {
+      "DependsOn": [
+        "InstanceRoleTestguec2appC325BE42",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguec2appProfileC5759753",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestguec2app",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestguec2appEBD7B195",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "test-gu-ec2-app",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "test-gu-ec2-app",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupTestguec2appASG49EA1878           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
+mkdir -p $(dirname '/test-gu-ec2-app/test-gu-ec2-app-123.deb')
+aws s3 cp 's3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/test-stack/TEST/test-gu-ec2-app/test-gu-ec2-app-123.deb' '/test-gu-ec2-app/test-gu-ec2-app-123.deb'
+dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
+
+      INSTANCE_ID=$(ec2metadata --instance-id)
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupTestguec2app9F67D503",
+                  },
+                  "         --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupTestguec2app9F67D503",
+                  },
+                  "           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance is healthy in target group."
+      ",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "test-gu-ec2-app",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu-ec2-app",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguec2appProfileC5759753": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguec2appC325BE42",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+  },
+}
+`;

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -180,11 +180,9 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           "MaxBatchSize": 2,
           "MinInstancesInService": 1,
           "MinSuccessfulInstancesPercent": 100,
+          "PauseTime": "PT5M",
           "SuspendProcesses": [],
           "WaitOnResourceSignals": true,
-        },
-        "AutoScalingScheduledAction": {
-          "IgnoreUnmodifiedGroupSizeProperties": true,
         },
       },
     },

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -181,7 +181,9 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           "MinInstancesInService": 1,
           "MinSuccessfulInstancesPercent": 100,
           "PauseTime": "PT5M",
-          "SuspendProcesses": [],
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
           "WaitOnResourceSignals": true,
         },
       },

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -1,17 +1,17 @@
-import { Duration } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { App, Duration } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { InstanceClass, InstanceSize, InstanceType, UserData } from "aws-cdk-lib/aws-ec2";
+import { CloudFormationStackArtifact } from "aws-cdk-lib/cx-api";
 import { AccessScope } from "../../constants";
 import { GuUserData } from "../../constructs/autoscaling";
-import type { GuStack } from "../../constructs/core";
+import { GuStack } from "../../constructs/core";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { GuEc2AppExperimentalProps } from "./ec2-app";
 import { GuEc2AppExperimental } from "./ec2-app";
 
 // TODO test User Data includes a build number
 describe("The GuEc2AppExperimental pattern", () => {
-  function initialProps(scope: GuStack): GuEc2AppExperimentalProps {
-    const app = "test-gu-ec2-app";
+  function initialProps(scope: GuStack, app: string = "test-gu-ec2-app"): GuEc2AppExperimentalProps {
     const buildNumber = 123;
 
     const { userData } = new GuUserData(scope, {
@@ -139,5 +139,68 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     // The target group healthcheck polling should be the last thing in the user data.
     expect(endMarkerPosition).toEqual(totalLines - 1);
+  });
+
+  it("should adjust properties of a horizontally scaling service", () => {
+    const cdkApp = new App();
+    const stack = new GuStack(cdkApp, "test", {
+      stack: "test-stack",
+      stage: "TEST",
+    });
+
+    const scalingApp = "my-scaling-app";
+    const { autoScalingGroup } = new GuEc2AppExperimental(stack, {
+      ...initialProps(stack, scalingApp),
+      scaling: {
+        minimumInstances: 5,
+      },
+    });
+    autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 100,
+    });
+
+    /*
+    We're ultimately testing an `Aspect`, which appear to run only at synth time.
+    As a work-around, synth the `App`, then perform assertions on the resulting template.
+
+    See also: https://github.com/aws/aws-cdk/issues/29047.
+     */
+    const { artifacts } = cdkApp.synth();
+    const cfnStack = artifacts.find((_): _ is CloudFormationStackArtifact => _ instanceof CloudFormationStackArtifact);
+
+    if (!cfnStack) {
+      throw new Error("Unable to locate a CloudFormationStackArtifact");
+    }
+
+    const template = Template.fromJSON(cfnStack.template as Record<string, unknown>);
+
+    const parameterName = `MinInstancesInServiceFor${scalingApp.replaceAll("-", "")}`;
+
+    template.hasParameter(parameterName, {
+      Type: "Number",
+      Default: 5,
+      MaxValue: 9, // (min * 2) - 1
+    });
+
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+        MaxSize: "10",
+        DesiredCapacity: Match.absent(),
+        Tags: Match.arrayWith([{ Key: "App", Value: scalingApp, PropagateAtLaunch: true }]),
+      },
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          MaxBatchSize: 10,
+          SuspendProcesses: ["AlarmNotification"],
+          MinSuccessfulInstancesPercent: 100,
+          WaitOnResourceSignals: true,
+          PauseTime: "PT5M",
+          MinInstancesInService: {
+            Ref: parameterName,
+          },
+        },
+      },
+    });
   });
 });

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -1,0 +1,105 @@
+import { Duration } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
+import { AccessScope } from "../../constants";
+import { GuUserData } from "../../constructs/autoscaling";
+import type { GuStack } from "../../constructs/core";
+import { simpleGuStackForTesting } from "../../utils/test";
+import type { GuEc2AppExperimentalProps } from "./ec2-app";
+import { GuEc2AppExperimental } from "./ec2-app";
+
+// TODO test User Data includes a build number
+describe("The GuEc2AppExperimental pattern", () => {
+  function initialProps(scope: GuStack): GuEc2AppExperimentalProps {
+    const app = "test-gu-ec2-app";
+    const buildNumber = 123;
+
+    const { userData } = new GuUserData(scope, {
+      app,
+      distributable: {
+        fileName: `${app}-${buildNumber}.deb`,
+        executionStatement: `dpkg -i /${app}/${app}-${buildNumber}.deb`,
+      },
+    });
+
+    return {
+      applicationPort: 9000,
+      app,
+      access: { scope: AccessScope.PUBLIC },
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+      monitoringConfiguration: { noMonitoring: true },
+      userData,
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      scaling: {
+        minimumInstances: 1,
+      },
+    };
+  }
+
+  it("matches the snapshot", () => {
+    const stack = simpleGuStackForTesting();
+    new GuEc2AppExperimental(stack, initialProps(stack));
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+
+  it("should create an ASG with a resource signal count that matches the min instances", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEc2AppExperimental(stack, { ...initialProps(stack), scaling: { minimumInstances: 5 } });
+
+    Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+      },
+      CreationPolicy: {
+        AutoScalingCreationPolicy: {
+          MinSuccessfulInstancesPercent: 100,
+        },
+        ResourceSignal: {
+          Count: 5,
+          Timeout: "PT5M",
+        },
+      },
+    });
+  });
+
+  it("should create an ASG with the maximum resource signal timeout", () => {
+    const stack = simpleGuStackForTesting();
+
+    const targetGroupHealthcheckTimeout = Duration.minutes(7);
+
+    new GuEc2AppExperimental(stack, {
+      ...initialProps(stack),
+      healthcheck: {
+        timeout: targetGroupHealthcheckTimeout,
+        interval: Duration.seconds(targetGroupHealthcheckTimeout.toSeconds() + 60),
+      },
+    });
+
+    const template = Template.fromStack(stack);
+
+    // The Target Group times out in 7 minutes.
+    template.hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckTimeoutSeconds: targetGroupHealthcheckTimeout.toSeconds(),
+    });
+
+    // The ASG grace period is 2 minutes, which is less than the Target Group.
+    // Therefore, the resource signal timeout should be 7 minutes.
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        HealthCheckGracePeriod: 120,
+      },
+      CreationPolicy: {
+        AutoScalingCreationPolicy: {
+          MinSuccessfulInstancesPercent: 100,
+        },
+        ResourceSignal: {
+          Count: 1,
+          Timeout: targetGroupHealthcheckTimeout.toIsoString(),
+        },
+      },
+    });
+  });
+});

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -203,4 +203,97 @@ describe("The GuEc2AppExperimental pattern", () => {
       },
     });
   });
+
+  it("should only adjust properties of a horizontally scaling service", () => {
+    const cdkApp = new App();
+    const stack = new GuStack(cdkApp, "test", {
+      stack: "test-stack",
+      stage: "TEST",
+    });
+
+    const scalingApp = "my-scaling-app";
+    const { autoScalingGroup } = new GuEc2AppExperimental(stack, {
+      ...initialProps(stack, scalingApp),
+      scaling: {
+        minimumInstances: 5,
+      },
+    });
+    autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 100,
+    });
+
+    const staticApp = "my-static-app";
+    new GuEc2AppExperimental(stack, initialProps(stack, staticApp));
+
+    /*
+    We're ultimately testing an `Aspect`, which appear to run only at synth time.
+    As a work-around, synth the `App`, then perform assertions on the resulting template.
+
+    See also: https://github.com/aws/aws-cdk/issues/29047.
+     */
+    const { artifacts } = cdkApp.synth();
+    const cfnStack = artifacts.find((_): _ is CloudFormationStackArtifact => _ instanceof CloudFormationStackArtifact);
+
+    if (!cfnStack) {
+      throw new Error("Unable to locate a CloudFormationStackArtifact");
+    }
+
+    const template = Template.fromJSON(cfnStack.template as Record<string, unknown>);
+
+    /*
+    The scaling ASG should:
+      - Not have `DesiredCapacity` set
+      - Have `MinInstancesInService` set via a CFN Parameter
+     */
+    const parameterName = `MinInstancesInServiceFor${scalingApp.replaceAll("-", "")}`;
+    template.hasParameter(parameterName, {
+      Type: "Number",
+      Default: 5,
+      MaxValue: 9, // (min * 2) - 1
+    });
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+        MaxSize: "10",
+        DesiredCapacity: Match.absent(),
+        Tags: Match.arrayWith([{ Key: "App", Value: scalingApp, PropagateAtLaunch: true }]),
+      },
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          MaxBatchSize: 10,
+          SuspendProcesses: ["AlarmNotification"],
+          MinSuccessfulInstancesPercent: 100,
+          WaitOnResourceSignals: true,
+          PauseTime: "PT5M",
+          MinInstancesInService: {
+            Ref: parameterName,
+          },
+        },
+      },
+    });
+
+    /*
+    The static ASG should:
+      - Have `DesiredCapacity` set explicitly
+      - Have `MinInstancesInService` set explicitly
+     */
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "1",
+        MaxSize: "2",
+        DesiredCapacity: "1",
+        Tags: Match.arrayWith([{ Key: "App", Value: staticApp, PropagateAtLaunch: true }]),
+      },
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          MaxBatchSize: 2,
+          SuspendProcesses: ["AlarmNotification"],
+          MinSuccessfulInstancesPercent: 100,
+          WaitOnResourceSignals: true,
+          PauseTime: "PT5M",
+          MinInstancesInService: 1,
+        },
+      },
+    });
+  });
 });

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -44,6 +44,20 @@ describe("The GuEc2AppExperimental pattern", () => {
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 
+  it("should create an ASG with min, max, and desired capacity set", () => {
+    const stack = simpleGuStackForTesting();
+
+    new GuEc2AppExperimental(stack, { ...initialProps(stack), scaling: { minimumInstances: 5 } });
+
+    Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+        MaxSize: "10",
+        DesiredCapacity: "5",
+      },
+    });
+  });
+
   it("should create an ASG with a resource signal count that matches the min instances", () => {
     const stack = simpleGuStackForTesting();
 

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -292,7 +292,7 @@ describe("The GuEc2AppExperimental pattern", () => {
     template.resourceCountIs("AWS::AutoScaling::ScalingPolicy", 3);
   });
 
-  it("should throw an error when a scaling policy is not created with aa GuAutoScalingGroup scope", () => {
+  it("should throw an error when a scaling policy is not created with a GuAutoScalingGroup scope", () => {
     const cdkApp = new App();
     const stack = new GuStack(cdkApp, "test", {
       stack: "test-stack",
@@ -301,10 +301,14 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     const { autoScalingGroup } = new GuEc2AppExperimental(stack, initialProps(stack));
 
-    /*
-    Should be created like this to avoid the error:
-
-      new CfnScalingPolicy(autoScalingGroup, "ScaleOut", { ... });
+    /**
+     * Should be created like this to avoid the error:
+     *
+     * @example
+     * ```ts
+     * declare const autoScalingGroup: GuAutoScalingGroup;
+     * new CfnScalingPolicy(autoScalingGroup, "ScaleOut", { ... });
+     * ```
      */
     new CfnScalingPolicy(stack, "ScaleOut", {
       autoScalingGroupName: autoScalingGroup.autoScalingGroupName,

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -185,18 +185,10 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
       Properties: {
-        MinSize: "5",
-        MaxSize: "10",
         DesiredCapacity: Match.absent(),
-        Tags: Match.arrayWith([{ Key: "App", Value: scalingApp, PropagateAtLaunch: true }]),
       },
       UpdatePolicy: {
         AutoScalingRollingUpdate: {
-          MaxBatchSize: 10,
-          SuspendProcesses: ["AlarmNotification"],
-          MinSuccessfulInstancesPercent: 100,
-          WaitOnResourceSignals: true,
-          PauseTime: "PT5M",
           MinInstancesInService: {
             Ref: parameterName,
           },
@@ -241,11 +233,7 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     const template = Template.fromJSON(cfnStack.template as Record<string, unknown>);
 
-    /*
-    The scaling ASG should:
-      - Not have `DesiredCapacity` set
-      - Have `MinInstancesInService` set via a CFN Parameter
-     */
+    // The scaling ASG should NOT have `DesiredCapacity` set, and `MinInstancesInService` set via a CFN Parameter
     const parameterName = `MinInstancesInServiceFor${scalingApp.replaceAll("-", "")}`;
     template.hasParameter(parameterName, {
       Type: "Number",
@@ -254,18 +242,11 @@ describe("The GuEc2AppExperimental pattern", () => {
     });
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
       Properties: {
-        MinSize: "5",
-        MaxSize: "10",
         DesiredCapacity: Match.absent(),
         Tags: Match.arrayWith([{ Key: "App", Value: scalingApp, PropagateAtLaunch: true }]),
       },
       UpdatePolicy: {
         AutoScalingRollingUpdate: {
-          MaxBatchSize: 10,
-          SuspendProcesses: ["AlarmNotification"],
-          MinSuccessfulInstancesPercent: 100,
-          WaitOnResourceSignals: true,
-          PauseTime: "PT5M",
           MinInstancesInService: {
             Ref: parameterName,
           },
@@ -273,25 +254,14 @@ describe("The GuEc2AppExperimental pattern", () => {
       },
     });
 
-    /*
-    The static ASG should:
-      - Have `DesiredCapacity` set explicitly
-      - Have `MinInstancesInService` set explicitly
-     */
+    // The static ASG SHOULD have `DesiredCapacity` and `MinInstancesInService` explicitly
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
       Properties: {
-        MinSize: "1",
-        MaxSize: "2",
         DesiredCapacity: "1",
         Tags: Match.arrayWith([{ Key: "App", Value: staticApp, PropagateAtLaunch: true }]),
       },
       UpdatePolicy: {
         AutoScalingRollingUpdate: {
-          MaxBatchSize: 2,
-          SuspendProcesses: ["AlarmNotification"],
-          MinSuccessfulInstancesPercent: 100,
-          WaitOnResourceSignals: true,
-          PauseTime: "PT5M",
           MinInstancesInService: 1,
         },
       },

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -94,12 +94,8 @@ describe("The GuEc2AppExperimental pattern", () => {
         MinSize: "5",
       },
       CreationPolicy: {
-        AutoScalingCreationPolicy: {
-          MinSuccessfulInstancesPercent: 100,
-        },
         ResourceSignal: {
           Count: 5,
-          Timeout: "PT5M",
         },
       },
     });
@@ -259,20 +255,10 @@ describe("The GuEc2AppExperimental pattern", () => {
       MaxValue: 9, // (min * 2) - 1
     });
 
+    template.resourceCountIs("AWS::AutoScaling::AutoScalingGroup", 1);
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
-      Properties: {
-        MinSize: "5",
-        MaxSize: "10",
-        DesiredCapacity: Match.absent(),
-        Tags: Match.arrayWith([{ Key: "App", Value: scalingApp, PropagateAtLaunch: true }]),
-      },
       UpdatePolicy: {
         AutoScalingRollingUpdate: {
-          MaxBatchSize: 10,
-          SuspendProcesses: ["AlarmNotification"],
-          MinSuccessfulInstancesPercent: 100,
-          WaitOnResourceSignals: true,
-          PauseTime: "PT5M",
           MinInstancesInService: {
             Ref: parameterName,
           },

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -58,6 +58,8 @@ export class GuEc2AppExperimental extends GuEc2App {
     const { userData, role } = autoScalingGroup;
     const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
 
+    cfnAutoScalingGroup.desiredCapacity = minimumInstances.toString();
+
     new Policy(scope, "AsgReplacingUpdatePolicy", {
       statements: [
         // Allow usage of command `cfn-signal`.

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -251,16 +251,14 @@ export class GuEc2AppExperimental extends GuEc2App {
     AsgRollingUpdatePolicy.getInstance(scope).attachToRole(role);
 
     /*
-    `ec2metadata` is available via `cloud-utils` installed on all Canonical Ubuntu AMIs.
-    See https://github.com/canonical/cloud-utils.
-
     `aws` is available via AMIgo baked AMIs.
     See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
      */
     userData.addCommands(
       `# ${GuEc2AppExperimental.name} UserData Start`,
       `
-      INSTANCE_ID=$(ec2metadata --instance-id)
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
 
       STATE=$(aws elbv2 describe-target-health \
         --target-group-arn ${targetGroup.targetGroupArn} \

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -1,11 +1,11 @@
-import type { IAspect, Stack } from "aws-cdk-lib";
+import type { IAspect } from "aws-cdk-lib";
 import { Aspects, CfnParameter, Duration } from "aws-cdk-lib";
 import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 import { CfnScalingPolicy, ScalingProcess, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
 import { GuAutoScalingGroup } from "../../constructs/autoscaling";
-import { GuStack } from "../../constructs/core";
+import type { GuStack } from "../../constructs/core";
 import type { GuEc2AppProps } from "../../patterns";
 import { GuEc2App } from "../../patterns";
 import { isSingletonPresentInStack } from "../../utils/singleton";
@@ -31,7 +31,7 @@ import { isSingletonPresentInStack } from "../../utils/singleton";
  * @see https://github.com/guardian/testing-asg-rolling-update
  */
 class HorizontallyScalingDeploymentProperties implements IAspect {
-  public readonly stack: Stack;
+  public readonly stack: GuStack;
   private readonly asgToParamMap: Map<string, CfnParameter>;
   private static instance: HorizontallyScalingDeploymentProperties | undefined;
 
@@ -52,7 +52,6 @@ class HorizontallyScalingDeploymentProperties implements IAspect {
     if (construct instanceof CfnScalingPolicy) {
       const { node } = construct;
       const { scopes, path } = node;
-      const guStack = GuStack.of(construct);
 
       /*
       Requiring a `CfnScalingPolicy` to be created in the scope of a `GuAutoScalingGroup`
@@ -92,7 +91,7 @@ class HorizontallyScalingDeploymentProperties implements IAspect {
         if (!this.asgToParamMap.has(asgNodeId)) {
           this.asgToParamMap.set(
             asgNodeId,
-            new CfnParameter(guStack, `MinInstancesInServiceFor${autoScalingGroup.app}`, {
+            new CfnParameter(this.stack, `MinInstancesInServiceFor${autoScalingGroup.app}`, {
               type: "Number",
               default: parseInt(cfnAutoScalingGroup.minSize),
               maxValue: parseInt(cfnAutoScalingGroup.maxSize) - 1,

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -59,6 +59,7 @@ export class GuEc2AppExperimental extends GuEc2App {
     See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
      */
     userData.addCommands(
+      `# ${GuEc2AppExperimental.name} UserData Start`,
       `
       INSTANCE_ID=$(ec2metadata --instance-id)
 
@@ -80,6 +81,7 @@ export class GuEc2AppExperimental extends GuEc2App {
 
       echo "Instance is healthy in target group."
       `,
+      `# ${GuEc2AppExperimental.name} UserData End`,
     );
 
     userData.addOnExitCommands(

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -1,0 +1,111 @@
+import { Duration } from "aws-cdk-lib";
+import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { GuStack } from "../../constructs/core";
+import type { GuEc2AppProps } from "../../patterns";
+import { GuEc2App } from "../../patterns";
+
+export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePolicy"> {}
+
+export class GuEc2AppExperimental extends GuEc2App {
+  constructor(scope: GuStack, props: GuEc2AppExperimentalProps) {
+    const { minimumInstances, maximumInstances = minimumInstances * 2 } = props.scaling;
+    const { applicationPort } = props;
+    const { region, stackId } = scope;
+
+    super(scope, {
+      ...props,
+      updatePolicy: UpdatePolicy.rollingUpdate({
+        maxBatchSize: maximumInstances,
+        minInstancesInService: minimumInstances,
+        minSuccessPercentage: 100,
+        waitOnResourceSignals: true,
+        suspendProcesses: [],
+      }),
+    });
+
+    const { autoScalingGroup, targetGroup } = this;
+    const { userData, role } = autoScalingGroup;
+    const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+
+    new Policy(scope, "AsgReplacingUpdatePolicy", {
+      statements: [
+        // Allow usage of command `cfn-signal`.
+        new PolicyStatement({
+          actions: ["cloudformation:SignalResource"],
+          effect: Effect.ALLOW,
+          resources: [stackId],
+        }),
+
+        /*
+        Allow usage of command `aws elbv2 describe-target-health`.
+        AWS Elastic Load Balancing does not support resource based policies, so the resource has to be `*` (any) here.
+        See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html
+         */
+        new PolicyStatement({
+          actions: ["elasticloadbalancing:DescribeTargetHealth"],
+          effect: Effect.ALLOW,
+          resources: ["*"],
+        }),
+      ],
+    }).attachToRole(role);
+
+    /*
+    `ec2metadata` is available via `cloud-utils` installed on all Canonical Ubuntu AMIs.
+    See https://github.com/canonical/cloud-utils.
+
+    `aws` is available via AMIgo baked AMIs.
+    See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
+     */
+    userData.addCommands(
+      `
+      INSTANCE_ID=$(ec2metadata --instance-id)
+
+      STATE=$(aws elbv2 describe-target-health \
+        --target-group-arn ${targetGroup.targetGroupArn} \
+        --region ${region} \
+        --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+        --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health \
+          --target-group-arn ${targetGroup.targetGroupArn} \
+          --region ${region} \
+          --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+          --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance is healthy in target group."
+      `,
+    );
+
+    userData.addOnExitCommands(
+      `
+        cfn-signal --stack ${stackId} \
+          --resource ${cfnAutoScalingGroup.logicalId} \
+          --region ${region} \
+          --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        `,
+    );
+
+    // TODO are these sensible values?
+    const signalTimeoutSeconds = Math.max(
+      targetGroup.healthCheck.timeout?.toSeconds() ?? 0,
+      cfnAutoScalingGroup.healthCheckGracePeriod ?? 0,
+      Duration.minutes(5).toSeconds(),
+    );
+
+    cfnAutoScalingGroup.cfnOptions.creationPolicy = {
+      autoScalingCreationPolicy: {
+        minSuccessfulInstancesPercent: 100,
+      },
+      resourceSignal: {
+        count: minimumInstances,
+        timeout: Duration.seconds(signalTimeoutSeconds).toIsoString(),
+      },
+    };
+  }
+}

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -50,7 +50,14 @@ export class GuEc2AppExperimental extends GuEc2App {
         minInstancesInService: minimumInstances,
         minSuccessPercentage: 100,
         waitOnResourceSignals: true,
-        suspendProcesses: [],
+
+        /*
+        If a scale-in event fires during an `AutoScalingRollingUpdate` operation, the update could fail and rollback.
+        For this reason, we suspend the `AlarmNotification` process, else availability of a service cannot be guaranteed.
+        Consequently, services cannot scale-out during deployments.
+        If AWS ever supports suspending scale-out and scale-in independently, we should allow scale-out.
+         */
+        suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
       }),
     });
 

--- a/src/riff-raff-yaml-file/index.test.ts
+++ b/src/riff-raff-yaml-file/index.test.ts
@@ -7,6 +7,7 @@ import { AccessScope } from "../constants";
 import type { GuStackProps } from "../constructs/core";
 import { GuStack } from "../constructs/core";
 import { GuLambdaFunction } from "../constructs/lambda";
+import { GuEc2AppExperimental } from "../experimental/patterns/ec2-app";
 import { GuEc2App, GuNodeApp, GuPlayApp, GuScheduledLambda } from "../patterns";
 import { RiffRaffYamlFile } from "./index";
 
@@ -1287,6 +1288,83 @@ describe("The RiffRaffYamlFile class", () => {
           applicationPort: 9000,
           imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
           updatePolicy: UpdatePolicy.rollingUpdate(),
+        });
+      }
+    }
+
+    new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
+
+    const actual = new RiffRaffYamlFile(app).toYAML();
+
+    expect(actual).toMatchInlineSnapshot(`
+      "allowedStages:
+        - TEST
+      deployments:
+        asg-upload-eu-west-1-test-my-app:
+          type: autoscaling
+          actions:
+            - uploadArtifacts
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-app
+          parameters:
+            bucketSsmLookup: true
+            prefixApp: true
+          contentDirectory: my-app
+        cfn-eu-west-1-test-my-application-stack:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-application-stack
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              TEST: test-stack.template.json
+            amiParametersToTags:
+              AMIMyapp:
+                BuiltBy: amigo
+                AmigoStage: PROD
+                Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
+          dependencies:
+            - asg-upload-eu-west-1-test-my-app
+      "
+    `);
+  });
+
+  it("Should only upload artifacts for a GuEc2AppExperimental", () => {
+    const app = new App({ outdir: "/tmp/cdk.out" });
+
+    class MyApplicationStack extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- unit testing
+      constructor(app: App, id: string, props: GuStackProps) {
+        super(app, id, props);
+
+        const appName = "my-app";
+
+        new GuEc2AppExperimental(this, {
+          app: appName,
+          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+          access: { scope: AccessScope.PUBLIC },
+          userData: {
+            distributable: {
+              fileName: `${appName}.deb`,
+              executionStatement: `dpkg -i /${appName}/${appName}.deb`,
+            },
+          },
+          certificateProps: {
+            domainName: "rip.gu.com",
+          },
+          monitoringConfiguration: { noMonitoring: true },
+          scaling: {
+            minimumInstances: 1,
+          },
+          applicationPort: 9000,
+          imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
         });
       }
     }

--- a/src/riff-raff-yaml-file/index.test.ts
+++ b/src/riff-raff-yaml-file/index.test.ts
@@ -1,4 +1,5 @@
 import { App, Duration } from "aws-cdk-lib";
+import { UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
 import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
 import { Schedule } from "aws-cdk-lib/aws-events";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
@@ -1253,6 +1254,84 @@ describe("The RiffRaffYamlFile class", () => {
         dependencies:
           - cfn-eu-west-1-deploy-shared-resource-stack
     "
+    `);
+  });
+
+  it("Should only upload artifacts for an ASG with an update policy", () => {
+    const app = new App({ outdir: "/tmp/cdk.out" });
+
+    class MyApplicationStack extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- unit testing
+      constructor(app: App, id: string, props: GuStackProps) {
+        super(app, id, props);
+
+        const appName = "my-app";
+
+        new GuEc2App(this, {
+          app: appName,
+          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+          access: { scope: AccessScope.PUBLIC },
+          userData: {
+            distributable: {
+              fileName: `${appName}.deb`,
+              executionStatement: `dpkg -i /${appName}/${appName}.deb`,
+            },
+          },
+          certificateProps: {
+            domainName: "rip.gu.com",
+          },
+          monitoringConfiguration: { noMonitoring: true },
+          scaling: {
+            minimumInstances: 1,
+          },
+          applicationPort: 9000,
+          imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
+          updatePolicy: UpdatePolicy.rollingUpdate(),
+        });
+      }
+    }
+
+    new MyApplicationStack(app, "test-stack", { stack: "test", stage: "TEST", env: { region: "eu-west-1" } });
+
+    const actual = new RiffRaffYamlFile(app).toYAML();
+
+    expect(actual).toMatchInlineSnapshot(`
+      "allowedStages:
+        - TEST
+      deployments:
+        asg-upload-eu-west-1-test-my-app:
+          type: autoscaling
+          actions:
+            - uploadArtifacts
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-app
+          parameters:
+            bucketSsmLookup: true
+            prefixApp: true
+          contentDirectory: my-app
+        cfn-eu-west-1-test-my-application-stack:
+          type: cloud-formation
+          regions:
+            - eu-west-1
+          stacks:
+            - test
+          app: my-application-stack
+          contentDirectory: /tmp/cdk.out
+          parameters:
+            templateStagePaths:
+              TEST: test-stack.template.json
+            amiParametersToTags:
+              AMIMyapp:
+                BuiltBy: amigo
+                AmigoStage: PROD
+                Recipe: arm64-bionic-java11-deploy-infrastructure
+                Encrypted: 'true'
+          dependencies:
+            - asg-upload-eu-west-1-test-my-app
+      "
     `);
   });
 });

--- a/src/riff-raff-yaml-file/index.ts
+++ b/src/riff-raff-yaml-file/index.ts
@@ -254,15 +254,14 @@ export class RiffRaffYamlFile {
             deployments.set(lambdaDeployment.name, lambdaDeployment.props);
           });
 
-          // ASGs without an UpdatePolicy can be deployed via Riff-Raff's (legacy) `autoscaling` deployment type.
-          // ASGs with an UpdatePolicy are updated via Riff-Raff's `cloud-formation` deployment type.
+          /*
+          Instances in an ASG with an `AutoScalingRollingUpdate` update policy are rotated via CloudFormation.
+          Therefore, they do not need to also perform an `autoscaling` deployment via Riff-Raff.
+           */
           const legacyAutoscalingGroups = autoscalingGroups.filter((asg) => {
             const { cfnOptions } = asg.node.defaultChild as CfnAutoScalingGroup;
             const { updatePolicy } = cfnOptions;
-            return (
-              updatePolicy?.autoScalingReplacingUpdate === undefined &&
-              updatePolicy?.autoScalingRollingUpdate === undefined
-            );
+            return updatePolicy?.autoScalingRollingUpdate === undefined;
           });
 
           legacyAutoscalingGroups.forEach((asg) => {

--- a/src/riff-raff-yaml-file/index.ts
+++ b/src/riff-raff-yaml-file/index.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from "fs";
 import path from "path";
 import type { App } from "aws-cdk-lib";
 import { Token } from "aws-cdk-lib";
+import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 import { dump } from "js-yaml";
 import { GuAutoScalingGroup } from "../constructs/autoscaling";
 import { GuStack } from "../constructs/core";
@@ -253,7 +254,18 @@ export class RiffRaffYamlFile {
             deployments.set(lambdaDeployment.name, lambdaDeployment.props);
           });
 
-          autoscalingGroups.forEach((asg) => {
+          // ASGs without an UpdatePolicy can be deployed via Riff-Raff's (legacy) `autoscaling` deployment type.
+          // ASGs with an UpdatePolicy are updated via Riff-Raff's `cloud-formation` deployment type.
+          const legacyAutoscalingGroups = autoscalingGroups.filter((asg) => {
+            const { cfnOptions } = asg.node.defaultChild as CfnAutoScalingGroup;
+            const { updatePolicy } = cfnOptions;
+            return (
+              updatePolicy?.autoScalingReplacingUpdate === undefined &&
+              updatePolicy?.autoScalingRollingUpdate === undefined
+            );
+          });
+
+          legacyAutoscalingGroups.forEach((asg) => {
             const asgDeployment = autoscalingDeployment(asg, cfnDeployment);
             deployments.set(asgDeployment.name, asgDeployment.props);
           });


### PR DESCRIPTION
## What does this change?
Reduce the “time spent broken” after failed deploys, making [these manual steps](https://github.com/guardian/riff-raff/blob/fc88a4ca485c93423e62724cea4cbc266daa9f00/riff-raff/public/docs/howto/fix-a-failed-deploy.md) redundant, by adding a new [experimental](https://github.com/guardian/cdk/blob/main/docs/architecture-decision-records/005-x01-package-structure.md) pattern `GuEc2AppExperimental` to provision an EC2 based service with an [`AutoScalingRollingUpdate` update policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate). The configuration is based on a number of [tests](https://github.com/guardian/testing-asg-rolling-update) we ran; we've [documented some various observations](https://github.com/guardian/testing-asg-rolling-update/tree/main/observations).

This is an alternative to #2395. It improves on the solution proposed in #2395 by providing continuity of ASG metrics and ASG activity history.

`AutoScalingRollingUpdate` offers an improved DX over the `autoscaling` Riff-Raff deployment type when a deployment fails. On deployment failure, the `autoscaling` Riff-Raff deployment type leaves the ASG over-capacity, requiring [manual intervention to resolve](https://github.com/guardian/riff-raff/blob/fc88a4ca485c93423e62724cea4cbc266daa9f00/riff-raff/public/docs/howto/fix-a-failed-deploy.md), whereas `AutoScalingRollingUpdate` will perform a rollback automatically. This means deployments are more atomic.

> [!NOTE]
> Unfortunately [testing](https://github.com/guardian/testing-asg-rolling-update) has shown unpredictable behaviour if a scale-in event occurs during deployment. Therefore we suspend the `AlarmNotification` process during a rolling update.
> 
> This means scaling events cannot occur during deployment and https://github.com/guardian/riff-raff/issues/1342 is not fixed.

With `AutoScalingRollingUpdate` CloudFormation will deploy application updates to an ASG in a rolling fashion. The rate at which the update rolls out is dependant on how scaled-out an ASG is:
- If an ASG does not have any scaling policies, deployment will behave similar to Riff-Raff; the `DesiredCapacity` will be doubled, once new instances are healthy the capacity will be halved removing the old instances.
- For an ASG that has a scaling policy, the rate will be dynamic:
  - If it is running normally, `DesiredCapacity` will be doubled, once new instances are healthy the capacity will be halved removing the old instances ([testing observations](https://github.com/guardian/testing-asg-rolling-update/blob/main/observations/healthy-to-healthy.md)).
  - If the service is partially scaled, deployment will happen in batches relative to the remaining capacity (`MinCapacity` / (`MaxCapacity` - `DesiredCapacity`)) ([testing observations](https://github.com/guardian/testing-asg-rolling-update/blob/main/observations/healthy-to-healthy-partially-scaled-v2.md)).
  - If the service is fully scaled, deployment will happen in a "one out, one in" fashion ([testing observations](https://github.com/guardian/testing-asg-rolling-update/blob/main/observations/healthy-to-healthy-fully-scaled-v2.md)).

   This will be achieved by Riff-Raff setting [`MinInstancesInService`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice) at deploy time via a CloudFormation Parameter.
   > 
   This functionality is yet to be added to Riff-Raff. It doesn't block shipping this change, however services that use scaling policies cannot use this experimental pattern until then.

As application updates are performed entirely by CloudFormation, it is not necessary to use the `autoscaling` RIff-Raff deployment type[^1]. If it is used, it shouldn't break anything. However it does mean deployments will take a long time, as the instances will be rotated twice; once by CloudFormation and once by Riff-Raff's custom logic.

### Changes to UserData
With `AutoScalingRollingUpdate` CloudFormation will remain in the `UPDATE_IN_PROGRESS` state whilst waiting for a `SUCCESS` [signal](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-signal.html) to be received from the instance. This signal is sent manually.

The `GuEc2AppExperimental` pattern will add this signal emission to the UserData. A `SUCCESS` signal will be sent once the instance has successfully registered with the Target Group.

### Why `experimental`?
There are a few requirements for this approach:
- The AWS CLI, and `cfn-signal` binaries need to be available and on the `PATH` (this is added via the [AMIgo role `aws-tools`](https://github.com/guardian/amigo/tree/main/roles/aws-tools)).
- The service's artifact should include a build number, as this is the most reliable way to create a difference with the running CloudFormation template, and thus trigger an update.

We're not (yet) validating these are met, as its tricky.

### Proposed rollout
The rollout plan looks something like this:
1. Dogfood on some DevX services.
2. Test on a service within the department.
3. Move the pattern to stable, as a breaking change, with communication on the migration path, etc.

## How to test
These changes have been informed by "real-world" testing that has been documented in https://github.com/guardian/testing-asg-rolling-update.

This branch is being successfully used in [guardian/amiable](https://github.com/guardian/amiable/pull/717), [guardian/cdk-playground](https://github.com/guardian/cdk-playground/pull/522) and [guardian/security-hq](https://github.com/guardian/security-hq/pull/1154).

## How can we measure success?
A DX improvement when a deployment fails.

Once fully adopted, we will be able to remove the `autoscaling` deployment type in Riff-Raff, reducing it's complexity.

## Have we considered potential risks?
As this new pattern is `experimental` there risk levels are fairly small. We should monitor usage and gather feedback before promoting to stable.

## Checklist

- [ - ] I have listed any breaking changes, along with a migration path [^2]
- [x] I have updated the documentation as required for the described changes [^3]

[^1]: We still need the `uploadArtifacts` action of the [`autoscaling` deployment type](https://riffraff.gutools.co.uk/docs/magenta-lib/types#autoscaling). The `cloud-formation` deployment type should depend on this step too.
[^2]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^3]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
