### PR TITLE
Add `GuKCLPolicy`, a IAM-policy construct for the Kinesis Client Library (KCL)

### DIFF
--- a/.changeset/neat-roses-smell.md
+++ b/.changeset/neat-roses-smell.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": major
+---
+
+Add GuKCLPolicy, a IAM-policy construct for the Kinesis Client Library

--- a/.changeset/neat-roses-smell.md
+++ b/.changeset/neat-roses-smell.md
@@ -1,5 +1,5 @@
 ---
-"@guardian/cdk": major
+"@guardian/cdk": minor
 ---
 
 Add GuKCLPolicy, a IAM-policy construct for the Kinesis Client Library

--- a/src/constructs/iam/policies/index.ts
+++ b/src/constructs/iam/policies/index.ts
@@ -4,6 +4,7 @@ export * from "./base-policy";
 export * from "./cloudwatch";
 export * from "./describe-ec2";
 export * from "./dynamodb";
+export * from "./kcl";
 export * from "./log-shipping";
 export * from "./parameter-store-read";
 export * from "./s3-get-object";

--- a/src/constructs/iam/policies/kcl.test.ts
+++ b/src/constructs/iam/policies/kcl.test.ts
@@ -1,0 +1,124 @@
+import { Template } from "aws-cdk-lib/assertions";
+import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../utils/test";
+import { GuKCLPolicy } from "./kcl";
+
+describe("GuKCLPolicy", () => {
+  it("should create a policy granting sufficient permissions for the KCL", () => {
+    const stack = simpleGuStackForTesting();
+
+    const policy = new GuKCLPolicy(stack, { streamName: "streamFoo", applicationName: "appBar" });
+
+    attachPolicyToTestRole(stack, policy);
+
+    Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+      PolicyName: "GuKCLPolicy9F96CFCB",
+      PolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: [
+              "kinesis:DescribeStream",
+              "kinesis:DescribeStreamSummary",
+              "kinesis:RegisterStreamConsumer",
+              "kinesis:GetRecords",
+              "kinesis:GetShardIterator",
+              "kinesis:ListShards",
+            ],
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                ["arn:aws:kinesis:", { Ref: "AWS::Region" }, ":", { Ref: "AWS::AccountId" }, ":stream/streamFoo"],
+              ],
+            },
+          },
+          {
+            Action: ["kinesis:SubscribeToShard", "kinesis:DescribeStreamConsumer"],
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:kinesis:",
+                  { Ref: "AWS::Region" },
+                  ":",
+                  { Ref: "AWS::AccountId" },
+                  ":stream/streamFoo/consumer/*",
+                ],
+              ],
+            },
+          },
+          {
+            Action: [
+              "dynamodb:Scan",
+              "dynamodb:CreateTable",
+              "dynamodb:DescribeTable",
+              "dynamodb:GetItem",
+              "dynamodb:PutItem",
+            ],
+            Effect: "Allow",
+            Resource: [
+              {
+                "Fn::Join": [
+                  "",
+                  ["arn:aws:dynamodb:", { Ref: "AWS::Region" }, ":", { Ref: "AWS::AccountId" }, ":table/appBar"],
+                ],
+              },
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:dynamodb:",
+                    { Ref: "AWS::Region" },
+                    ":",
+                    { Ref: "AWS::AccountId" },
+                    ":table/appBar-WorkerMetricStats",
+                  ],
+                ],
+              },
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:dynamodb:",
+                    { Ref: "AWS::Region" },
+                    ":",
+                    { Ref: "AWS::AccountId" },
+                    ":table/appBar-CoordinatorState",
+                  ],
+                ],
+              },
+            ],
+          },
+          {
+            Action: ["dynamodb:UpdateTable", "dynamodb:UpdateItem", "dynamodb:DeleteItem"],
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                ["arn:aws:dynamodb:", { Ref: "AWS::Region" }, ":", { Ref: "AWS::AccountId" }, ":table/appBar"],
+              ],
+            },
+          },
+          {
+            Action: "dynamodb:Query",
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": [
+                "",
+                ["arn:aws:dynamodb:", { Ref: "AWS::Region" }, ":", { Ref: "AWS::AccountId" }, ":table/appBar/index/*"],
+              ],
+            },
+          },
+          {
+            Action: "cloudwatch:PutMetricData",
+            Effect: "Allow",
+            Resource: {
+              "Fn::Join": ["", ["arn:aws:cloudwatch:", { Ref: "AWS::Region" }, ":", { Ref: "AWS::AccountId" }, ":*"]],
+            },
+          },
+        ],
+      },
+    });
+  });
+});

