### PR TITLE
feat: mount a volume and enforce readonlyRootFilesystem in ecs-task

### DIFF
--- a/.changeset/fluffy-cameras-enjoy.md
+++ b/.changeset/fluffy-cameras-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": major
+---
+
+Enforce readonlyRootFilesystem in ecs-task. Support mounting a volume in ecs-task.

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -479,8 +479,15 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
               },
             },
             "Memory": 1024,
+            "MountPoints": [
+              {
+                "ContainerPath": "/opt/testing",
+                "ReadOnly": false,
+                "SourceVolume": "ecs-test-volume",
+              },
+            ],
             "Name": "test-ecs-task-ecs-test-TaskContainer",
-            "ReadonlyRootFilesystem": false,
+            "ReadonlyRootFilesystem": true,
           },
         ],
         "Cpu": "1024",
@@ -531,6 +538,11 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
             "Arn",
           ],
         },
+        "Volumes": [
+          {
+            "Name": "ecs-test-volume",
+          },
+        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -1191,8 +1203,15 @@ exports[`The GuEcsTask pattern should support overriding the subnets used by the
               },
             },
             "Memory": 1024,
+            "MountPoints": [
+              {
+                "ContainerPath": "/opt/testing",
+                "ReadOnly": false,
+                "SourceVolume": "ecs-test-volume",
+              },
+            ],
             "Name": "test-ecs-task-ecs-test-TaskContainer",
-            "ReadonlyRootFilesystem": false,
+            "ReadonlyRootFilesystem": true,
           },
         ],
         "Cpu": "1024",
@@ -1243,6 +1262,11 @@ exports[`The GuEcsTask pattern should support overriding the subnets used by the
             "Arn",
           ],
         },
+        "Volumes": [
+          {
+            "Name": "ecs-test-volume",
+          },
+        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -49,6 +49,7 @@ describe("The GuEcsTask pattern", () => {
       cpu: 1024,
       memory: 1024,
       storage: 30,
+      volumeMountPath: "/opt/testing",
       monitoringConfiguration: { snsTopicArn: "arn:something:else:here:we:goalarm-topic", noMonitoring: false },
       taskCommand: `echo "yo ho row ho it's a pirates life for me"`,
       securityGroups: [securityGroup(stack, app)],


### PR DESCRIPTION
## What does this change?
I'm trying to resolve [[ECS.5] ECS containers should be limited to read-only access to root filesystems
](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-5) for a number of ECS tasks in the investigations account. To do this we need to switch those tasks over to writing to a non-root volume.

Given that this is best practice, in this PR I am enforcing readonlyRootFilesystem. Of the 3 services that use this pattern, coverdrop already has readonlyRootFilesystem set to true. I'll update lurch and transcription service once this feature is out. 

This PR adds an extra parameter to ecs-task `volumeMountPath` which, when set, will mount a volume for use by the container. I opted to just support a single volume rather than making this an array or similar to keep the task simple - of the 3 services which use this pattern, all of them will be fine with just the one volume.

## How to test
I tested this change using one of the lurch CODE tasks definitions, and verified that it was able to run succesfully (writing to disk along the way) without any problems