### PR TITLE
feat(GuEc2App): Replace `enabledDetailedInstanceMonitoring` optional property with mandatory `instanceMetricGranularity` property

### DIFF
--- a/.changeset/cyan-worlds-grab.md
+++ b/.changeset/cyan-worlds-grab.md
@@ -1,0 +1,16 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(GuEc2App): Replace `enabledDetailedInstanceMonitoring` optional property with mandatory `instanceMetricGranularity` property
+
+Specifying how an ASG service should be monitored is now explicitly required.
+When detailed monitoring is enabled, EC2 metrics are produced at a higher granularity of one minute (default is five minutes).
+This should allow for earlier horizontal scaling and provide more detail during incident triage.
+
+This change will cost roughly $3 per instance per month.
+We'd recommend using detailed monitoring for production environments.
+
+See also:
+- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/manage-detailed-monitoring.html
+- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html

--- a/src/constructs/autoscaling/asg.test.ts
+++ b/src/constructs/autoscaling/asg.test.ts
@@ -27,6 +27,7 @@ describe("The GuAutoScalingGroup", () => {
     instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
     userData: UserData.custom(["#!/bin/bash", "service some-dependency start", "service my-app start"].join("\n")),
     minimumInstances: 1,
+    instanceMetricGranularity: "5Minute",
   };
 
   test("Uses the AppIdentity to create the logicalId and tag the resource", () => {
@@ -168,6 +169,7 @@ describe("The GuAutoScalingGroup", () => {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       vpc,
       minimumInstances: 1,
+      instanceMetricGranularity: "5Minute",
     });
 
     GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::IAM::Role", { appIdentity: { app: "TestApp" } });
@@ -204,6 +206,7 @@ describe("The GuAutoScalingGroup", () => {
         ],
       }),
       minimumInstances: 1,
+      instanceMetricGranularity: "5Minute",
     });
 
     const template = Template.fromStack(stack);
