### PR TITLE
Allow inputs in GuScheduledLambda

### DIFF
--- a/.changeset/sweet-olives-refuse.md
+++ b/.changeset/sweet-olives-refuse.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Allow inputs in GuScheduledLambda

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -242,6 +242,7 @@ exports[`The GuScheduledLambda pattern should create the correct resources with 
               ],
             },
             "Id": "Target0",
+            "Input": ""Testing"",
           },
         ],
       },

--- a/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/scheduled-lambda.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The GuScheduledLambda pattern should create the correct resources with minimal config 1`] = `
+exports[`The GuScheduledLambda pattern should create the correct resources with an input in the rule 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
@@ -243,6 +243,276 @@ exports[`The GuScheduledLambda pattern should create the correct resources with 
             },
             "Id": "Target0",
             "Input": ""Testing"",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "mylambdafunctionmylambdafunctionrate1minute0AllowEventRuleTestmylambdafunction4858F7ED96852F99": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "mylambdafunction8D341B54",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "mylambdafunctionmylambdafunctionrate1minute06AD0015D",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+}
+`;
+
+exports[`The GuScheduledLambda pattern should create the correct resources with minimal config 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuDistributionBucketParameter",
+      "GuScheduledLambda",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "mylambdafunction8D341B54": {
+      "DependsOn": [
+        "mylambdafunctionServiceRoleDefaultPolicy769897D4",
+        "mylambdafunctionServiceRoleE82C2E25",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "test-stack/TEST/testing/lambda.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "testing",
+            "STACK": "test-stack",
+            "STAGE": "TEST",
+          },
+        },
+        "FunctionName": "my-lambda-function",
+        "Handler": "my-lambda/handler",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "mylambdafunctionServiceRoleE82C2E25",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "mylambdafunctionServiceRoleDefaultPolicy769897D4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/test-stack/TEST/testing/lambda.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/testing",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/testing/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "mylambdafunctionServiceRoleDefaultPolicy769897D4",
+        "Roles": [
+          {
+            "Ref": "mylambdafunctionServiceRoleE82C2E25",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "mylambdafunctionServiceRoleE82C2E25": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "testing",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "mylambdafunctionmylambdafunctionrate1minute06AD0015D": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 minute)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "mylambdafunction8D341B54",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
           },
         ],
       },

--- a/src/patterns/scheduled-lambda.test.ts
+++ b/src/patterns/scheduled-lambda.test.ts
@@ -1,6 +1,6 @@
 import { Duration } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { Schedule } from "aws-cdk-lib/aws-events";
+import { RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import type { NoMonitoring } from "../constructs/cloudwatch";
 import { simpleGuStackForTesting } from "../utils/test";
@@ -15,7 +15,7 @@ describe("The GuScheduledLambda pattern", () => {
       functionName: "my-lambda-function",
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
-      rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)), input: RuleTargetInput.fromText("Testing") }],
       monitoringConfiguration: noMonitoring,
       app: "testing",
     };

--- a/src/patterns/scheduled-lambda.test.ts
+++ b/src/patterns/scheduled-lambda.test.ts
@@ -15,7 +15,7 @@ describe("The GuScheduledLambda pattern", () => {
       functionName: "my-lambda-function",
       handler: "my-lambda/handler",
       runtime: Runtime.NODEJS_12_X,
-      rules: [{ schedule: Schedule.rate(Duration.minutes(1)), input: RuleTargetInput.fromText("Testing") }],
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
       monitoringConfiguration: noMonitoring,
       app: "testing",
     };
@@ -84,5 +84,21 @@ describe("The GuScheduledLambda pattern", () => {
         },
       ],
     });
+  });
+
+  it("should create the correct resources with an input in the rule", () => {
+    const stack = simpleGuStackForTesting();
+    const noMonitoring: NoMonitoring = { noMonitoring: true };
+    const props = {
+      fileName: "lambda.zip",
+      functionName: "my-lambda-function",
+      handler: "my-lambda/handler",
+      runtime: Runtime.NODEJS_12_X,
+      rules: [{ schedule: Schedule.rate(Duration.minutes(1)), input: RuleTargetInput.fromText("Testing") }],
+      monitoringConfiguration: noMonitoring,
+      app: "testing",
+    };
+    new GuScheduledLambda(stack, "my-lambda-function", props);
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 });

--- a/src/patterns/scheduled-lambda.ts
+++ b/src/patterns/scheduled-lambda.ts
@@ -1,5 +1,5 @@
 import { Rule } from "aws-cdk-lib/aws-events";
-import type { RuleTargetInput , Schedule } from "aws-cdk-lib/aws-events";
+import type { RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";

--- a/src/patterns/scheduled-lambda.ts
+++ b/src/patterns/scheduled-lambda.ts
@@ -1,5 +1,5 @@
 import { Rule } from "aws-cdk-lib/aws-events";
-import type { Schedule } from "aws-cdk-lib/aws-events";
+import type { RuleTargetInput , Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import type { GuLambdaErrorPercentageMonitoringProps, NoMonitoring } from "../constructs/cloudwatch";
 import type { GuStack } from "../constructs/core";
@@ -22,6 +22,10 @@ export interface GuScheduledLambdaProps extends Omit<GuFunctionProps, "errorPerc
      * Optional description.
      */
     description?: string;
+    /**
+     * Optional input
+     */
+    input?: RuleTargetInput;
   }>;
   /**
    * Monitoring configuration for the lambda.
@@ -50,7 +54,7 @@ export class GuScheduledLambda extends GuLambdaFunction {
       const resourceToInvoke = this.alias ?? this;
       new Rule(this, `${id}-${rule.schedule.expressionString}-${index}`, {
         schedule: rule.schedule,
-        targets: [new LambdaFunction(resourceToInvoke)],
+        targets: [new LambdaFunction(resourceToInvoke, { event: rule.input })],
         ...(rule.description && { description: rule.description }),
         enabled: true,
       });


### PR DESCRIPTION
Currently the `GuScheduledLambda` pattern lets you pass in schedules, but you cannot associate an input with each schedule.

This PR changes the props to optionally take a `RuleTargetInput` value with each scheduled rule.