### PR TITLE
enable InstanceMetadataTags on EC2 patterns

### DIFF
--- a/.changeset/cold-coins-flow.md
+++ b/.changeset/cold-coins-flow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+enable InstanceMetadataTags on EC2 patterns

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -128,6 +128,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       // Favour HTTPS only egress rules by default.
       securityGroup: GuHttpsEgressSecurityGroup.forVpc(scope, { app, vpc }),
       requireImdsv2: !withoutImdsv2,
+      instanceMetadataTags: true,
       userData,
       role,
       httpPutResponseHopLimit,

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -890,6 +890,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
           "InstanceType": "t4g.medium",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {
@@ -1785,6 +1786,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
           "InstanceType": "t4g.medium",
           "MetadataOptions": {
             "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
           },
           "SecurityGroupIds": [
             {


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/instance-tag-discovery recommends enabling tags on instance metadata, but that option isn't available to users of the EC2 patterns in gucdk. This doesn't have any real problems, [aside from an error log on startup](https://logs.gutools.co.uk/goto/61f12e30-613d-11ef-9d32-0b00a291b047) that currently can't be resolved and can cause confusion.

This PR enables the option for all users of the EC2 patterns. I could have made it a configurable option, but I've neither thought up nor discovered a reason _not_ to have it enabled, so I opted to hard-code it to true. I'd be happy to relax that back to a configurable option if there's any objection though! 

## How to test

See the updated snapshots.

## How can we measure success?

Error logs from `instance-tag-discovery` should fall as users adopt the new version.

## Have we considered potential risks?

Could this cause a breaking change to a gucdk consumer? I can't see how...

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