@@ -244,6 +247,7 @@ describe("The GuAutoScalingGroup", () => {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       vpc,
       minimumInstances: 3,
+      instanceMetricGranularity: "5Minute",
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::AutoScalingGroup", {
@@ -262,6 +266,7 @@ describe("The GuAutoScalingGroup", () => {
       vpc,
       minimumInstances: 2,
       maximumInstances: 11,
+      instanceMetricGranularity: "5Minute",
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::AutoScaling::AutoScalingGroup", {

--- a/src/constructs/autoscaling/user-data.test.ts
+++ b/src/constructs/autoscaling/user-data.test.ts
@@ -34,6 +34,7 @@ describe("GuUserData", () => {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       minimumInstances: 1,
       app: "testing",
+      instanceMetricGranularity: "5Minute",
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {
@@ -80,6 +81,7 @@ describe("GuUserData", () => {
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       minimumInstances: 1,
       app: "testing",
+      instanceMetricGranularity: "5Minute",
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::EC2::LaunchTemplate", {

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -733,6 +733,9 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
             "HttpTokens": "required",
             "InstanceMetadataTags": "enabled",
           },
+          "Monitoring": {
+            "Enabled": false,
+          },
           "SecurityGroupIds": [
             {
               "Fn::GetAtt": [

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -29,6 +29,7 @@ describe("The GuEc2AppExperimental pattern", () => {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData,
       certificateProps: {
         domainName: "domain-name-for-your-application.example",

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -760,6 +760,9 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
             "HttpTokens": "required",
             "InstanceMetadataTags": "enabled",
           },
+          "Monitoring": {
+            "Enabled": false,
+          },
           "SecurityGroupIds": [
             {
               "Fn::GetAtt": [
@@ -1559,6 +1562,9 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
           "MetadataOptions": {
             "HttpTokens": "required",
             "InstanceMetadataTags": "enabled",
+          },
+          "Monitoring": {
+            "Enabled": false,
           },
           "SecurityGroupIds": [
             {

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -19,6 +19,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -38,6 +39,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [Peer.ipv4("1.2.3.4/5")] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -57,6 +59,7 @@ describe("the GuEC2App pattern", function () {
       access: { scope: AccessScope.INTERNAL, cidrRanges: [Peer.ipv4("10.0.0.0/8")] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -88,6 +91,7 @@ describe("the GuEC2App pattern", function () {
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: {
         distributable: {
           fileName: "my-app.deb",
@@ -160,6 +164,7 @@ describe("the GuEC2App pattern", function () {
         },
         unhealthyInstancesAlarm: false,
       },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
     });
     //The shape of this alarm is tested at construct level
@@ -189,6 +194,7 @@ describe("the GuEC2App pattern", function () {
         unhealthyInstancesAlarm: false,
       },
       userData: UserData.forLinux(),
+      instanceMetricGranularity: "5Minute",
     });
     //The shape of this alarm is tested at construct level
     GuTemplate.fromStack(stack).hasResourceWithLogicalId("AWS::CloudWatch::Alarm", /^High4xxPercentageAlarm.+/);
@@ -213,6 +219,7 @@ describe("the GuEC2App pattern", function () {
         http5xxAlarm: false,
         unhealthyInstancesAlarm: true,
       },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
     });
     //The shape of this alarm is tested at construct level
@@ -238,6 +245,7 @@ describe("the GuEC2App pattern", function () {
         http5xxAlarm: false,
         unhealthyInstancesAlarm: false,
       },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
     });
     Template.fromStack(stack).resourceCountIs("AWS::CloudWatch::Alarm", 0);
@@ -258,6 +266,7 @@ describe("the GuEC2App pattern", function () {
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
     });
 
@@ -307,6 +316,7 @@ describe("the GuEC2App pattern", function () {
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
     });
 
@@ -340,6 +350,7 @@ describe("the GuEC2App pattern", function () {
             minimumInstances: 1,
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
         }),
     ).toThrowError(
@@ -364,6 +375,7 @@ describe("the GuEC2App pattern", function () {
             minimumInstances: 1,
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
         }),
     ).toThrowError(
@@ -386,6 +398,7 @@ describe("the GuEC2App pattern", function () {
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       roleConfiguration: {
         withoutLogShipping: true,
@@ -491,6 +504,7 @@ describe("the GuEC2App pattern", function () {
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux({ shebang: "#!/user/data/from/pattern" }),
     });
 
@@ -517,6 +531,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       blockDevices: [
         {
@@ -558,6 +573,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
     });
 
@@ -597,6 +613,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "node-app.code.example.com",
@@ -612,6 +629,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "play-app.code.example.com",
@@ -651,6 +669,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       accessLogging: { enabled: true, prefix: "access-logging-prefix" },
     });
@@ -680,6 +699,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       accessLogging: { enabled: false },
     });
@@ -709,6 +729,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       applicationLogging: { enabled: true },
     });
@@ -738,6 +759,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       applicationLogging: { enabled: true, systemdUnitName: "not-my-app-name" },
     });
@@ -768,6 +790,7 @@ UserData from accessed construct`);
           minimumInstances: 1,
         },
         monitoringConfiguration: { noMonitoring: true },
+        instanceMetricGranularity: "5Minute",
         userData: UserData.forLinux(),
         applicationLogging: { enabled: true },
         roleConfiguration: {
@@ -795,6 +818,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       accessLogging: { enabled: false },
     });
@@ -823,6 +847,7 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       accessLogging: { enabled: false },
       googleAuth: {
@@ -864,6 +889,7 @@ UserData from accessed construct`);
             minimumInstances: 1,
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
           accessLogging: { enabled: false },
           googleAuth: {
@@ -894,6 +920,7 @@ UserData from accessed construct`);
             minimumInstances: 1,
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
           accessLogging: { enabled: false },
           googleAuth: {
@@ -924,6 +951,7 @@ UserData from accessed construct`);
             minimumInstances: 1,
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
           accessLogging: { enabled: false },
           googleAuth: {
@@ -943,6 +971,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -968,6 +997,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -996,6 +1026,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1028,6 +1059,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1048,6 +1080,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1081,6 +1114,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1105,6 +1139,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1133,6 +1168,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "1Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1140,7 +1176,6 @@ UserData from accessed construct`);
       scaling: {
         minimumInstances: 1,
       },
-      enabledDetailedInstanceMonitoring: true,
     });
     Template.fromStack(stack).hasResource("AWS::EC2::LaunchTemplate", {
       Properties: {
@@ -1161,6 +1196,7 @@ UserData from accessed construct`);
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -1168,7 +1204,6 @@ UserData from accessed construct`);
       scaling: {
         minimumInstances: 1,
       },
-      enabledDetailedInstanceMonitoring: true,
       defaultInstanceWarmup: Duration.minutes(2),
     });
     Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -305,12 +305,6 @@ export interface GuEc2AppProps extends AppIdentity {
   updatePolicy?: UpdatePolicy;
 
   /**
-   * This setting configures the launch template to enable or disable detailed monitoring on instances.
-   *
-   * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-monitoring.html
-   */
-  enabledDetailedInstanceMonitoring?: boolean;
-  /**
    * You can specify how long after an instance reaches the InService state it waits before contributing
    * usage data to the aggregated metrics. This specified time is called the default instance warmup.
    * This keeps dynamic scaling from being affected by metrics for individual instances that aren't yet
@@ -319,6 +313,17 @@ export interface GuEc2AppProps extends AppIdentity {
    * @see https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-default-instance-warmup.html
    */
   defaultInstanceWarmup?: Duration;
+
+  /**
+   * How often to send EC2 metrics, such as CPU usage.
+   * By default, AWS will produce `5Minute` granular metrics.
+   *
+   * It is recommended to produce `1Minute` granular metrics in production,
+   * especially when using ASG metrics to trigger horizontal scaling as it allows for earlier scaling.
+   *
+   * @see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html
+   */
+  instanceMetricGranularity: "1Minute" | "5Minute";
 }
 
 function restrictedCidrRanges(ranges: IPeer[]) {
@@ -373,8 +378,8 @@ export class GuEc2App extends Construct {
       publicSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       instanceMetadataHopLimit,
       updatePolicy,
-      enabledDetailedInstanceMonitoring,
       defaultInstanceWarmup,
+      instanceMetricGranularity,
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
@@ -431,8 +436,8 @@ export class GuEc2App extends Construct {
       imageRecipe,
       httpPutResponseHopLimit: instanceMetadataHopLimit,
       updatePolicy,
-      enabledDetailedInstanceMonitoring,
       defaultInstanceWarmup,
+      instanceMetricGranularity,
     });
 
     // This allows automatic shipping of instance Cloud Init logs when using the

--- a/src/patterns/ec2-app/framework.test.ts
+++ b/src/patterns/ec2-app/framework.test.ts
@@ -12,6 +12,7 @@ describe("Framework level EC2 app patterns", () => {
       access: { scope: AccessScope.PUBLIC },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -34,6 +35,7 @@ describe("Framework level EC2 app patterns", () => {
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [] },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "domain-name-for-your-application.example",
@@ -55,6 +57,7 @@ describe("Framework level EC2 app patterns", () => {
       app: "PlayApp",
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
       monitoringConfiguration: { noMonitoring: true },
+      instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
       certificateProps: {
         domainName: "code-guardian.com",

--- a/src/riff-raff-yaml-file/index.test.ts
+++ b/src/riff-raff-yaml-file/index.test.ts
@@ -609,6 +609,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "rip.gu.com",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -709,6 +710,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "rip.gu.com",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -914,6 +916,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "api.devx.gutools.co.uk",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -937,6 +940,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "data-collector.devx.gutools.co.uk",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -1062,6 +1066,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "api.devx.gutools.co.uk",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -1284,6 +1289,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "rip.gu.com",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -1362,6 +1368,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "rip.gu.com",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },
@@ -1442,6 +1449,7 @@ describe("The RiffRaffYamlFile class", () => {
             domainName: "rip.gu.com",
           },
           monitoringConfiguration: { noMonitoring: true },
+          instanceMetricGranularity: "5Minute",
           scaling: {
             minimumInstances: 1,
           },


### PR DESCRIPTION
## What does this change?
Replaces the `enabledDetailedInstanceMonitoring` optional property from the `GuEc2App` pattern with a mandatory `instanceMetricGranularity` property. There are two values: `1Minute`, `5Minute`. By default, AWS produces metrics every 5 minutes.

Adding a mandatory property aims to encourage teams to enable granular metrics in production as it allows for earlier horizontal scaling and provides more detail during incident triage.

> [!NOTE]
> - This change will cost roughly $3 per instance per month. We might want to consider disabling it for non-production environments.
> - These are not the same as metrics from the [CloudWatch Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/metrics-collected-by-CloudWatch-agent.html), which services might also be using.

See also:
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/manage-detailed-monitoring.html
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html

## How to test
See updated tests.

## How can we measure success?
Our services can horizontally scale earlier.

## Have we considered potential risks?
This has a direct cost implication. At the time of writing, we have [~630 running instances](https://metrics.gutools.co.uk/goto/zuzCf7bHg?orgId=1) across all accounts. At ~$3 per instance per month, this'll be a total of ~$23,000[^1]. If we only enable this on [production instances](https://metrics.gutools.co.uk/goto/Pojuf7bNR?orgId=1), this reduces to ~$15k.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^2]
- [ ] I have updated the documentation as required for the described changes [^3]

[^1]: 630 * 3 * 12
[^2]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^3]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?