### PR TITLE
vpc construct: only try setting context if unset

### DIFF
--- a/.changeset/dirty-cherries-hug.md
+++ b/.changeset/dirty-cherries-hug.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Fix bug preventing creation of multiple VPCs in single stack

--- a/src/constructs/vpc/vpc.test.ts
+++ b/src/constructs/vpc/vpc.test.ts
@@ -11,4 +11,13 @@ describe("The GuVpc construct", () => {
     new GuVpc(stack, "MyVpc");
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
+
+  it("should be possible to create two vpcs in the same stack", () => {
+    const stack = simpleGuStackForTesting({
+      stack: "test-stack",
+      env: { region: "eu-west-1", account: "000000000000" },
+    });
+    new GuVpc(stack, "MyVpc");
+    new GuVpc(stack, "MyOtherVpc");
+  });
 });

--- a/src/constructs/vpc/vpc.ts
+++ b/src/constructs/vpc/vpc.ts
@@ -61,11 +61,11 @@ export class GuVpc extends Vpc {
       );
     }
 
-    node.setContext(`availability-zones:account=${account}:region=eu-west-1`, [
-      "eu-west-1a",
-      "eu-west-1b",
-      "eu-west-1c",
-    ]);
+    const contextKey = `availability-zones:account=${account}:region=eu-west-1`;
+
+    if (node.tryGetContext(contextKey) === undefined) {
+      node.setContext(contextKey, ["eu-west-1a", "eu-west-1b", "eu-west-1c"]);
+    }
   }
 
   constructor(scope: GuStack, id: string, props?: GuVpcProps) {


### PR DESCRIPTION
## What does this change?

currently a single stack cannot create multiple vpcs, as each will try to set the context itself, and the subsequent creations will throw errors like

```
Cannot set context after children have been added: MyVpc
```

Instead, only attempt to set the context if it is unset

## How to test

Run the provided unit test

## How can we measure success?

Stacks in the account setup repo can succeed even if one account attempts to create two "new VPCs".

## Have we considered potential risks?

I don't **really** understand this error, I may have missed a more correct fix for this situation.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
