### PR TITLE
feat: Require subnet property for ecs task, new subnetsFromParameter property

### DIFF
--- a/.changeset/bright-lamps-repair.md
+++ b/.changeset/bright-lamps-repair.md
@@ -1,0 +1,8 @@
+---
+"@guardian/cdk": major
+---
+
+ECS task now uses GuVpc.subnetsFromParameter rather than defaulting to CDK context
+
+Note that this is a breaking change, because the previous behaviour was [this](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_stepfunctions_tasks.EcsRunTask.html#subnets)
+ - which relied on a CDK context file with details of the different subnets.

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -711,3 +711,711 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
   },
 }
 `;
+
+exports[`The GuEcsTask pattern should support overriding the subnets used by the task 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuEcsTask",
+      "GuDistributionBucketParameter",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "testecstaskecstestStateMachineArnOutput": {
+      "Value": {
+        "Ref": "testecstaskecstestStateMachineC0B6383F",
+      },
+    },
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ecstestexecutionfailedC93F511B": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:something:else:here:we:goalarm-topic",
+        ],
+        "AlarmDescription": "ecs-test-TEST job failed ",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "StateMachineArn",
+            "Value": {
+              "Ref": "testecstaskecstestStateMachineC0B6383F",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ecstesttimeoutFE335653": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          "arn:something:else:here:we:goalarm-topic",
+        ],
+        "AlarmDescription": "ecs-test-TEST job timed out ",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "StateMachineArn",
+            "Value": {
+              "Ref": "testecstaskecstestStateMachineC0B6383F",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsTimedOut",
+        "Namespace": "AWS/States",
+        "Period": 3600,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testecstaskecstestCluster71BC62CB": {
+      "Properties": {
+        "CapacityProviders": [
+          "FARGATE",
+          "FARGATE_SPOT",
+        ],
+        "Cluster": {
+          "Ref": "testecstaskecstestClusterCBD4036C",
+        },
+        "DefaultCapacityProviderStrategy": [],
+      },
+      "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
+    },
+    "testecstaskecstestClusterCBD4036C": {
+      "Properties": {
+        "ClusterName": "ecs-test-cluster-TEST",
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": "disabled",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "testecstaskecstestStateMachineC0B6383F": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "testecstaskecstestStateMachineRoleDefaultPolicy81B8C5B5",
+        "testecstaskecstestStateMachineRole93D08A02",
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{"StartAt":"test-ecs-task-ecs-test-task","States":{"test-ecs-task-ecs-test-task":{"End":true,"Type":"Task","TimeoutSeconds":3600,"ResultPath":null,"Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::ecs:runTask.sync","Parameters":{"Cluster":"",
+              {
+                "Fn::GetAtt": [
+                  "testecstaskecstestClusterCBD4036C",
+                  "Arn",
+                ],
+              },
+              "","TaskDefinition":"test-stack-TEST-ecs-test","NetworkConfiguration":{"AwsvpcConfiguration":{"Subnets":["abc-123","def-456"],"SecurityGroups":["id-123"]}},"Overrides":{"ContainerOverrides":[{"Name":"test-ecs-task-ecs-test-TaskContainer"}]},"LaunchType":"FARGATE","PlatformVersion":"LATEST"}}}}",
+            ],
+          ],
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "testecstaskecstestStateMachineRole93D08A02",
+            "Arn",
+          ],
+        },
+        "StateMachineName": "ecs-test-TEST",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "testecstaskecstestStateMachineRole93D08A02": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "states.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testecstaskecstestStateMachineRoleDefaultPolicy81B8C5B5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Fn::Select": [
+                        1,
+                        {
+                          "Fn::Split": [
+                            ":",
+                            {
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    ":",
+                    {
+                      "Fn::Select": [
+                        2,
+                        {
+                          "Fn::Split": [
+                            ":",
+                            {
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    ":",
+                    {
+                      "Fn::Select": [
+                        3,
+                        {
+                          "Fn::Split": [
+                            ":",
+                            {
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    ":",
+                    {
+                      "Fn::Select": [
+                        4,
+                        {
+                          "Fn::Split": [
+                            ":",
+                            {
+                              "Ref": "testecstaskecstestTaskDefinition4BF687D5",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    ":",
+                    {
+                      "Fn::Select": [
+                        0,
+                        {
+                          "Fn::Split": [
+                            "/",
+                            {
+                              "Fn::Select": [
+                                5,
+                                {
+                                  "Fn::Split": [
+                                    ":",
+                                    {
+                                      "Ref": "testecstaskecstestTaskDefinition4BF687D5",
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    "/",
+                    {
+                      "Fn::Select": [
+                        1,
+                        {
+                          "Fn::Split": [
+                            "/",
+                            {
+                              "Fn::Select": [
+                                5,
+                                {
+                                  "Fn::Split": [
+                                    ":",
+                                    {
+                                      "Ref": "testecstaskecstestTaskDefinition4BF687D5",
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    ":*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ecs:StopTask",
+                "ecs:DescribeTasks",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "testecstaskecstestTaskDefinitionTaskRole4D626B6F",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::GetAtt": [
+                    "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
+                    "Arn",
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "events:PutTargets",
+                "events:PutRule",
+                "events:DescribeRule",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":events:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":rule/StepFunctionsGetEventsForECSTaskRule",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testecstaskecstestStateMachineRoleDefaultPolicy81B8C5B5",
+        "Roles": [
+          {
+            "Ref": "testecstaskecstestStateMachineRole93D08A02",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "testecstaskecstestTaskDefinition4BF687D5": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "-c",
+              "echo "yo ho row ho it's a pirates life for me"",
+            ],
+            "Cpu": 1024,
+            "EntryPoint": [
+              "/bin/sh",
+            ],
+            "Essential": true,
+            "Image": "node:10",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "testecstaskecstestTaskDefinitiontestecstaskecstestTaskContainerLogGroup3F63585A",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "ecs-test",
+              },
+            },
+            "Memory": 1024,
+            "Name": "test-ecs-task-ecs-test-TaskContainer",
+            "ReadonlyRootFilesystem": false,
+          },
+        ],
+        "Cpu": "1024",
+        "EphemeralStorage": {
+          "SizeInGiB": 30,
+        },
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
+            "Arn",
+          ],
+        },
+        "Family": "test-stack-TEST-ecs-test",
+        "Memory": "1024",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "testecstaskecstestTaskDefinitionTaskRole4D626B6F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "testecstaskecstestTaskDefinitionExecutionRoleDefaultPolicy85ED5386": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "testecstaskecstestTaskDefinitiontestecstaskecstestTaskContainerLogGroup3F63585A",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testecstaskecstestTaskDefinitionExecutionRoleDefaultPolicy85ED5386",
+        "Roles": [
+          {
+            "Ref": "testecstaskecstestTaskDefinitionExecutionRoleF588BC50",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "testecstaskecstestTaskDefinitionExecutionRoleF588BC50": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testecstaskecstestTaskDefinitionTaskRole4D626B6F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testecstaskecstestTaskDefinitionTaskRoleDefaultPolicy65D034C8": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/test-stack/TEST/ecs-test/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "databaseSecretArn",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testecstaskecstestTaskDefinitionTaskRoleDefaultPolicy65D034C8",
+        "Roles": [
+          {
+            "Ref": "testecstaskecstestTaskDefinitionTaskRole4D626B6F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "testecstaskecstestTaskDefinitiontestecstaskecstestTaskContainerLogGroup3F63585A": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 14,
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "ecs-test",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+  },
+}
+`;

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
     "gu:cdk:constructs": [
       "GuStack",
       "GuEcsTask",
+      "GuSubnetListParameter",
       "GuDistributionBucketParameter",
     ],
     "gu:cdk:version": "TEST",
@@ -22,6 +23,11 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "ecstestPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
   },
   "Resources": {
@@ -190,7 +196,34 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
                   "Arn",
                 ],
               },
-              "","TaskDefinition":"test-stack-TEST-ecs-test","NetworkConfiguration":{"AwsvpcConfiguration":{"Subnets":["abc-123"],"SecurityGroups":["id-123"]}},"Overrides":{"ContainerOverrides":[{"Name":"test-ecs-task-ecs-test-TaskContainer"}]},"LaunchType":"FARGATE","PlatformVersion":"LATEST"}}}}",
+              "","TaskDefinition":"test-stack-TEST-ecs-test","NetworkConfiguration":{"AwsvpcConfiguration":{"Subnets":["",
+              {
+                "Fn::Select": [
+                  0,
+                  {
+                    "Ref": "ecstestPrivateSubnets",
+                  },
+                ],
+              },
+              "","",
+              {
+                "Fn::Select": [
+                  1,
+                  {
+                    "Ref": "ecstestPrivateSubnets",
+                  },
+                ],
+              },
+              "","",
+              {
+                "Fn::Select": [
+                  2,
+                  {
+                    "Ref": "ecstestPrivateSubnets",
+                  },
+                ],
+              },
+              ""],"SecurityGroups":["id-123"]}},"Overrides":{"ContainerOverrides":[{"Name":"test-ecs-task-ecs-test-TaskContainer"}]},"LaunchType":"FARGATE","PlatformVersion":"LATEST"}}}}",
             ],
           ],
         },

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -1211,6 +1211,10 @@ exports[`The GuEcsTask pattern should support overriding the subnets used by the
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -6,7 +6,6 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
     "gu:cdk:constructs": [
       "GuStack",
       "GuEcsTask",
-      "GuSubnetListParameter",
       "GuDistributionBucketParameter",
     ],
     "gu:cdk:version": "TEST",
@@ -23,11 +22,6 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "ecstestPrivateSubnets": {
-      "Default": "/account/vpc/primary/subnets/private",
-      "Description": "A list of private subnets",
-      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
   },
   "Resources": {
@@ -196,34 +190,7 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
                   "Arn",
                 ],
               },
-              "","TaskDefinition":"test-stack-TEST-ecs-test","NetworkConfiguration":{"AwsvpcConfiguration":{"Subnets":["",
-              {
-                "Fn::Select": [
-                  0,
-                  {
-                    "Ref": "ecstestPrivateSubnets",
-                  },
-                ],
-              },
-              "","",
-              {
-                "Fn::Select": [
-                  1,
-                  {
-                    "Ref": "ecstestPrivateSubnets",
-                  },
-                ],
-              },
-              "","",
-              {
-                "Fn::Select": [
-                  2,
-                  {
-                    "Ref": "ecstestPrivateSubnets",
-                  },
-                ],
-              },
-              ""],"SecurityGroups":["id-123"]}},"Overrides":{"ContainerOverrides":[{"Name":"test-ecs-task-ecs-test-TaskContainer"}]},"LaunchType":"FARGATE","PlatformVersion":"LATEST"}}}}",
+              "","TaskDefinition":"test-stack-TEST-ecs-test","NetworkConfiguration":{"AwsvpcConfiguration":{"Subnets":["abc-123"],"SecurityGroups":["id-123"]}},"Overrides":{"ContainerOverrides":[{"Name":"test-ecs-task-ecs-test-TaskContainer"}]},"LaunchType":"FARGATE","PlatformVersion":"LATEST"}}}}",
             ],
           ],
         },

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -1,6 +1,6 @@
 import { Template } from "aws-cdk-lib/assertions";
-import type { ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
-import { SecurityGroup, Vpc } from "aws-cdk-lib/aws-ec2";
+import type { ISubnet, IVpc} from "aws-cdk-lib/aws-ec2";
+import { SecurityGroup, Subnet, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
 import type { GuStack } from "../core";
@@ -81,13 +81,11 @@ describe("The GuEcsTask pattern", () => {
   it("should support overriding the subnets used by the task", () => {
     const stack = simpleGuStackForTesting();
 
-    const vpc2 = Vpc.fromVpcAttributes(stack, "VPC2", {
-      vpcId: "test",
-      availabilityZones: [""],
-      publicSubnetIds: [""],
-      privateSubnetIds: ["abc-123", "def-456"],
-    });
-    generateComplexStack(stack, "ecs-test", makeVpc(stack), vpc2.privateSubnets);
+    const subnets = [
+      Subnet.fromSubnetId(stack, "subnet-abc-123", "abc-123"),
+      Subnet.fromSubnetId(stack, "subnet-def-456", "def-456"),
+    ];
+    generateComplexStack(stack, "ecs-test", makeVpc(stack), subnets);
 
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -1,5 +1,5 @@
 import { Template } from "aws-cdk-lib/assertions";
-import type {ISubnet, IVpc} from "aws-cdk-lib/aws-ec2";
+import type { ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { SecurityGroup, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -1,5 +1,5 @@
 import { Template } from "aws-cdk-lib/assertions";
-import type { ISubnet, IVpc} from "aws-cdk-lib/aws-ec2";
+import type { ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { SecurityGroup, Subnet, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -1,5 +1,5 @@
 import { Template } from "aws-cdk-lib/assertions";
-import type { IVpc } from "aws-cdk-lib/aws-ec2";
+import type {ISubnet, IVpc} from "aws-cdk-lib/aws-ec2";
 import { SecurityGroup, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
@@ -39,11 +39,11 @@ describe("The GuEcsTask pattern", () => {
     });
   });
 
-  const generateComplexStack = (stack: GuStack, app: string, vpc: IVpc) => {
+  const generateComplexStack = (stack: GuStack, app: string, vpc: IVpc, subnets?: ISubnet[]) => {
     new GuEcsTask(stack, `test-ecs-task-${app}`, {
       containerConfiguration: { id: "node:10", type: "registry" },
       vpc,
-      subnets: vpc.privateSubnets,
+      subnets: subnets ?? vpc.privateSubnets,
       app: app,
       taskTimeoutInMinutes: 60,
       cpu: 1024,
@@ -76,5 +76,19 @@ describe("The GuEcsTask pattern", () => {
 
     template.hasGuTaggedResource("AWS::ECS::TaskDefinition", { appIdentity: { app: "ecs-test" } });
     template.hasGuTaggedResource("AWS::ECS::TaskDefinition", { appIdentity: { app: "ecs-test2" } });
+  });
+
+  it("should support overriding the subnets used by the task", () => {
+    const stack = simpleGuStackForTesting();
+
+    const vpc2 = Vpc.fromVpcAttributes(stack, "VPC2", {
+      vpcId: "test",
+      availabilityZones: [""],
+      publicSubnetIds: [""],
+      privateSubnetIds: ["abc-123", "def-456"],
+    });
+    generateComplexStack(stack, "ecs-test", makeVpc(stack), vpc2.privateSubnets);
+
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 });

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -25,11 +25,12 @@ const testPolicy = new PolicyStatement({
 describe("The GuEcsTask pattern", () => {
   it("should use the specified container", () => {
     const stack = simpleGuStackForTesting();
-
+    const vpc = makeVpc(stack);
     new GuEcsTask(stack, "test-ecs-task", {
       containerConfiguration: { id: "node:10", type: "registry" },
       monitoringConfiguration: { noMonitoring: true },
-      vpc: makeVpc(stack),
+      vpc,
+      subnets: vpc.privateSubnets,
       app: "ecs-test",
     });
 
@@ -42,6 +43,7 @@ describe("The GuEcsTask pattern", () => {
     new GuEcsTask(stack, `test-ecs-task-${app}`, {
       containerConfiguration: { id: "node:10", type: "registry" },
       vpc,
+      subnets: vpc.privateSubnets,
       app: app,
       taskTimeoutInMinutes: 60,
       cpu: 1024,

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -202,8 +202,8 @@ export class GuEcsTask extends Construct {
     const taskSubnets = subnets
       ? subnets
       : assignPublicIp
-        ? GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app })
-        : GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app });
+        ? GuVpc.subnetsFromParameterFixedNumber(scope, { type: SubnetType.PUBLIC, app }, 3)
+        : GuVpc.subnetsFromParameterFixedNumber(scope, { type: SubnetType.PRIVATE, app }, 3);
 
     const { stack, stage } = scope;
 

--- a/src/patterns/scheduled-ecs-task.test.ts
+++ b/src/patterns/scheduled-ecs-task.test.ts
@@ -17,13 +17,14 @@ const makeVpc = (stack: GuStack) =>
 describe("The GuScheduledEcsTask pattern", () => {
   it("should use the specified schedule", () => {
     const stack = simpleGuStackForTesting();
-
+    const vpc = makeVpc(stack);
     new GuScheduledEcsTask(stack, "test", {
       schedule: Schedule.rate(Duration.minutes(1)),
       containerConfiguration: { id: "node:10", type: "registry" },
       monitoringConfiguration: { noMonitoring: true },
-      vpc: makeVpc(stack),
+      vpc,
       app: "ecs-test",
+      subnets: vpc.privateSubnets,
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", { ScheduleExpression: "rate(1 minute)" });


### PR DESCRIPTION
## What does this change?
I ran into an issue when working with the ecs-task role where I found it only worked if you provided a cdk context file. This was because, by default an EcsRunTask will try to assign itself to the 'PRIVATE' subnets identified by the cdk context file. This works for lurch (which was the project the Ecs task role was created for) because that project is a private repo, with a [checked in context file](https://github.com/guardian/lurch/blob/main/packages/infra/cdk.context.json#L8).

Relying on a context file isn't ideal. This PR removes the need for a context file by requiring consumers to either specify which subnets to use directly, or falling back to using `GuVpc.subnetsFromParameterFixedNumber`

But what is `GuVpc.subnetsFromParameterFixedNumber`?

Unfortunately, when I tried to use just the normal `GuVpc.subnetsFromParameter` it resulted in CDK creating a custom resource, presumably to deal with some assumed circular dependency. You can see an example of the custom resource mess [here](https://github.com/guardian/cdk/actions/runs/11348935560/job/31563876756?pr=2477).

The issue is caused by this line in GuVpc: https://github.com/guardian/cdk/blob/b61bbc6f06d05f3cebfab057e310d9b3323041f8/src/constructs/ec2/vpc.ts#L45

With some experimentation, I discovered that if you specify the subnets using .bySubnetId, and use a standard cloudformation list operation (Fn.select), then this custom resource is avoided. The thing is, I was a bit reluctant (scared) to change the existing approach to subnets, as it would affect all GuEc2Apps. The alternative approach of using Fn.select also makes for slightly messier cloudformation output - instead of looking like this:

        "Subnets": {
          "Ref": "testguec2appPublicSubnets",
        },

the subnets definition ends up looking like this:

```
{"Subnets":["",
              {
                "Fn::Select": [
                  0,
                  {
                    "Ref": "ecstestPrivateSubnets",
                  },
                ],
              },
              "","",
              {
                "Fn::Select": [
                  1,
                  {
                    "Ref": "ecstestPrivateSubnets",
                  },
                ],
              },
              "","",
              {
                "Fn::Select": [
                  2,
                  {
                    "Ref": "ecstestPrivateSubnets",
                  },
                ],
              },
              ""]
```

The new approach also assumes knowledge of how many subnets there are - whilst we usually have 3, in the tests we sometimes just have one, so more effort would be needed there.

I think this approach is a reasonable compromise, but very happy to talk it through/try to pair on a better solution.

Whilst I try and resolve that, this is a placeholder PR so I can share the work with others

## How to test
