### PR TITLE
feat: add rolling update support for MAPI

### DIFF
--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -7,6 +7,7 @@ import type { IConstruct } from "constructs";
 import { MetadataKeys } from "../../constants";
 import { GuAutoScalingGroup } from "../../constructs/autoscaling";
 import type { GuStack } from "../../constructs/core";
+import type { GuApplicationTargetGroup } from "../../constructs/loadbalancing";
 import type { GuEc2AppProps } from "../../patterns";
 import { GuEc2App } from "../../patterns";
 import { isSingletonPresentInStack } from "../../utils/singleton";
@@ -41,17 +42,17 @@ export const RollingUpdateDurations: AutoScalingRollingUpdateDurations = {
  *
  * TODO Expose the healthcheck grace period as a property on {@link GuEc2App} and remove this `Aspect`.
  */
-class AutoScalingRollingUpdateTimeout implements IAspect {
+export class AutoScalingRollingUpdateTimeoutExperimental implements IAspect {
   public readonly stack: GuStack;
-  private static instance: AutoScalingRollingUpdateTimeout | undefined;
+  private static instance: AutoScalingRollingUpdateTimeoutExperimental | undefined;
 
   private constructor(scope: GuStack) {
     this.stack = scope;
   }
 
-  public static getInstance(stack: GuStack): AutoScalingRollingUpdateTimeout {
+  public static getInstance(stack: GuStack): AutoScalingRollingUpdateTimeoutExperimental {
     if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
-      this.instance = new AutoScalingRollingUpdateTimeout(stack);
+      this.instance = new AutoScalingRollingUpdateTimeoutExperimental(stack);
     }
     return this.instance;
   }
@@ -109,20 +110,19 @@ class AutoScalingRollingUpdateTimeout implements IAspect {
  *
  * @see https://github.com/guardian/testing-asg-rolling-update
  */
-// eslint-disable-next-line custom-rules/experimental-classes -- this class is not indented for public use
-export class HorizontallyScalingDeploymentProperties implements IAspect {
+export class HorizontallyScalingDeploymentPropertiesExperimental implements IAspect {
   public readonly stack: GuStack;
   public readonly asgToParamMap: Map<string, CfnParameter>;
-  private static instance: HorizontallyScalingDeploymentProperties | undefined;
+  private static instance: HorizontallyScalingDeploymentPropertiesExperimental | undefined;
 
   private constructor(scope: GuStack) {
     this.stack = scope;
     this.asgToParamMap = new Map();
   }
 
-  public static getInstance(stack: GuStack): HorizontallyScalingDeploymentProperties {
+  public static getInstance(stack: GuStack): HorizontallyScalingDeploymentPropertiesExperimental {
     if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
-      this.instance = new HorizontallyScalingDeploymentProperties(stack);
+      this.instance = new HorizontallyScalingDeploymentPropertiesExperimental(stack);
     }
 
     return this.instance;
@@ -253,6 +253,90 @@ export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePo
   buildIdentifier: string;
 }
 
+export function rollingUpdatePolicy(maximumInstances: number, minimumInstances?: number): UpdatePolicy {
+  return UpdatePolicy.rollingUpdate({
+    maxBatchSize: maximumInstances,
+    minInstancesInService: minimumInstances,
+    minSuccessPercentage: 100,
+    waitOnResourceSignals: true,
+    /*
+    If a scale-in event fires during an `AutoScalingRollingUpdate` operation, the update could fail and rollback.
+    For this reason, we suspend the `AlarmNotification` process, else availability of a service cannot be guaranteed.
+    Consequently, services cannot scale-out during deployments.
+    If AWS ever supports suspending scale-out and scale-in independently, we should allow scale-out.
+     */
+    suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
+    // Note: there is also an important property called pauseTime, but this is set via an Aspect.
+  });
+}
+
+export function modifyRoleForRollingUpdate(scope: GuStack, autoScalingGroup: GuAutoScalingGroup) {
+  const policy = AsgRollingUpdatePolicy.getInstance(scope);
+  policy.attachToRole(autoScalingGroup.role);
+
+  // Create the Policy with necessary permissions first.
+  // Then create the ASG that requires the permissions.
+  const cfnPolicy = policy.node.defaultChild as CfnPolicy;
+  const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+  cfnAutoScalingGroup.addDependency(cfnPolicy);
+}
+
+export function modifyUserDataForRollingUpdate(
+  scope: GuStack,
+  autoScalingGroup: GuAutoScalingGroup,
+  targetGroup: GuApplicationTargetGroup,
+  applicationPort: number,
+  buildIdentifier: string,
+) {
+  const { region, stackId } = scope;
+  const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+
+  /*
+    `aws` is available via AMIgo baked AMIs.
+    See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
+     */
+  autoScalingGroup.userData.addCommands(
+    `# ${GuEc2AppExperimental.name} UserData Start`,
+    `
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
+
+      STATE=$(aws elbv2 describe-target-health \
+        --target-group-arn ${targetGroup.targetGroupArn} \
+        --region ${region} \
+        --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+        --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance running build ${buildIdentifier} not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep ${RollingUpdateDurations.sleep.toSeconds()}
+        STATE=$(aws elbv2 describe-target-health \
+          --target-group-arn ${targetGroup.targetGroupArn} \
+          --region ${region} \
+          --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+          --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance running build ${buildIdentifier} is healthy in target group."
+      `,
+    `# ${GuEc2AppExperimental.name} UserData End`,
+  );
+
+  autoScalingGroup.userData.addOnExitCommands(
+    `
+        cfn-signal --stack ${stackId} \
+          --resource ${cfnAutoScalingGroup.logicalId} \
+          --region ${region} \
+          --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        `,
+  );
+
+  // If https://github.com/guardian/devx-logs is used, this tag will be added as a marker to logs in Central ELK.
+  Tags.of(autoScalingGroup.instanceLaunchTemplate).add(MetadataKeys.BUILD_IDENTIFIER, buildIdentifier, {
+    applyToLaunchedInstances: true,
+  });
+}
+
 /**
  * An experimental pattern to instantiate an EC2 application that is updated entirely via CloudFormation.
  * It sets the update policy of the `AWS::AutoScaling::AutoScalingGroup` to `AutoScalingRollingUpdate`.
@@ -291,32 +375,20 @@ export class GuEc2AppExperimental extends GuEc2App {
   constructor(scope: GuStack, props: GuEc2AppExperimentalProps) {
     const { minimumInstances, maximumInstances = minimumInstances * 2 } = props.scaling;
     const { applicationPort, buildIdentifier } = props;
-    const { region, stackId } = scope;
 
     super(scope, {
       ...props,
-      updatePolicy: UpdatePolicy.rollingUpdate({
-        maxBatchSize: maximumInstances,
-        minInstancesInService: minimumInstances,
-        minSuccessPercentage: 100,
-        waitOnResourceSignals: true,
-
-        /*
-        If a scale-in event fires during an `AutoScalingRollingUpdate` operation, the update could fail and rollback.
-        For this reason, we suspend the `AlarmNotification` process, else availability of a service cannot be guaranteed.
-        Consequently, services cannot scale-out during deployments.
-        If AWS ever supports suspending scale-out and scale-in independently, we should allow scale-out.
-         */
-        suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
-      }),
+      // Note: if the service uses horizontal scaling, minimumInstances is overridden by an Aspect (to prevent accidental scale downs!)
+      updatePolicy: rollingUpdatePolicy(maximumInstances, minimumInstances),
     });
 
     const { autoScalingGroup, targetGroup } = this;
-    const { userData, role } = autoScalingGroup;
     const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
 
+    // Note: if the service uses horizontal scaling, this property is unset by an Aspect (to prevent accidental scale downs!)
     cfnAutoScalingGroup.desiredCapacity = minimumInstances.toString();
 
+    // This is used when an ASG is first created; it is not needed to support the new deployment mechanism
     cfnAutoScalingGroup.cfnOptions.creationPolicy = {
       autoScalingCreationPolicy: {
         minSuccessfulInstancesPercent: 100,
@@ -326,61 +398,15 @@ export class GuEc2AppExperimental extends GuEc2App {
       },
     };
 
-    const policy = AsgRollingUpdatePolicy.getInstance(scope);
-    policy.attachToRole(role);
-
-    // Create the Policy with necessary permissions first.
-    // Then create the ASG that requires the permissions.
-    const cfnPolicy = policy.node.defaultChild as CfnPolicy;
-    cfnAutoScalingGroup.addDependency(cfnPolicy);
-
-    /*
-    `aws` is available via AMIgo baked AMIs.
-    See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
-     */
-    userData.addCommands(
-      `# ${GuEc2AppExperimental.name} UserData Start`,
-      `
-      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
-
-      STATE=$(aws elbv2 describe-target-health \
-        --target-group-arn ${targetGroup.targetGroupArn} \
-        --region ${region} \
-        --targets Id=$INSTANCE_ID,Port=${applicationPort} \
-        --query "TargetHealthDescriptions[0].TargetHealth.State")
-
-      until [ "$STATE" == "\\"healthy\\"" ]; do
-        echo "Instance running build ${buildIdentifier} not yet healthy within target group. Current state $STATE. Sleeping..."
-        sleep ${RollingUpdateDurations.sleep.toSeconds()}
-        STATE=$(aws elbv2 describe-target-health \
-          --target-group-arn ${targetGroup.targetGroupArn} \
-          --region ${region} \
-          --targets Id=$INSTANCE_ID,Port=${applicationPort} \
-          --query "TargetHealthDescriptions[0].TargetHealth.State")
-      done
-
-      echo "Instance running build ${buildIdentifier} is healthy in target group."
-      `,
-      `# ${GuEc2AppExperimental.name} UserData End`,
-    );
-
-    userData.addOnExitCommands(
-      `
-        cfn-signal --stack ${stackId} \
-          --resource ${cfnAutoScalingGroup.logicalId} \
-          --region ${region} \
-          --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
-        `,
-    );
-
-    // If https://github.com/guardian/devx-logs is used, this tag will be added as a marker to logs in Central ELK.
-    Tags.of(autoScalingGroup.instanceLaunchTemplate).add(MetadataKeys.BUILD_IDENTIFIER, buildIdentifier, {
-      applyToLaunchedInstances: true,
-    });
+    // IIUC we could get this to work for MAPI by:
+    // 1. Passing in the correct rolling update policy when creating the ASG
+    // 2. Calling these 2 functions
+    // 3. Adding the 2 aspects (these could be removed from MAPI's codebase once they become part of GuStack)
+    modifyRoleForRollingUpdate(scope, autoScalingGroup);
+    modifyUserDataForRollingUpdate(scope, autoScalingGroup, targetGroup, applicationPort, buildIdentifier);
 
     // TODO Once out of experimental, instantiate these `Aspect`s directly in `GuStack`.
-    Aspects.of(scope).add(AutoScalingRollingUpdateTimeout.getInstance(scope));
-    Aspects.of(scope).add(HorizontallyScalingDeploymentProperties.getInstance(scope));
+    Aspects.of(scope).add(AutoScalingRollingUpdateTimeoutExperimental.getInstance(scope));
+    Aspects.of(scope).add(HorizontallyScalingDeploymentPropertiesExperimental.getInstance(scope));
   }
 }

--- a/src/riff-raff-yaml-file/index.ts
+++ b/src/riff-raff-yaml-file/index.ts
@@ -7,7 +7,7 @@ import { dump } from "js-yaml";
 import { GuAutoScalingGroup } from "../constructs/autoscaling";
 import { GuStack } from "../constructs/core";
 import { GuLambdaFunction } from "../constructs/lambda";
-import { HorizontallyScalingDeploymentProperties } from "../experimental/patterns/ec2-app";
+import { HorizontallyScalingDeploymentPropertiesExperimental } from "../experimental/patterns/ec2-app";
 import { autoscalingDeployment, uploadAutoscalingArtifact } from "./deployments/autoscaling";
 import {
   cloudFormationDeployment,
@@ -276,7 +276,8 @@ export class RiffRaffYamlFile {
 
           const amiParametersToTags = getAmiParameters(autoscalingGroups);
 
-          const minInServiceParamMap = HorizontallyScalingDeploymentProperties.getInstance(stack).asgToParamMap;
+          const minInServiceParamMap =
+            HorizontallyScalingDeploymentPropertiesExperimental.getInstance(stack).asgToParamMap;
           const minInServiceAsgs = autoscalingGroups.filter((asg) => minInServiceParamMap.has(asg.node.id));
           const minInstancesInServiceParameters = getMinInstancesInServiceParameters(minInServiceAsgs);
 


### PR DESCRIPTION
Refactor new deployment functionality (introduced in https://github.com/guardian/cdk/pull/2417) to allow it to be used outside of the experimental pattern.

This is useful for MAPI, which uses GuCDK constructs but cannot use the `GuEC2App` pattern (or the closely related `GuEC2AppExperimental` pattern) because it has multiple target groups[^1].

There's a demonstration of how this could be utilised for `mobile-sport` [here](https://github.com/guardian/mobile-apps-api/pull/3610/files#diff-4d018da4e363cfcecdb3fbe02e21f5818cf4826c27c6df7d0269377981071503). Note that most of the changes in https://github.com/guardian/mobile-apps-api/pull/3610 would be required regardless of whether we take this approach or implement a new experimental pattern for the multi-target group architecture, as there is quite a bit of wiring involved in moving MAPI to versioned deployments.

[^1]: The aforementioned patterns support the common case i.e. a single target group.