### PR TITLE
feat(riff-raff.yaml): Add `minInstancesInServiceParameters` when applicable

### DIFF
--- a/.changeset/yellow-chefs-laugh.md
+++ b/.changeset/yellow-chefs-laugh.md
@@ -1,0 +1,8 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(riff-raff.yaml): Add `minInstancesInServiceParameters` when applicable
+
+To complement the changes in https://github.com/guardian/riff-raff/pull/1383,
+add the `minInstancesInServiceParameters` property to the `riff-raff.yaml` file when applicable.

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -3,38 +3,12 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 import { CfnScalingPolicy } from "aws-cdk-lib/aws-autoscaling";
 import { InstanceClass, InstanceSize, InstanceType, UserData } from "aws-cdk-lib/aws-ec2";
-import { CloudFormationStackArtifact } from "aws-cdk-lib/cx-api";
 import { AccessScope } from "../../constants";
 import { GuUserData } from "../../constructs/autoscaling";
 import { GuStack } from "../../constructs/core";
-import { simpleGuStackForTesting } from "../../utils/test";
+import { getTemplateAfterAspectInvocation, simpleGuStackForTesting } from "../../utils/test";
 import type { GuEc2AppExperimentalProps } from "./ec2-app";
 import { getAsgRollingUpdateCfnParameterName, GuEc2AppExperimental, RollingUpdateDurations } from "./ec2-app";
