### PR TITLE
feat: Default to GP3 storage type in RDS for better performance and cost saving

### DIFF
--- a/.changeset/soft-scissors-turn.md
+++ b/.changeset/soft-scissors-turn.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Default to GP3 storage type for RDS

--- a/src/constructs/rds/instance.ts
+++ b/src/constructs/rds/instance.ts
@@ -1,6 +1,6 @@
 import { Fn, Tags } from "aws-cdk-lib";
 import { InstanceType } from "aws-cdk-lib/aws-ec2";
-import { DatabaseInstance } from "aws-cdk-lib/aws-rds";
+import { DatabaseInstance, StorageType } from "aws-cdk-lib/aws-rds";
 import type { DatabaseInstanceProps } from "aws-cdk-lib/aws-rds";
 import { GuAppAwareConstruct } from "../../utils/mixin/app-aware-construct";
 import type { AppIdentity, GuStack } from "../core";
@@ -39,6 +39,7 @@ export class GuDatabaseInstance extends GuAppAwareConstruct(DatabaseInstance) {
     const instanceType = new InstanceType(Fn.join("", Fn.split("db.", props.instanceType)));
 
     super(scope, id, {
+      storageType: StorageType.GP3,
       deletionProtection: true,
       deleteAutomatedBackups: false,
       backupRetention: props.devXBackups.enabled ? undefined : props.devXBackups.backupRetention,


### PR DESCRIPTION
## What does this change?
Hello my old friends 👋 
While doing some DB work, I got curious and noticed that `GuDatabaseInstance` defaults to the older class of SSD storage `gp2`, which is outclassed by the newer `gp3` in terms of both performance and costs.

There is really no reason to use `gp2` these days, but I'm going to be cynical and assume that Amazon defaults to that because they can charge more for it and get away with it.

Even the official AWS docs say you should default to `gp3`: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage.GeneralSSD

## How to test
I've added a couple of tests to verify that you can still override the storage type, if you wish to do so.

## How can we measure success?
Cheaper AWS bill (roughly 35% cheaper with the same storage requirements and IOPS - [source](https://cloudfix.com/blog/migrate-gp2-to-gp3-better-performance-lower-costs/)), equal or better performance.

## Have we considered potential risks?
Yes. As per [official documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.ModifyingExisting.html), changing the storage type **will not** cause downtime or data loss, so I've marked this as a minor semver change rather than breaking.

> Scaling storage usually doesn't cause any outage or performance degradation of the DB instance. After you modify the storage size for a DB instance, the status of the DB instance is storage-optimization.

> Storage optimization can take several hours. You can't make further storage modifications for either six (6) hours or until storage optimization has completed on the instance, whichever is longer. You can view the storage optimization progress in the AWS Management Console or by using the [describe-db-instances](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-instances.html) AWS CLI command.
## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] ~I have updated the documentation as required for the described changes~ [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
