### PR TITLE
fix: Resolve two deprecation warnings from AWS CDK

### DIFF
--- a/.changeset/social-streets-rescue.md
+++ b/.changeset/social-streets-rescue.md
@@ -1,0 +1,7 @@
+---
+"@guardian/cdk": patch
+---
+
+fix(GuEcsTaskProps): Change type of `containerInsights` property from `boolean` to `ContainerInsights`.
+
+This enables support of enhanced ECS monitoring and addresses an AWS CDK deprecation warning.

--- a/src/constructs/ecs/ecs-task.test.ts
+++ b/src/constructs/ecs/ecs-task.test.ts
@@ -1,6 +1,7 @@
 import { Template } from "aws-cdk-lib/assertions";
 import type { ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { SecurityGroup, Subnet, Vpc } from "aws-cdk-lib/aws-ec2";
+import { ContainerInsights } from "aws-cdk-lib/aws-ecs";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
 import type { GuStack } from "../core";
@@ -32,6 +33,7 @@ describe("The GuEcsTask pattern", () => {
       vpc,
       subnets: vpc.privateSubnets,
       app: "ecs-test",
+      containerInsights: ContainerInsights.DISABLED,
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ECS::TaskDefinition", {
@@ -53,6 +55,7 @@ describe("The GuEcsTask pattern", () => {
       taskCommand: `echo "yo ho row ho it's a pirates life for me"`,
       securityGroups: [securityGroup(stack, app)],
       customTaskPolicies: [testPolicy],
+      containerInsights: ContainerInsights.DISABLED,
     });
   };
 

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -14,6 +14,7 @@ import {
   OperatingSystemFamily,
   TaskDefinition,
 } from "aws-cdk-lib/aws-ecs";
+import type { ContainerInsights } from "aws-cdk-lib/aws-ecs/lib/cluster";
 import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { DefinitionBody, IntegrationPattern, JsonPath, StateMachine, Timeout } from "aws-cdk-lib/aws-stepfunctions";
@@ -128,11 +129,13 @@ export interface GuEcsTaskProps extends AppIdentity {
    * shoud set this value to `false`.
    */
   enableDistributablePolicy?: boolean;
+
   /**
-   * If `true`, CloudWatch Container Insights will be enabled for the cluster
-   * @default false
+   * The CloudWatch Container Insights setting
+   *
+   * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html
    */
-  containerInsights?: boolean;
+  containerInsights: ContainerInsights;
 }
 
 /**
@@ -184,7 +187,7 @@ export class GuEcsTask extends Construct {
       securityGroups = [],
       environmentOverrides,
       enableDistributablePolicy = true,
-      containerInsights = false,
+      containerInsights,
     } = props;
 
     if (storage && storage < 21) {
@@ -199,7 +202,7 @@ export class GuEcsTask extends Construct {
       clusterName: `${app}-cluster-${stage}`,
       enableFargateCapacityProviders: true,
       vpc,
-      containerInsights,
+      containerInsightsV2: containerInsights,
     });
 
     const taskDefinition = new TaskDefinition(scope, `${id}-TaskDefinition`, {

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -1,7 +1,7 @@
 /* eslint "@guardian/tsdoc-required/tsdoc-required": 2 -- to begin rolling this out for public APIs. */
 import { Duration, SecretValue, Tags } from "aws-cdk-lib";
 import type { BlockDevice, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
-import { HealthCheck } from "aws-cdk-lib/aws-autoscaling";
+import { AdditionalHealthCheckType, HealthChecks } from "aws-cdk-lib/aws-autoscaling";
 import {
   ProviderAttribute,
   UserPool,
@@ -418,7 +418,13 @@ export class GuEc2App extends Construct {
       minimumInstances,
       maximumInstances,
       role: new GuInstanceRole(scope, { app, ...mergedRoleConfiguration }),
-      healthCheck: HealthCheck.elb({ grace: Duration.minutes(2) }), // should this be defaulted at pattern or construct level?
+
+      // TODO should this be defaulted at pattern or construct level?
+      healthChecks: HealthChecks.withAdditionalChecks({
+        additionalTypes: [AdditionalHealthCheckType.ELB],
+        gracePeriod: Duration.minutes(2),
+      }),
+
       userData: userData instanceof GuUserData ? userData.userData : userData,
       vpcSubnets: { subnets: privateSubnets },
       ...(blockDevices && { blockDevices }),

--- a/src/patterns/scheduled-ecs-task.test.ts
+++ b/src/patterns/scheduled-ecs-task.test.ts
@@ -1,6 +1,7 @@
 import { Duration } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { Vpc } from "aws-cdk-lib/aws-ec2";
+import { ContainerInsights } from "aws-cdk-lib/aws-ecs";
 import { Schedule } from "aws-cdk-lib/aws-events";
 import type { GuStack } from "../constructs/core";
 import { simpleGuStackForTesting } from "../utils/test";
@@ -25,6 +26,7 @@ describe("The GuScheduledEcsTask pattern", () => {
       vpc,
       app: "ecs-test",
       subnets: vpc.privateSubnets,
+      containerInsights: ContainerInsights.DISABLED,
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::Events::Rule", { ScheduleExpression: "rate(1 minute)" });


### PR DESCRIPTION
## What does this change?
Addresses two deprecation warnings from AWS CDK:
- In a `Cluster` [`containerInsights` is deprecated in favour of `containerInsightsV2`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.Cluster.html#containerinsightsspan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan). This requires a new (patch) release as the props for the `GuEcsTask` construct have changed too.
- In an AutoScalingGroup [`healthCheck` is deprecated in favour of `healthChecks`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_autoscaling.AutoScalingGroup.html#healthcheckspan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan). This does not require a release, as this option is not user accessible.

## How to test
See CI.

## How can we measure success?
This change makes reading test output easier as stdout is less verbose.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