-
-/**
- * `Aspects` appear to run only at synth time.
- * This means we must synth the stack to see the results of the `Aspect`.
- *
- * @see https://github.com/aws/aws-cdk/issues/29047
- *
- * @param stack the stack to synthesise
- */
-function getTemplateAfterAspectInvocation(stack: GuStack): Template {
-  const app = App.of(stack);
-
-  if (!app) {
-    throw new Error(`Unable to locate the enclosing App from GuStack ${stack.node.id}`);
-  }
-
-  const { artifacts } = app.synth();
-  const cfnStack = artifacts.find((_): _ is CloudFormationStackArtifact => _ instanceof CloudFormationStackArtifact);
-
-  if (!cfnStack) {
-    throw new Error("Unable to locate a CloudFormationStackArtifact");
-  }
-
-  return Template.fromJSON(cfnStack.template as Record<string, unknown>);
-}
 
 // TODO test User Data includes a build number
 describe("The GuEc2AppExperimental pattern", () => {

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -9,7 +9,7 @@ import { GuUserData } from "../../constructs/autoscaling";
 import { GuStack } from "../../constructs/core";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { GuEc2AppExperimentalProps } from "./ec2-app";
-import { GuEc2AppExperimental, RollingUpdateDurations } from "./ec2-app";
+import { getAsgRollingUpdateCfnParameterName, GuEc2AppExperimental, RollingUpdateDurations } from "./ec2-app";
 
 /**
  * `Aspects` appear to run only at synth time.
@@ -176,7 +176,7 @@ describe("The GuEc2AppExperimental pattern", () => {
     const template = getTemplateAfterAspectInvocation(stack);
 
     // The scaling ASG should NOT have `DesiredCapacity` set, and `MinInstancesInService` set via a CFN Parameter
-    const parameterName = `MinInstancesInServiceFor${scalingApp.replaceAll("-", "")}`;
+    const parameterName = getAsgRollingUpdateCfnParameterName(autoScalingGroup);
     template.hasParameter(parameterName, {
       Type: "Number",
       Default: 5,

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -109,9 +109,10 @@ class AutoScalingRollingUpdateTimeout implements IAspect {
  *
  * @see https://github.com/guardian/testing-asg-rolling-update
  */
-class HorizontallyScalingDeploymentProperties implements IAspect {
+// eslint-disable-next-line custom-rules/experimental-classes -- this class is not indented for public use
+export class HorizontallyScalingDeploymentProperties implements IAspect {
   public readonly stack: GuStack;
-  private readonly asgToParamMap: Map<string, CfnParameter>;
+  public readonly asgToParamMap: Map<string, CfnParameter>;
   private static instance: HorizontallyScalingDeploymentProperties | undefined;
 
   private constructor(scope: GuStack) {

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -168,9 +168,10 @@ class HorizontallyScalingDeploymentProperties implements IAspect {
         const asgNodeId = autoScalingGroup.node.id;
 
         if (!this.asgToParamMap.has(asgNodeId)) {
+          const cfnParameterName = getAsgRollingUpdateCfnParameterName(autoScalingGroup);
           this.asgToParamMap.set(
             asgNodeId,
-            new CfnParameter(this.stack, `MinInstancesInServiceFor${autoScalingGroup.app}`, {
+            new CfnParameter(this.stack, cfnParameterName, {
               type: "Number",
               default: parseInt(cfnAutoScalingGroup.minSize),
               maxValue: parseInt(cfnAutoScalingGroup.maxSize) - 1,
@@ -189,6 +190,11 @@ class HorizontallyScalingDeploymentProperties implements IAspect {
       }
     }
   }
+}
+
+export function getAsgRollingUpdateCfnParameterName(autoScalingGroup: GuAutoScalingGroup) {
+  const { app } = autoScalingGroup;
+  return `MinInstancesInServiceFor${app.replaceAll("-", "")}`;
 }
 
 /**

--- a/src/riff-raff-yaml-file/deployments/cloudformation.ts
+++ b/src/riff-raff-yaml-file/deployments/cloudformation.ts
@@ -1,4 +1,5 @@
 import type { GuAutoScalingGroup } from "../../constructs/autoscaling";
+import { getAsgRollingUpdateCfnParameterName } from "../../experimental/patterns/ec2-app";
 import type { CdkStacksDifferingOnlyByStage, RiffRaffDeployment, RiffRaffDeploymentParameters } from "../types";
 
 export function cloudFormationDeployment(
@@ -68,6 +69,21 @@ export function getAmiParameters(autoScalingGroups: GuAutoScalingGroup[]): RiffR
         AmigoStage,
         Recipe,
         Encrypted,
+      },
+    };
+  }, {});
+}
+
+export function getMinInstancesInServiceParameters(
+  autoScalingGroups: GuAutoScalingGroup[],
+): RiffRaffDeploymentParameters {
+  return autoScalingGroups.reduce<RiffRaffDeploymentParameters>((acc, asg) => {
+    const { app } = asg;
+    const cfnParameter = getAsgRollingUpdateCfnParameterName(asg);
+    return {
+      ...acc,
+      [cfnParameter]: {
+        App: app,
       },
     };
   }, {});

--- a/src/riff-raff-yaml-file/deployments/cloudformation.ts
+++ b/src/riff-raff-yaml-file/deployments/cloudformation.ts
@@ -1,5 +1,5 @@
 import type { GuAutoScalingGroup } from "../../constructs/autoscaling";
-import type { CdkStacksDifferingOnlyByStage, RiffRaffDeployment, RiffRaffDeploymentProps } from "../types";
+import type { CdkStacksDifferingOnlyByStage, RiffRaffDeployment, RiffRaffDeploymentParameters } from "../types";
 
 export function cloudFormationDeployment(
   cdkStacks: CdkStacksDifferingOnlyByStage,
@@ -47,11 +47,8 @@ export function cloudFormationDeployment(
   };
 }
 
-export function addAmiParametersToCloudFormationDeployment(
-  cfnDeployment: RiffRaffDeployment,
-  autoScalingGroups: GuAutoScalingGroup[],
-): RiffRaffDeploymentProps {
-  const amiParametersToTags = autoScalingGroups.reduce((acc, asg) => {
+export function getAmiParameters(autoScalingGroups: GuAutoScalingGroup[]): RiffRaffDeploymentParameters {
+  return autoScalingGroups.reduce<RiffRaffDeploymentParameters>((acc, asg) => {
     const { imageRecipe, app, amiParameter } = asg;
 
     if (!imageRecipe) {
@@ -74,14 +71,4 @@ export function addAmiParametersToCloudFormationDeployment(
       },
     };
   }, {});
-
-  return {
-    ...cfnDeployment.props,
-    parameters: {
-      ...cfnDeployment.props.parameters,
-
-      // only add the `amiParametersToTags` property if there are some
-      ...(autoScalingGroups.length > 0 && { amiParametersToTags }),
-    },
-  };
 }

--- a/src/riff-raff-yaml-file/index.ts
+++ b/src/riff-raff-yaml-file/index.ts
@@ -8,7 +8,7 @@ import { GuAutoScalingGroup } from "../constructs/autoscaling";
 import { GuStack } from "../constructs/core";
 import { GuLambdaFunction } from "../constructs/lambda";
 import { autoscalingDeployment, uploadAutoscalingArtifact } from "./deployments/autoscaling";
-import { addAmiParametersToCloudFormationDeployment, cloudFormationDeployment } from "./deployments/cloudformation";
+import { cloudFormationDeployment, getAmiParameters } from "./deployments/cloudformation";
 import { updateLambdaDeployment, uploadLambdaArtifact } from "./deployments/lambda";
 import { groupByClassNameStackRegionStage } from "./group-by";
 import type {
@@ -269,10 +269,17 @@ export class RiffRaffYamlFile {
             deployments.set(asgDeployment.name, asgDeployment.props);
           });
 
-          deployments.set(
-            cfnDeployment.name,
-            addAmiParametersToCloudFormationDeployment(cfnDeployment, autoscalingGroups),
-          );
+          const amiParametersToTags = getAmiParameters(autoscalingGroups);
+
+          deployments.set(cfnDeployment.name, {
+            ...cfnDeployment.props,
+            parameters: {
+              ...cfnDeployment.props.parameters,
+
+              // only add the `amiParametersToTags` property if there are some
+              ...(autoscalingGroups.length > 0 && { amiParametersToTags }),
+            },
+          });
         });
       });
     });

--- a/src/riff-raff-yaml-file/types.ts
+++ b/src/riff-raff-yaml-file/types.ts
@@ -14,13 +14,15 @@ export interface RiffRaffYaml {
 
 export type RiffRaffDeploymentName = string;
 
+export type RiffRaffDeploymentParameters = Record<string, string | boolean | Record<string, unknown>>;
+
 export interface RiffRaffDeploymentProps {
   type: string;
   regions: Set<Region>;
   stacks: Set<StackTag>;
   app: string;
   contentDirectory: string;
-  parameters: Record<string, string | boolean | Record<string, string>>;
+  parameters: RiffRaffDeploymentParameters;
   dependencies?: RiffRaffDeploymentName[];
   actions?: string[];
 }

--- a/src/utils/test/index.ts
+++ b/src/utils/test/index.ts
@@ -1,3 +1,4 @@
 export * from "./assertions";
 export * from "./simple-gu-stack";
 export * from "./attach-policy-to-test-role";
+export * from "./template";

--- a/src/utils/test/template.ts
+++ b/src/utils/test/template.ts
@@ -1,0 +1,29 @@
+import { App } from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { CloudFormationStackArtifact } from "aws-cdk-lib/cx-api";
+import type { GuStack } from "../../constructs/core";
+
+/**
+ * `Aspects` appear to run only at synth time.
+ * This means we must synth the stack to see the results of the `Aspect`.
+ *
+ * @see https://github.com/aws/aws-cdk/issues/29047
+ *
+ * @param stack the stack to synthesise
+ */
+export function getTemplateAfterAspectInvocation(stack: GuStack): Template {
+  const app = App.of(stack);
+
+  if (!app) {
+    throw new Error(`Unable to locate the enclosing App from GuStack ${stack.node.id}`);
+  }
+
+  const { artifacts } = app.synth();
+  const cfnStack = artifacts.find((_): _ is CloudFormationStackArtifact => _ instanceof CloudFormationStackArtifact);
+
+  if (!cfnStack) {
+    throw new Error("Unable to locate a CloudFormationStackArtifact");
+  }
+
+  return Template.fromJSON(cfnStack.template as Record<string, unknown>);
+}


### PR DESCRIPTION
## What does this change?
Updates the `riff-raff.yaml` generator to add the newly added `minInstancesInServiceParameters` property. See also https://github.com/guardian/riff-raff/pull/1383.

To support this change, a number of refactor changes have also been made. For that reason reviewing [commit by commit](https://github.com/guardian/cdk/pull/2476/commits) is advised.

This completes the changes in #2417, specifically addressing [these comments](https://github.com/guardian/cdk/pull/2417#discussion_r1759408280).

## How to test
See added unit tests.

## How can we measure success?
Full support for the new ASG deployment mechanism (AutoScalingRollingUpdate).

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
