### PR TITLE
feat: Remove `withoutImdsv2` property from `GuEc2App` and `GuAutoScalingGroup`

### DIFF
--- a/.changeset/rare-plums-fix.md
+++ b/.changeset/rare-plums-fix.md
@@ -1,0 +1,25 @@
+---
+"@guardian/cdk": minor
+---
+
+Removal of the `withoutImdsv2` property from `GuEc2App` and `GuAutoScalingGroup`.
+When this property was set to `true`, launched instances would not meet the [FSBP EC2.8 control](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8).
+
+Removing this property as a signal that GuCDK will follow FSBP controls by default.
+
+If for whatever reason you need to disable IMDSv2, you can do so via an [escape hatch](https://docs.aws.amazon.com/cdk/v2/guide/cfn_layer.html):
+
+```typescript
+import { CfnLaunchTemplate } from "aws-cdk-lib/aws-ec2";
+
+declare const asg: GuAutoScalingGroup;
+
+const launchTemplate = asg.instanceLaunchTemplate.node.defaultChild as CfnLaunchTemplate;
+
+// Set the value to "optional", allowing IMDSv1 and IMDSv2.
+// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-metadataoptions.html#cfn-ec2-launchtemplate-metadataoptions-httptokens.
+launchTemplate.addPropertyOverride("LaunchTemplateData.MetadataOptions.HttpTokens", "optional");
+
+// Or remove the property entirely.
+launchTemplate.addPropertyDeletionOverride("LaunchTemplateData.MetadataOptions.HttpTokens");
+```

--- a/src/constructs/autoscaling/asg.ts
+++ b/src/constructs/autoscaling/asg.ts
@@ -49,7 +49,6 @@ export interface GuAutoScalingGroupProps
   userData: UserData;
   additionalSecurityGroups?: ISecurityGroup[];
   targetGroup?: ApplicationTargetGroup;
-  withoutImdsv2?: boolean;
   httpPutResponseHopLimit?: number;
   enabledDetailedInstanceMonitoring?: boolean;
   defaultInstanceWarmup?: Duration;
@@ -98,7 +97,6 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       targetGroup,
       userData,
       vpc,
-      withoutImdsv2 = false,
       httpPutResponseHopLimit,
       updatePolicy,
       enabledDetailedInstanceMonitoring,
@@ -130,7 +128,13 @@ export class GuAutoScalingGroup extends GuAppAwareConstruct(AutoScalingGroup) {
       // Do not use the default AWS security group which allows egress on any port.
       // Favour HTTPS only egress rules by default.
       securityGroup: GuHttpsEgressSecurityGroup.forVpc(scope, { app, vpc }),
-      requireImdsv2: !withoutImdsv2,
+
+      /*
+      Ensure we satisfy FSBP EC2.8 control. If needed, an escape hatch can override this.
+      See https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8.
+       */
+      requireImdsv2: true,
+
       instanceMetadataTags: true,
       userData,
       role,

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -177,12 +177,7 @@ export interface GuEc2AppProps extends AppIdentity {
    * Specify certificate for the load balancer.
    */
   certificateProps?: GuDomainName;
-  /**
-   * Disable imdsv2. Most of the time you should not set this.
-   *
-   * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
-   */
-  withoutImdsv2?: boolean;
+
   /**
    * Configure AMIgo image recipe. This is only necessary if you are using GuCDK to generate your riff-raff.yaml file.
    */
@@ -372,7 +367,6 @@ export class GuEc2App extends Construct {
       roleConfiguration = { withoutLogShipping: false, additionalPolicies: [] },
       scaling: { minimumInstances, maximumInstances = minimumInstances * 2 },
       userData: userDataLike,
-      withoutImdsv2,
       imageRecipe,
       vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText({ app }, "VPC")),
       privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app }),
@@ -423,7 +417,6 @@ export class GuEc2App extends Construct {
       instanceType,
       minimumInstances,
       maximumInstances,
-      withoutImdsv2,
       role: new GuInstanceRole(scope, { app, ...mergedRoleConfiguration }),
       healthCheck: HealthCheck.elb({ grace: Duration.minutes(2) }), // should this be defaulted at pattern or construct level?
       userData: userData instanceof GuUserData ? userData.userData : userData,


### PR DESCRIPTION
## What does this change?
When this property was set to `true`, launched instances would not meet the [FSBP EC2.8 control](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-8). Removing this property reinforces that GuCDK provides a paved path, following best practice by default.

If for whatever reason one needs to disable IMDSv2, the escape hatch patten can be used:

```typescript
import { CfnLaunchTemplate } from "aws-cdk-lib/aws-ec2";

declare const asg: GuAutoScalingGroup;

// Set the value to "optional", allowing IMDSv1 and IMDSv2.
// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-metadataoptions.html#cfn-ec2-launchtemplate-metadataoptions-httptokens.
launchTemplate.addPropertyOverride("LaunchTemplateData.MetadataOptions.HttpTokens", "optional");

// Or remove the property entirely.
launchTemplate.addPropertyDeletionOverride("LaunchTemplateData.MetadataOptions.HttpTokens");
```

## How to test
N/A.

## How can we measure success?
Reinforcement of the idea that GuCDK provides a paved path.

## Have we considered potential risks?
As this change removes an optional property, and doesn't change the default, I don't think it is a breaking change. That said, the [services that make use of the `withoutImdsv2` property](https://github.com/search?q=org%3Aguardian+withoutImdsv2++NOT+is%3Aarchived+NOT+repo%3Aguardian%2Fcdk&type=code) would need to upgrade carefully, ensuring to implement the escape hatch.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
