### PR TITLE
chore: Specify minimum `aws-cdk` version in peerDependencies instead of a specific version

### DIFF
--- a/.changeset/gold-owls-give.md
+++ b/.changeset/gold-owls-give.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Broaden CDK peer dependency ranges to allow any aws-cdk/construct version provided more recent than the specified version

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "aws-cdk": "2.1005.0",
-    "aws-cdk-lib": "2.185.0",
-    "constructs": "10.4.2"
+    "aws-cdk": "^2.1005.0",
+    "aws-cdk-lib": "^2.185.0",
+    "constructs": "^10.4.2"
   }
 }

--- a/script/ci-project-generation
+++ b/script/ci-project-generation
@@ -22,12 +22,10 @@ npm pack --pack-destination $TMP_DIR
     exit 1
   fi
 
-  npm install guardian-cdk-*.tgz
-
   # Ensure the CLI runs - the exit code should be 0.
-  npx gu-cdk --version
+  npx --yes guardian-cdk-*.tgz --version
 
-  NODE_ENV=test npx gu-cdk new \
+  NODE_ENV=test npx --yes guardian-cdk-*.tgz new \
     --app integration-test \
     --stack cdk \
     --stage CODE \

--- a/src/bin/commands/new-project/utils/init.ts
+++ b/src/bin/commands/new-project/utils/init.ts
@@ -84,14 +84,7 @@ function createPackageJson(outputDirectory: string): void {
   ].reduce((acc, depName) => ({ ...acc, [depName]: getDevDependency(depName)! }), {});
 
   const cdkDeps: Record<string, string> = {
-    /*
-      Do not add `@guardian/cdk` to the generated `package.json` file when in TEST as we'll `npm link` it instead.
-      See https://docs.npmjs.com/cli/v8/commands/npm-link#caveat
-
-      TODO remove this once the `new` command allows opting out of automatic dependency installation
-       */
-    ...(!isTest && { "@guardian/cdk": LibraryInfo.VERSION }),
-
+    "@guardian/cdk": isTest ? `file:../guardian-cdk-${LibraryInfo.VERSION}.tgz` : LibraryInfo.VERSION,
     "aws-cdk": LibraryInfo.AWS_CDK_VERSION,
     "aws-cdk-lib": LibraryInfo.AWS_CDK_LIB_VERSION,
     constructs: LibraryInfo.CONSTRUCTS_VERSION,


### PR DESCRIPTION
## What does this change?

We often get Dependabot PRs on our repos that try to update our version of `aws-cdk` before a new version of `@guardian/cdk` has been released, its quite annoying to have to wait till a new version of `@guardian/cdk` is released just to make a minor version update. Particularly as we group Dependabot PRs together causing us to have to manually remove the `aws-cdk` bumps from the group PR.

---

This pull request specifies a minimum `aws-cdk` version in `peerDependencies` instead of tagging a specific version. This is as per AWS's own recommendation [here](https://www.npmjs.com/package/aws-cdk-lib#installation):

> To make sure your library is compatible with the widest range of CDK versions: pick the minimum aws-cdk-lib version that your library requires; declare a range dependency with a caret on that version in peerDependencies, and declare a point version dependency on that version in devDependencies.

In practice we use Snapshot testing in most of our CDK projects meaning any compatability issues should be flagged by either failing snapshots or failing CI.