--- a/src/constructs/iam/policies/kcl.test.ts
+++ b/src/constructs/iam/policies/kcl.test.ts
@@ -11,7 +11,7 @@ describe("GuKCLPolicy", () => {
     attachPolicyToTestRole(stack, policy);
 
     Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
-      PolicyName: "GuKCLPolicy9F96CFCB",
+      PolicyName: "GuKCLPolicyappBar97AA7802",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/kcl.ts
+++ b/src/constructs/iam/policies/kcl.ts
@@ -18,7 +18,13 @@ const kinesisActions: string[] = [
 
 const kinesisEnhancedFanOutActions: string[] = ["SubscribeToShard", "DescribeStreamConsumer"];
 
-const actionsOnAllTables: string[] = ["Scan", "CreateTable", "DescribeTable", "GetItem", "PutItem"];
+const actionsOnAllTables: string[] = [
+  "Scan",
+  "CreateTable", // Allow KCL creating the lease, metrics, and coordinator tables - see https://github.com/guardian/cdk/pull/2578#discussion_r1954061397
+  "DescribeTable",
+  "GetItem",
+  "PutItem",
+];
 
 const additionalLeaseTableActions: string[] = ["UpdateTable", "UpdateItem", "DeleteItem"];
 

--- a/src/constructs/iam/policies/kcl.ts
+++ b/src/constructs/iam/policies/kcl.ts
@@ -1,0 +1,65 @@
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { GuStack } from "../../core";
+import { GuPolicy } from "./base-policy";
+
+export interface KCLApplication {
+  streamName: string;
+  applicationName: string;
+}
+
+const kinesisActions: string[] = [
+  "DescribeStream",
+  "DescribeStreamSummary",
+  "RegisterStreamConsumer",
+  "GetRecords",
+  "GetShardIterator",
+  "ListShards",
+];
+
+const kinesisEnhancedFanOutActions: string[] = ["SubscribeToShard", "DescribeStreamConsumer"];
+
+const actionsOnAllTables: string[] = ["Scan", "CreateTable", "DescribeTable", "GetItem", "PutItem"];
+
+const additionalLeaseTableActions: string[] = ["UpdateTable", "UpdateItem", "DeleteItem"];
+
+/**
+ * Creates an `AWS::IAM::Policy` to grant all the required permissions for the Kinesis Client Library
+ * (https://github.com/awslabs/amazon-kinesis-client) - specifically for KCL v3, which requires many
+ * additional permissions over KCL v2.
+ *
+ * @see https://docs.aws.amazon.com/streams/latest/dev/kcl-iam-permissions.html
+ */
+export class GuKCLPolicy extends GuPolicy {
+  constructor(scope: GuStack, props: KCLApplication) {
+    function allow(actionType: string, actions: string[], resources: string[]): PolicyStatement {
+      return new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: actions.map((a) => `${actionType}:${a}`),
+        resources: resources.map((r) => `arn:aws:${actionType}:${scope.region}:${scope.account}:${r}`),
+      });
+    }
+
+    function allowDynamoDB(actions: string[], tableOrIndexNames: string[]): PolicyStatement {
+      return allow(
+        "dynamodb",
+        actions,
+        tableOrIndexNames.map((name) => `table/${name}`),
+      );
+    }
+
+    const leaseTable = props.applicationName;
+    const metricsTable = `${props.applicationName}-WorkerMetricStats`;
+    const coordinatorTable = `${props.applicationName}-CoordinatorState`;
+
+    super(scope, "GuKCLPolicy", {
+      statements: [
+        allow("kinesis", kinesisActions, [`stream/${props.streamName}`]),
+        allow("kinesis", kinesisEnhancedFanOutActions, [`stream/${props.streamName}/consumer/*`]),
+        allowDynamoDB(actionsOnAllTables, [leaseTable, metricsTable, coordinatorTable]),
+        allowDynamoDB(additionalLeaseTableActions, [leaseTable]),
+        allowDynamoDB(["Query"], [`${leaseTable}/index/*`]),
+        allow("cloudwatch", ["PutMetricData"], ["*"]),
+      ],
+    });
+  }
+}

--- a/src/constructs/iam/policies/kcl.ts
+++ b/src/constructs/iam/policies/kcl.ts
@@ -51,7 +51,7 @@ export class GuKCLPolicy extends GuPolicy {
     const metricsTable = `${props.applicationName}-WorkerMetricStats`;
     const coordinatorTable = `${props.applicationName}-CoordinatorState`;
 
-    super(scope, "GuKCLPolicy", {
+    super(scope, `GuKCLPolicy${props.applicationName}`, {
       statements: [
         allow("kinesis", kinesisActions, [`stream/${props.streamName}`]),
         allow("kinesis", kinesisEnhancedFanOutActions, [`stream/${props.streamName}/consumer/*`]),


### PR DESCRIPTION
The new `GuKCLPolicy` construct creates an `AWS::IAM::Policy` to grant all the required permissions for the [Kinesis Client Library](https://github.com/awslabs/amazon-kinesis-client) - specifically for KCL **v3**, which requires [many additional permissions](https://docs.aws.amazon.com/streams/latest/dev/kcl-iam-permissions.html) over KCL v2 (largely because KCL 3.x introduced **two** new DynamoDB tables for metadata: [worker metrics](https://docs.aws.amazon.com/streams/latest/dev/kcl-dynamoDB.html#kcl-worker-metrics-table) & [coordinator state](https://docs.aws.amazon.com/streams/latest/dev/kcl-dynamoDB.html#kcl-coordinator-state-table)).

## Example of use

This PR is an example of swapping out existing KCL v2 policy code to use the new `GuKCLPolicy` construct:

* https://github.com/guardian/apple-news/pull/426

## Effective IAM permissions

The key code in `GuKCLPolicy` _defining_ the required policy statements is this: 

https://github.com/guardian/cdk/blob/ea3e23f87f817307549ed2169833f1473794c35f/src/constructs/iam/policies/kcl.ts#L56-L61

...we can compare this with the full cloudformation example taken from [AWS's documentation](https://docs.aws.amazon.com/streams/latest/dev/kcl-iam-permissions.html) (converted to YAML):

```yaml
- Effect: Allow
  Action:
    - kinesis:DescribeStream
    - kinesis:DescribeStreamSummary
    - kinesis:RegisterStreamConsumer
    - kinesis:GetRecords
    - kinesis:GetShardIterator
    - kinesis:ListShards
  Resource: arn:aws:kinesis:REGION:ACCOUNT_ID:stream/STREAM_NAME
- Effect: Allow
  Action:
    - kinesis:SubscribeToShard
    - kinesis:DescribeStreamConsumer
  Resource: arn:aws:kinesis:REGION:ACCOUNT_ID:stream/STREAM_NAME/consumer/*
- Effect: Allow
  Action:
    - dynamodb:CreateTable
    - dynamodb:DescribeTable
    - dynamodb:UpdateTable
    - dynamodb:GetItem
    - dynamodb:UpdateItem
    - dynamodb:PutItem
    - dynamodb:DeleteItem
    - dynamodb:Scan
  Resource:
    - arn:aws:dynamodb:REGION:ACCOUNT_ID:table/KCL_APPLICATION_NAME
- Effect: Allow
  Action:
    - dynamodb:CreateTable
    - dynamodb:DescribeTable
    - dynamodb:GetItem
    - dynamodb:UpdateItem
    - dynamodb:PutItem
    - dynamodb:DeleteItem
    - dynamodb:Scan
  Resource:
    - arn:aws:dynamodb:REGION:ACCOUNT_ID:table/KCL_APPLICATION_NAME-WorkerMetricStats
    - arn:aws:dynamodb:REGION:ACCOUNT_ID:table/KCL_APPLICATION_NAME-CoordinatorState
- Effect: Allow
  Action:
    - dynamodb:Query
  Resource:
    - arn:aws:dynamodb:REGION:ACCOUNT_ID:table/KCL_APPLICATION_NAME/index/*
- Effect: Allow
  Action:
    - cloudwatch:PutMetricData
  Resource: '*'
```

## See also

* https://github.com/guardian/content-api-firehose-client/pull/56
* Examples of previous PRs adding an IAM-policy construct:
  * https://github.com/guardian/cdk/pull/139
  * https://github.com/guardian/cdk/pull/278
