### PR TITLE
Parameterise cpuArchitecture for GuEcsTask

### DIFF
--- a/.changeset/brave-pots-act.md
+++ b/.changeset/brave-pots-act.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": major
+---
+
+Add cpuArchitecture property to guecstask, default it to ARM64

--- a/.changeset/brave-pots-act.md
+++ b/.changeset/brave-pots-act.md
@@ -2,4 +2,4 @@
 "@guardian/cdk": major
 ---
 
-Add cpuArchitecture property to guecstask, default it to ARM64
+Set CPU architecture of ECS tasks to ARM64

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier:check": "prettier --check \"src/**/*.ts\"",
     "format": "prettier --write \"src/**/*.ts\"",
     "watch": "tsc -w",
-    "test": "jest --detectOpenHandles --runInBand",
+    "test": "jest --detectOpenHandles --runInBand -u",
     "test:custom-lint-rule": "eslint tools/eslint/rules/*.test.ts",
     "test:dev": "jest --detectOpenHandles --runInBand --watch",
     "prepare": "tsc",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prettier:check": "prettier --check \"src/**/*.ts\"",
     "format": "prettier --write \"src/**/*.ts\"",
     "watch": "tsc -w",
-    "test": "jest --detectOpenHandles --runInBand -u",
+    "test": "jest --detectOpenHandles --runInBand",
     "test:custom-lint-rule": "eslint tools/eslint/rules/*.test.ts",
     "test:dev": "jest --detectOpenHandles --runInBand --watch",
     "prepare": "tsc",

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -499,6 +499,10 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -8,8 +8,10 @@ import {
   Cluster,
   Compatibility,
   ContainerImage,
+  CpuArchitecture,
   FargatePlatformVersion,
   LogDrivers,
+  OperatingSystemFamily,
   TaskDefinition,
 } from "aws-cdk-lib/aws-ecs";
 import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
@@ -131,6 +133,11 @@ export interface GuEcsTaskProps extends AppIdentity {
    * @default false
    */
   containerInsights?: boolean;
+  /**
+   * Set architecture
+   * @default ARM64
+   */
+  cpuArchitecture?: CpuArchitecture;
 }
 
 /**
@@ -180,6 +187,7 @@ export class GuEcsTask extends Construct {
       enableDistributablePolicy = true,
       readonlyRootFilesystem = false,
       containerInsights = false,
+      cpuArchitecture = CpuArchitecture.ARM64,
     } = props;
 
     if (storage && storage < 21) {
@@ -203,6 +211,10 @@ export class GuEcsTask extends Construct {
       memoryMiB: memory.toString(),
       family: `${stack}-${stage}-${app}`,
       ephemeralStorageGiB: storage,
+      runtimePlatform: {
+        cpuArchitecture: cpuArchitecture,
+        operatingSystemFamily: OperatingSystemFamily.of("LINUX"),
+      },
     });
 
     const containerDefinition = taskDefinition.addContainer(`${id}-TaskContainer`, {

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -133,11 +133,6 @@ export interface GuEcsTaskProps extends AppIdentity {
    * @default false
    */
   containerInsights?: boolean;
-  /**
-   * Set architecture
-   * @default ARM64
-   */
-  cpuArchitecture?: CpuArchitecture;
 }
 
 /**
@@ -187,7 +182,6 @@ export class GuEcsTask extends Construct {
       enableDistributablePolicy = true,
       readonlyRootFilesystem = false,
       containerInsights = false,
-      cpuArchitecture = CpuArchitecture.ARM64,
     } = props;
 
     if (storage && storage < 21) {
@@ -212,7 +206,7 @@ export class GuEcsTask extends Construct {
       family: `${stack}-${stage}-${app}`,
       ephemeralStorageGiB: storage,
       runtimePlatform: {
-        cpuArchitecture: cpuArchitecture,
+        cpuArchitecture: CpuArchitecture.ARM64,
         operatingSystemFamily: OperatingSystemFamily.of("LINUX"),
       },
     });


### PR DESCRIPTION
## What does this change?
Previously we could only launch x86 ecs tasks. This resolves that.

Note - @akash1810 suggested pulling the ecs task out of GuCDK since it's only used by investigations. V happy to do this but in the short term it would be helpful to have this extra configuration property

## How to test
I've tested this by deploying to a project in the investigations account.
