### PR TITLE
feat(experimental-ec2-pattern): Add `buildIdentifier` prop

### DIFF
--- a/src/constants/metadata-keys.ts
+++ b/src/constants/metadata-keys.ts
@@ -4,4 +4,5 @@ export const MetadataKeys = {
   REPOSITORY_NAME: "gu:repo",
   LOG_KINESIS_STREAM_NAME: "LogKinesisStreamName",
   SYSTEMD_UNIT: "SystemdUnit",
+  BUILD_IDENTIFIER: "gu:build-identifier",
 };

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -80,6 +80,9 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
   public readonly amiParameter: GuAmiParameter;
   public readonly imageRecipe?: string | AmigoProps;
 
+  // Sadly this cannot be named `launchTemplate` as it would clash with a private property on the `AutoScalingGroup` class
+  public readonly instanceLaunchTemplate: LaunchTemplate;
+
   constructor(scope: GuStack, id: string, props: GuAutoScalingGroupProps) {
     const {
       app,
@@ -162,6 +165,7 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
     this.app = app;
     this.amiParameter = imageId;
     this.imageRecipe = imageRecipe;
+    this.instanceLaunchTemplate = launchTemplate;
 
     targetGroup && this.attachToApplicationTargetGroup(targetGroup);
 

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -842,6 +842,10 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
                   "Value": "test-gu-ec2-app",
                 },
                 {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
+                },
+                {
                   "Key": "gu:cdk:version",
                   "Value": "TEST",
                 },
@@ -869,6 +873,10 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
                 {
                   "Key": "App",
                   "Value": "test-gu-ec2-app",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
                 },
                 {
                   "Key": "gu:cdk:version",
@@ -937,7 +945,7 @@ dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
                   "         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
 
       until [ "$STATE" == "\\"healthy\\"" ]; do
-        echo "Instance not yet healthy within target group. Current state $STATE. Sleeping..."
+        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
         sleep 5
         STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
                   {
@@ -950,7 +958,7 @@ dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
                   "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
       done
 
-      echo "Instance is healthy in target group."
+      echo "Instance running build TEST is healthy in target group."
       
 # GuEc2AppExperimental UserData End",
                 ],
@@ -965,6 +973,10 @@ dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
               {
                 "Key": "App",
                 "Value": "test-gu-ec2-app",
+              },
+              {
+                "Key": "gu:build-identifier",
+                "Value": "TEST",
               },
               {
                 "Key": "gu:cdk:version",

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -62,6 +62,7 @@ describe("The GuEc2AppExperimental pattern", () => {
       scaling: {
         minimumInstances: 1,
       },
+      buildIdentifier: "TEST",
     };
   }
 

--- a/src/riff-raff-yaml-file/index.test.ts
+++ b/src/riff-raff-yaml-file/index.test.ts
@@ -1365,6 +1365,7 @@ describe("The RiffRaffYamlFile class", () => {
           },
           applicationPort: 9000,
           imageRecipe: "arm64-bionic-java11-deploy-infrastructure",
+          buildIdentifier: "TEST",
         });
       }
     }


### PR DESCRIPTION
## What does this change?
A requirement of using `GuEc2AppExperimental` is the filename of the application artifact should include the build identifier. Adding a required `buildIdentifier` prop to `GuEc2AppExperimental` uses the type-system to enforce the requirement.

This change also adds a `gu:build-identifier` tag to the launch template, meaning launched instances receive this tag. Furthermore, if instance logs are shipped with [devx-logs](https://github.com/guardian/devx-logs) then this tag becomes a marker on the log lines in Central ELK.

## How to test
See updated snapshot.

## How can we measure success?
Improved observability.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
