### PR TITLE
fix(experimental-ec2-pattern): Create Policy first

### DIFF
--- a/.changeset/popular-laws-thank.md
+++ b/.changeset/popular-laws-thank.md
@@ -1,0 +1,15 @@
+---
+"@guardian/cdk": patch
+---
+
+fix(experimental-ec2-pattern): Create Policy first
+
+When deploying Prism with the `GuEc2AppExperimental` for the first time, the deployment failed with the cloud-init-output logs stating:
+
+```log
+An error occurred (AccessDenied) when calling the DescribeTargetHealth operation: User: arn:aws:sts::000000000000:assumed-role/prism-CODE-InstanceRolePrism/i-0cee86d64de253ca4 is not authorized to perform: elasticloadbalancing:DescribeTargetHealth because no identity-based policy allows the elasticloadbalancing:DescribeTargetHealth action
+```
+
+This suggests the instance update was started before the policy was created.
+
+Make the ASG depend on the policy that grants these permissions to resolve, as CloudFormation creates dependencies first.

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -109,6 +109,9 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           "Timeout": "PT3M",
         },
       },
+      "DependsOn": [
+        "AsgRollingUpdatePolicy2A1DDC6F",
+      ],
       "Properties": {
         "DesiredCapacity": "1",
         "HealthCheckGracePeriod": 120,

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -1,6 +1,7 @@
 import type { IAspect } from "aws-cdk-lib";
 import { Aspects, CfnParameter, Duration } from "aws-cdk-lib";
 import { CfnAutoScalingGroup, CfnScalingPolicy, ScalingProcess, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import type { CfnPolicy } from "aws-cdk-lib/aws-iam";
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import type { IConstruct } from "constructs";
 import { GuAutoScalingGroup } from "../../constructs/autoscaling";
@@ -308,7 +309,13 @@ export class GuEc2AppExperimental extends GuEc2App {
       },
     };
 
-    AsgRollingUpdatePolicy.getInstance(scope).attachToRole(role);
+    const policy = AsgRollingUpdatePolicy.getInstance(scope);
+    policy.attachToRole(role);
+
+    // Create the Policy with necessary permissions first.
+    // Then create the ASG that requires the permissions.
+    const cfnPolicy = policy.node.defaultChild as CfnPolicy;
+    cfnAutoScalingGroup.addDependency(cfnPolicy);
 
     /*
     `aws` is available via AMIgo baked AMIs.


### PR DESCRIPTION
## What does this change?
When deploying Prism with the `GuEc2AppExperimental` for the first time, the deployment [failed](https://riffraff.gutools.co.uk/deployment/view/dab404bb-30aa-49f0-9be0-361f88a44490?verbose=1) with the cloud-init-output logs stating:

```log
An error occurred (AccessDenied) when calling the DescribeTargetHealth operation: User: arn:aws:sts::000000000000:assumed-role/prism-CODE-InstanceRolePrism/i-0cee86d64de253ca4 is not authorized to perform: elasticloadbalancing:DescribeTargetHealth because no identity-based policy allows the elasticloadbalancing:DescribeTargetHealth action
```

This suggests the instance update was started before the policy that grants these permissions was created.

Make the ASG [depend on](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) the policy that grants these permissions to resolve, as CloudFormation creates dependencies first.

## How to test
See updated test.

## How can we measure success?
Improved stability.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
