### PR TITLE
fix(GitHubOidcProvider): Ensure `AWS::IAM::OIDCProvider` resource is tagged

### DIFF
--- a/.changeset/nasty-parrots-mix.md
+++ b/.changeset/nasty-parrots-mix.md
@@ -1,0 +1,6 @@
+---
+"@guardian/cdk": patch
+---
+
+Apply the standard `Stack`, `Stage`, `App` and `gu:repo` tags to the `AWS::IAM::OIDCProvider` resource
+created via the `GitHubOidcProvider` construct.

--- a/src/constructs/iam/roles/github-actions.test.ts
+++ b/src/constructs/iam/roles/github-actions.test.ts
@@ -1,7 +1,7 @@
 import { Template } from "aws-cdk-lib/assertions";
-import { simpleGuStackForTesting } from "../../../utils/test";
+import { GuTemplate, simpleGuStackForTesting } from "../../../utils/test";
 import { GuGetS3ObjectsPolicy } from "../policies";
-import { GuGithubActionsRole } from "./github-actions";
+import { GitHubOidcProvider, GuGithubActionsRole } from "./github-actions";
 
 describe("The GitHubActionsRole construct", () => {
   it("should create the correct resources with minimal config", () => {
@@ -45,5 +45,14 @@ describe("The GitHubActionsRole construct", () => {
         ],
       },
     });
+  });
+});
+
+describe("The GitHubOidcProvider construct", () => {
+  it("should be tagged correctly", () => {
+    const stack = simpleGuStackForTesting();
+    new GitHubOidcProvider(stack);
+
+    GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::IAM::OIDCProvider");
   });
 });

--- a/src/constructs/iam/roles/github-actions.ts
+++ b/src/constructs/iam/roles/github-actions.ts
@@ -75,6 +75,7 @@ export class GitHubOidcProvider extends CfnResource {
         Url: `https://${GITHUB_ACTIONS_ID_TOKEN_REQUEST_DOMAIN}`,
         ClientIdList: ["sts.amazonaws.com"],
         ThumbprintList: GITHUB_ACTIONS_ID_TOKEN_REQUEST_DOMAIN_THUMBPRINTS,
+        Tags: scope.tags.renderedTags,
       },
     });
   }


### PR DESCRIPTION
## What does this change?
Apply the standard `Stack`, `Stage`, `App` and `gu:repo` tags to the `AWS::IAM::OIDCProvider` resource created by the `GitHubOidcProvider` construct.

This was previously absent as we're creating `AWS::IAM::OIDCProvider` via a level 1 construct; AWS CDK only automatically tags level 2 constructs.

## How to test
See the added unit test. The test uses the [`hasGuTaggedResource`](https://github.com/guardian/cdk/blob/5f483a0abe04e4f962729f5fa43ba1a7f3afb664/src/utils/test/assertions.ts#L67) assertion helper.

## How can we measure success?
Tagging resources makes it easier to identify their origin, and to allocate costs, etc.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
