### PR TITLE
Fix construct id for `GuKCLPolicy`

### DIFF
--- a/.changeset/dirty-kids-camp.md
+++ b/.changeset/dirty-kids-camp.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Fix construct id for GuKCLPolicy

--- a/src/constructs/iam/policies/kcl.test.ts
+++ b/src/constructs/iam/policies/kcl.test.ts
@@ -6,12 +6,12 @@ describe("GuKCLPolicy", () => {
   it("should create a policy granting sufficient permissions for the KCL", () => {
     const stack = simpleGuStackForTesting();
 
-    const policy = new GuKCLPolicy(stack, { streamName: "streamFoo", applicationName: "appBar" });
+    const policy = new GuKCLPolicy(stack, "StreamFooKCLPolicy", { streamName: "streamFoo", applicationName: "appBar" });
 
     attachPolicyToTestRole(stack, policy);
 
     Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
-      PolicyName: "GuKCLPolicyappBar97AA7802",
+      PolicyName: "StreamFooKCLPolicy36019522",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/kcl.ts
+++ b/src/constructs/iam/policies/kcl.ts
@@ -36,7 +36,7 @@ const additionalLeaseTableActions: string[] = ["UpdateTable", "UpdateItem", "Del
  * @see https://docs.aws.amazon.com/streams/latest/dev/kcl-iam-permissions.html
  */
 export class GuKCLPolicy extends GuPolicy {
-  constructor(scope: GuStack, props: KCLApplication) {
+  constructor(scope: GuStack, id: string, props: KCLApplication) {
     function allow(actionType: string, actions: string[], resources: string[]): PolicyStatement {
       return new PolicyStatement({
         effect: Effect.ALLOW,
@@ -57,7 +57,7 @@ export class GuKCLPolicy extends GuPolicy {
     const metricsTable = `${props.applicationName}-WorkerMetricStats`;
     const coordinatorTable = `${props.applicationName}-CoordinatorState`;
 
-    super(scope, `GuKCLPolicy${props.applicationName}`, {
+    super(scope, id, {
       statements: [
         allow("kinesis", kinesisActions, [`stream/${props.streamName}`]),
         allow("kinesis", kinesisEnhancedFanOutActions, [`stream/${props.streamName}/consumer/*`]),


### PR DESCRIPTION
This fixes up a problem with this recent PR:

* https://github.com/guardian/cdk/pull/2578

Construct ids can not have unresolved tokens - but projects like `apple-news` load the name of the Kinesis stream from an SSM parameter, then [use it](https://github.com/guardian/apple-news/blob/79ac5e951ed37c5840d8b56212d5fffd3382deb6/cdk/lib/apple-news.ts#L103) as part of the 'application name':

```yaml
applicationName: `${crierStreamName}_apple-news-${this.stage}-LIVE`
```

This means that sadly we _can't_ use the application name as part of the construct id for the `GuKCLPolicy` (an alteration made with 5ab19bc6e49af3413b84f3a3b1da4cf51eb81dfc)...

https://github.com/guardian/cdk/blob/5ab19bc6e49af3413b84f3a3b1da4cf51eb81dfc/src/constructs/iam/policies/kcl.ts#L54

...if we do, with `apple-news`, we get an error like [this](https://github.com/guardian/apple-news/actions/runs/13328773507/job/37227875895?pr=426#step:6:13):

```
Resolution error: ID components may not include unresolved tokens: GuKCLPolicy${Token[TOKEN.36]}_apple-news-TEST-LIVE.
```

Instead, I think it's probably best to just delegate the choice of `id` to the calling code - if the calling code has 3 `GuKCLPolicy`s for 3 different kinesis streams, we can just come up with a reasonable meaningful id for each one - eg, for `apple-news`, the one there could just be called `crierKCLPolicy`.

## Testing

I've updated https://github.com/guardian/apple-news/pull/426 to verify that this fix allows `npm test` to pass after `npm i "guardian/cdk#fix-construct-id-for-GuKCLPolicy"` is run.