### PR TITLE
fix: Publish new version reverting 59.5.3

### DIFF
--- a/.changeset/wise-starfish-prove.md
+++ b/.changeset/wise-starfish-prove.md
@@ -1,0 +1,5 @@
+  ---
+  "@guardian/cdk": patch
+  ---
+
+  Revert mistakenly published version v59.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @guardian/cdk
 
+## 59.5.3
+
+**DO NOT USE**: Published by mistake.
+
 ## 59.5.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@guardian/cdk",
   "description": "Generic Guardian flavoured AWS CDK components",
-  "version": "59.5.2",
+  "version": "59.5.3",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## What does this change?

v59.5.3 was published by mistake whilst trying to publish a beta build from the `beta` branch.

Instead of unpublishing 59.5.3 which would leave a hole in our NPM versions as per https://docs.npmjs.com/policies/unpublish instead publish a new 59.5.4 version which reverts the changes that were made in 59.5.3.

Also include the latest version bumps.