### PR TITLE
Support multiple usages of `GuGithubActionsRole` in a single AWS account

### DIFF
--- a/.changeset/friendly-trainers-cry.md
+++ b/.changeset/friendly-trainers-cry.md
@@ -1,0 +1,16 @@
+---
+"@guardian/cdk": major
+---
+
+Support multiple usages of `GuGithubActionsRole` in a single AWS account
+
+This significantly changes the resources constructed by `GuGithubActionsRole`,
+specifically, **the construct will no longer instantiate a `GitHubOidcProvider`**.
+This is because you can only ever have one `GitHubOidcProvider` per provider
+domain (ie `token.actions.githubusercontent.com`) - while we may want multiple
+instances of `GuGithubActionsRole` in an AWS account, we can't have the
+`GuGithubActionsRole` construct trying to make a new `GitHubOidcProvider` with
+each instance.
+
+Consequently, you will need to instantiate the `GitHubOidcProvider` elsewhere
+as a singleton. At the Guardian, we do this with https://github.com/guardian/aws-account-setup.

--- a/src/constructs/iam/roles/__snapshots__/github-actions.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/github-actions.test.ts.snap
@@ -42,19 +42,6 @@ exports[`The GitHubActionsRole construct should create the correct resources wit
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GithubActionsOidc": {
-      "Properties": {
-        "ClientIdList": [
-          "sts.amazonaws.com",
-        ],
-        "ThumbprintList": [
-          "6938fd4d98bab03faadb97b34396831e3780aea1",
-          "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
-        ],
-        "Url": "https://token.actions.githubusercontent.com",
-      },
-      "Type": "AWS::IAM::OIDCProvider",
-    },
     "GithubActionsRoleF5CC769F": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -69,7 +56,16 @@ exports[`The GitHubActionsRole construct should create the correct resources wit
               "Effect": "Allow",
               "Principal": {
                 "Federated": {
-                  "Ref": "GithubActionsOidc",
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:iam::",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":oidc-provider/token.actions.githubusercontent.com",
+                    ],
+                  ],
                 },
               },
             },


### PR DESCRIPTION
This significantly changes the resources constructed by `GuGithubActionsRole`, specifically, **the construct will no longer instantiate a `GitHubOidcProvider`**. This is because you can only ever have one `GitHubOidcProvider` per provider domain (ie `token.actions.githubusercontent.com`) - while we may want multiple instances of `GuGithubActionsRole` in an AWS account, we can't have the `GuGithubActionsRole` construct trying to make a new `GitHubOidcProvider` with each instance.

Consequently, you will need to instantiate the `GitHubOidcProvider` elsewhere as a singleton. At the Guardian, we do this with https://github.com/guardian/aws-account-setup.

Fixes https://github.com/guardian/cdk/issues/2529.
