### PR TITLE
feat(asg): Collect all ASG level metrics

### DIFF
--- a/.changeset/rare-geese-wait.md
+++ b/.changeset/rare-geese-wait.md
@@ -1,0 +1,27 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(asg) Collect all ASG level metrics
+
+This change should have no cost impact:
+
+> Group metrics are available at one-minute granularity at no additional charge, but you must enable them.
+> – https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-metrics.html.
+
+If it does, or if you only want a subset, the escape hatch mechanism can be used:
+
+```ts
+declare const asg: AutoScalingGroup;
+
+const cfnAsg = asg.node.defaultChild as CfnAutoScalingGroup;
+
+cfnAsg.metricsCollection = [
+  {
+    granularity: "1Minute",
+    metrics: [
+      // A subset of metrics
+    ],
+  },
+];
+```

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -1,6 +1,6 @@
 import type { Duration } from "aws-cdk-lib";
 import { Tags, Token } from "aws-cdk-lib";
-import { AutoScalingGroup, GroupMetric, GroupMetrics } from "aws-cdk-lib/aws-autoscaling";
+import { AutoScalingGroup, GroupMetrics } from "aws-cdk-lib/aws-autoscaling";
 import type { AutoScalingGroupProps, CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 import { LaunchTemplate, OperatingSystemType } from "aws-cdk-lib/aws-ec2";
 import type { InstanceType, ISecurityGroup, MachineImageConfig, UserData } from "aws-cdk-lib/aws-ec2";
@@ -88,7 +88,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       imageId = new GuAmiParameter(scope, { app }),
       imageRecipe,
       instanceType,
-      groupMetrics = [new GroupMetrics(GroupMetric.TOTAL_INSTANCES, GroupMetric.IN_SERVICE_INSTANCES)],
+      groupMetrics = [GroupMetrics.all()],
       minimumInstances,
       maximumInstances,
       role = new GuInstanceRole(scope, { app }),

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -91,10 +91,6 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
         "MetricsCollection": [
           {
             "Granularity": "1Minute",
-            "Metrics": [
-              "GroupTotalInstances",
-              "GroupInServiceInstances",
-            ],
           },
         ],
         "MinSize": "1",
@@ -1108,10 +1104,6 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
         "MetricsCollection": [
           {
             "Granularity": "1Minute",
-            "Metrics": [
-              "GroupTotalInstances",
-              "GroupInServiceInstances",
-            ],
           },
         ],
         "MinSize": "1",


### PR DESCRIPTION
## What does this change?
Extends on https://github.com/guardian/cdk/pull/2255 to collect all ASG level metrics as standard. These metrics _should_ come at no extra cost, at least the docs state:

> Group metrics are available at one-minute granularity at no additional charge, but you must enable them.
> – https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-metrics.html.

UPDATE: After raising an AWS have responded to a support ticket about this:

> Amazon EC2 Auto Scaling Group Metrics have no additional charge to enable. They are similar to EC2 basic monitoring metrics, which is also sent for free to Cloudwatch.
> 
> Amazon EC2 Auto Scaling fleet management for EC2 instances carries no additional fees. The dynamic scaling capabilities of Amazon EC2 Auto Scaling are enabled by Amazon CloudWatch and also carry no additional fees. Amazon EC2 and Amazon CloudWatch service fees apply and are billed separately.

## How to test
See updated snapshots.

## How can we measure success?
Group level metrics are useful when understanding service disruption.

## Have we considered potential risks?
This change should have no cost impact. If it does, or if you only want a subset, the escape hatch mechanism can be used:

```ts
declare const asg: AutoScalingGroup;

const cfnAsg = asg.node.defaultChild as CfnAutoScalingGroup;

cfnAsg.metricsCollection = [
  {
    granularity: "1Minute",
    metrics: [
      // A subset of metrics
    ],
  },
];
```

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
