### PR TITLE
feat: add slow start support to new deployment mechanism

### DIFF
--- a/.changeset/better-eels-judge.md
+++ b/.changeset/better-eels-judge.md
@@ -1,0 +1,8 @@
+---
+"@guardian/cdk": minor
+---
+
+Addition of [slow start mode](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/edit-target-group-attributes.html#slow-start-mode)
+support for GuEc2AppExperimental.
+
+We recommend enabling this setting if you run a high-traffic service, particularly if it is JVM-based.

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -840,7 +840,7 @@ aws s3 cp 's3://",
                   },
                   "/test-stack/TEST/test-gu-ec2-app/test-gu-ec2-app-123.deb' '/test-gu-ec2-app/test-gu-ec2-app-123.deb'
 dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
-# GuEc2AppExperimental UserData Start
+# GuEc2AppExperimental Instance Health Check Start
 
       TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
       INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
@@ -871,7 +871,7 @@ dpkg -i /test-gu-ec2-app/test-gu-ec2-app-123.deb
 
       echo "Instance running build TEST is healthy in target group."
       
-# GuEc2AppExperimental UserData End",
+# GuEc2AppExperimental Instance Health Check End",
                 ],
               ],
             },

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -276,11 +276,11 @@ describe("The GuEc2AppExperimental pattern", () => {
     template.hasResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
       Properties: {
         TargetGroupAttributes: Match.arrayWith([
-          { Key: "deregistration_delay.timeout_seconds", Value: "30"},
+          { Key: "deregistration_delay.timeout_seconds", Value: "30" },
           { Key: "stickiness.enabled", Value: "false" },
-          { Key: "slow_start.duration_seconds", Value: "44" }
+          { Key: "slow_start.duration_seconds", Value: "44" },
         ]),
-      }
+      },
     });
   });
 
@@ -291,9 +291,9 @@ describe("The GuEc2AppExperimental pattern", () => {
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
       UpdatePolicy: {
         AutoScalingRollingUpdate: {
-          PauseTime: 'PT4M'
+          PauseTime: "PT4M",
         },
-      }
+      },
     });
   });
 
@@ -303,7 +303,10 @@ describe("The GuEc2AppExperimental pattern", () => {
     const userData = UserData.forLinux();
     userData.addCommands(userDataCommand);
 
-    const { autoScalingGroup } = new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(30) });
+    const { autoScalingGroup } = new GuEc2AppExperimental(stack, {
+      ...initialProps(stack),
+      slowStartDuration: Duration.seconds(30),
+    });
 
     const renderedUserData = autoScalingGroup.userData.render();
     const splitUserData = renderedUserData.split("\n");
@@ -318,7 +321,5 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     // If slow start is enabled, the logic related to this should be the last thing in the user data script.
     expect(slowStartMarkerEnd).toEqual(totalLines - 1);
-
   });
-
 });

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -121,8 +121,8 @@ describe("The GuEc2AppExperimental pattern", () => {
     const totalLines = splitUserData.length;
 
     const appCommandPosition = splitUserData.indexOf(userDataCommand);
-    const startMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental UserData Start");
-    const endMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental UserData End");
+    const startMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental Instance Health Check Start");
+    const endMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental Instance Health Check End");
 
     // Application user data should be before the target group healthcheck polling.
     expect(appCommandPosition).toBeLessThan(startMarkerPosition);
@@ -268,4 +268,57 @@ describe("The GuEc2AppExperimental pattern", () => {
       "Failed to detect the autoscaling group relating to the scaling policy on path test/ScaleOut. Was it created in the scope of a GuAutoScalingGroup?",
     );
   });
+
+  it("should add the correct target group attributes if slow start is enabled", () => {
+    const stack = simpleGuStackForTesting();
+    new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(44) });
+    const template = getTemplateAfterAspectInvocation(stack);
+    template.hasResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Properties: {
+        TargetGroupAttributes: Match.arrayWith([
+          { Key: "deregistration_delay.timeout_seconds", Value: "30"},
+          { Key: "stickiness.enabled", Value: "false" },
+          { Key: "slow_start.duration_seconds", Value: "44" }
+        ]),
+      }
+    });
+  });
+
+  it("should update the pause time for the rolling update correctly", () => {
+    const stack = simpleGuStackForTesting();
+    new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.minutes(1) });
+    const template = getTemplateAfterAspectInvocation(stack);
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          PauseTime: 'PT4M'
+        },
+      }
+    });
+  });
+
+  it("should update the script correctly if slow start is enabled", () => {
+    const stack = simpleGuStackForTesting();
+    const userDataCommand = `echo "Hello there"`;
+    const userData = UserData.forLinux();
+    userData.addCommands(userDataCommand);
+
+    const { autoScalingGroup } = new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(30) });
+
+    const renderedUserData = autoScalingGroup.userData.render();
+    const splitUserData = renderedUserData.split("\n");
+    const totalLines = splitUserData.length;
+
+    const healthCheckMarkerEnd = splitUserData.indexOf("# GuEc2AppExperimental Instance Health Check End");
+    const slowStartMarkerStart = splitUserData.indexOf("# GuEc2AppExperimental SlowStart Wait Period Start");
+    const slowStartMarkerEnd = splitUserData.indexOf("# GuEc2AppExperimental SlowStart Wait Period End");
+
+    // Health check polling should end just before the slow start pause kicks in
+    expect(healthCheckMarkerEnd).toEqual(slowStartMarkerStart - 1);
+
+    // If slow start is enabled, the logic related to this should be the last thing in the user data script.
+    expect(slowStartMarkerEnd).toEqual(totalLines - 1);
+
+  });
+
 });

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -322,4 +322,18 @@ describe("The GuEc2AppExperimental pattern", () => {
     // If slow start is enabled, the logic related to this should be the last thing in the user data script.
     expect(slowStartMarkerEnd).toEqual(totalLines - 1);
   });
+
+  it("should throw an error if the slow start value is too low", () => {
+    const stack = simpleGuStackForTesting();
+    expect(() => {
+      new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(29) });
+    }).toThrowError("Slow start duration must be between 30 and 900 seconds");
+  });
+
+  it("should throw an error if the slow start value is too high", () => {
+    const stack = simpleGuStackForTesting();
+    expect(() => {
+      new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(901) });
+    }).toThrowError("Slow start duration must be between 30 and 900 seconds");
+  });
 });

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -276,7 +276,11 @@ export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePo
  * If you need to use this class for a service other than MAPI, please speak to DevX about your use-case first.
  */
 export class GuRollingUpdatePolicyExperimental {
-  static getPolicy(maximumInstances: number, minimumInstances?: number, slowStartDuration?: Duration) {
+  static getPolicy(
+    maximumInstances: number,
+    minimumInstances?: number,
+    slowStartDuration: Duration = Duration.seconds(0),
+  ) {
     return UpdatePolicy.rollingUpdate({
       maxBatchSize: maximumInstances,
       minInstancesInService: minimumInstances,
@@ -289,8 +293,19 @@ export class GuRollingUpdatePolicyExperimental {
       If AWS ever supports suspending scale-out and scale-in independently, we should allow scale-out.
        */
       suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
-      // Note: this is increased via an Aspect which also takes healthcheck grace period into account.
-      pauseTime: slowStartDuration ?? Duration.seconds(0),
+      /*
+      Note: this is increased via an Aspect which also takes healthcheck grace period into account.
+
+      It was easier to pass the slow start duration through here rather than trying to do this via the
+      GuAutoScalingRollingUpdateTimeoutExperimental aspect.
+
+      If we do this via the aspect then we need to find all mappings between ASGs and target groups and then
+      get the relevant slow start duration for each. This is probably possible but would be reasonably complex.
+      However, it's worth mentioning that by taking this approach we open up a small risk that things will not work
+      as expected if users enable slow start via a different mechanism (e.g. by modifying the target group outside
+      the pattern).
+       */
+      pauseTime: slowStartDuration,
     });
   }
 }

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -276,7 +276,7 @@ export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePo
  * If you need to use this class for a service other than MAPI, please speak to DevX about your use-case first.
  */
 export class GuRollingUpdatePolicyExperimental {
-  static getPolicy(slowStartDuration: Duration, maximumInstances: number, minimumInstances?: number) {
+  static getPolicy(maximumInstances: number, minimumInstances?: number, slowStartDuration?: Duration) {
     return UpdatePolicy.rollingUpdate({
       maxBatchSize: maximumInstances,
       minInstancesInService: minimumInstances,
@@ -290,7 +290,7 @@ export class GuRollingUpdatePolicyExperimental {
        */
       suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
       // Note: this is increased via an Aspect which also takes healthcheck grace period into account.
-      pauseTime: slowStartDuration,
+      pauseTime: slowStartDuration ?? Duration.seconds(0),
     });
   }
 }
@@ -460,11 +460,7 @@ export class GuEc2AppExperimental extends GuEc2App {
     super(scope, {
       ...props,
       // Note: if the service uses horizontal scaling, minimumInstances is overridden by an Aspect (to prevent accidental scale downs!)
-      updatePolicy: GuRollingUpdatePolicyExperimental.getPolicy(
-        slowStartDuration ?? Duration.seconds(0),
-        maximumInstances,
-        minimumInstances,
-      ),
+      updatePolicy: GuRollingUpdatePolicyExperimental.getPolicy(maximumInstances, minimumInstances, slowStartDuration),
     });
 
     const { autoScalingGroup, targetGroup } = this;

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -72,7 +72,9 @@ export class GuAutoScalingRollingUpdateTimeoutExperimental implements IAspect {
         construct.cfnOptions.updatePolicy = {
           autoScalingRollingUpdate: {
             ...currentRollingUpdate,
-            pauseTime: Duration.seconds(Duration.parse(currentRollingUpdate.pauseTime ?? '0').toSeconds() + signalTimeoutSeconds).toIsoString(),
+            pauseTime: Duration.seconds(
+              Duration.parse(currentRollingUpdate.pauseTime ?? "0").toSeconds() + signalTimeoutSeconds,
+            ).toIsoString(),
           },
         };
       }
@@ -288,7 +290,7 @@ export class GuRollingUpdatePolicyExperimental {
        */
       suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
       // Note: this is increased via an Aspect which also takes healthcheck grace period into account.
-      pauseTime: slowStartDuration
+      pauseTime: slowStartDuration,
     });
   }
 }
@@ -375,7 +377,7 @@ export class GuUserDataForRollingUpdateExperimental {
 
     if (slowStartDuration) {
       const slowStartInSeconds = slowStartDuration.toSeconds().toString();
-      targetGroup.setAttribute("slow_start.duration_seconds", slowStartInSeconds)
+      targetGroup.setAttribute("slow_start.duration_seconds", slowStartInSeconds);
       autoScalingGroup.userData.addCommands(
         `# ${GuEc2AppExperimental.name} SlowStart Wait Period Start`,
         `
@@ -396,7 +398,7 @@ export class GuUserDataForRollingUpdateExperimental {
           exit 1
         fi
         `,
-        `# ${GuEc2AppExperimental.name} SlowStart Wait Period End`
+        `# ${GuEc2AppExperimental.name} SlowStart Wait Period End`,
       );
     }
 
@@ -458,7 +460,11 @@ export class GuEc2AppExperimental extends GuEc2App {
     super(scope, {
       ...props,
       // Note: if the service uses horizontal scaling, minimumInstances is overridden by an Aspect (to prevent accidental scale downs!)
-      updatePolicy: GuRollingUpdatePolicyExperimental.getPolicy(slowStartDuration ?? Duration.seconds(0), maximumInstances, minimumInstances),
+      updatePolicy: GuRollingUpdatePolicyExperimental.getPolicy(
+        slowStartDuration ?? Duration.seconds(0),
+        maximumInstances,
+        minimumInstances,
+      ),
     });
 
     const { autoScalingGroup, targetGroup } = this;
@@ -483,7 +489,7 @@ export class GuEc2AppExperimental extends GuEc2App {
       targetGroup,
       applicationPort,
       buildIdentifier,
-      slowStartDuration
+      slowStartDuration,
     });
 
     // TODO Once out of experimental, instantiate these `Aspect`s directly in `GuStack`.

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -254,8 +254,8 @@ export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePo
    */
   buildIdentifier: string;
   /**
-   * The amount of time that newly launched instances will spend warming-up / serving fewer requests than other instances
-   * (defaults to 0 seconds).
+   * The amount of time that newly launched instances will spend warming-up / serving fewer requests than other instances.
+   * The range is 30-900 seconds (15 minutes). The default is 0 seconds (disabled).
    *
    * See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/edit-target-group-attributes.html#slow-start-mode
    * for more details.
@@ -471,6 +471,11 @@ export class GuEc2AppExperimental extends GuEc2App {
   constructor(scope: GuStack, props: GuEc2AppExperimentalProps) {
     const { minimumInstances, maximumInstances = minimumInstances * 2 } = props.scaling;
     const { applicationPort, buildIdentifier, slowStartDuration } = props;
+
+    const slowStartDurationInSeconds = slowStartDuration?.toSeconds();
+    if (slowStartDurationInSeconds && (slowStartDurationInSeconds < 30 || slowStartDurationInSeconds > 900)) {
+      throw new Error("Slow start duration must be between 30 and 900 seconds");
+    }
 
     super(scope, {
       ...props,

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -72,7 +72,7 @@ export class GuAutoScalingRollingUpdateTimeoutExperimental implements IAspect {
         construct.cfnOptions.updatePolicy = {
           autoScalingRollingUpdate: {
             ...currentRollingUpdate,
-            pauseTime: Duration.seconds(signalTimeoutSeconds).toIsoString(),
+            pauseTime: Duration.seconds(Duration.parse(currentRollingUpdate.pauseTime ?? '0').toSeconds() + signalTimeoutSeconds).toIsoString(),
           },
         };
       }
@@ -251,6 +251,19 @@ export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePo
    * process.env.GITHUB_RUN_NUMBER
    */
   buildIdentifier: string;
+  /**
+   * The amount of time that newly launched instances will spend warming-up / serving fewer requests than other instances
+   * (defaults to 0 seconds).
+   *
+   * See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/edit-target-group-attributes.html#slow-start-mode
+   * for more details.
+   *
+   * We recommend enabling this setting if you run a high-traffic service, particularly if it is JVM-based.
+   *
+   * Note that there is a trade-off between reliability and speed here; a longer duration will give new instances
+   * more time to warm-up, but it will also slow down deployments and scale-up events.
+   */
+  slowStartDuration?: Duration;
 }
 
 /**
@@ -261,7 +274,7 @@ export interface GuEc2AppExperimentalProps extends Omit<GuEc2AppProps, "updatePo
  * If you need to use this class for a service other than MAPI, please speak to DevX about your use-case first.
  */
 export class GuRollingUpdatePolicyExperimental {
-  static getPolicy(maximumInstances: number, minimumInstances?: number) {
+  static getPolicy(slowStartDuration: Duration, maximumInstances: number, minimumInstances?: number) {
     return UpdatePolicy.rollingUpdate({
       maxBatchSize: maximumInstances,
       minInstancesInService: minimumInstances,
@@ -274,7 +287,8 @@ export class GuRollingUpdatePolicyExperimental {
       If AWS ever supports suspending scale-out and scale-in independently, we should allow scale-out.
        */
       suspendProcesses: [ScalingProcess.ALARM_NOTIFICATION],
-      // Note: there is also an important property called pauseTime, but this is set via an Aspect.
+      // Note: this is increased via an Aspect which also takes healthcheck grace period into account.
+      pauseTime: slowStartDuration
     });
   }
 }
@@ -310,6 +324,7 @@ export interface GuUserDataForRollingUpdateExperimentalProps {
   targetGroup: GuApplicationTargetGroup;
   applicationPort: number;
   buildIdentifier: string;
+  slowStartDuration?: Duration;
 }
 
 /**
@@ -324,7 +339,7 @@ export interface GuUserDataForRollingUpdateExperimentalProps {
 export class GuUserDataForRollingUpdateExperimental {
   constructor(scope: GuStack, props: GuUserDataForRollingUpdateExperimentalProps) {
     const { region, stackId } = scope;
-    const { autoScalingGroup, targetGroup, applicationPort, buildIdentifier } = props;
+    const { autoScalingGroup, targetGroup, applicationPort, buildIdentifier, slowStartDuration } = props;
     const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
 
     /*
@@ -332,7 +347,7 @@ export class GuUserDataForRollingUpdateExperimental {
       See https://github.com/guardian/amigo/tree/main/roles/aws-tools.
        */
     autoScalingGroup.userData.addCommands(
-      `# ${GuEc2AppExperimental.name} UserData Start`,
+      `# ${GuEc2AppExperimental.name} Instance Health Check Start`,
       `
       TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
       INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
@@ -355,8 +370,35 @@ export class GuUserDataForRollingUpdateExperimental {
 
       echo "Instance running build ${buildIdentifier} is healthy in target group."
       `,
-      `# ${GuEc2AppExperimental.name} UserData End`,
+      `# ${GuEc2AppExperimental.name} Instance Health Check End`,
     );
+
+    if (slowStartDuration) {
+      const slowStartInSeconds = slowStartDuration.toSeconds().toString();
+      targetGroup.setAttribute("slow_start.duration_seconds", slowStartInSeconds)
+      autoScalingGroup.userData.addCommands(
+        `# ${GuEc2AppExperimental.name} SlowStart Wait Period Start`,
+        `
+        echo "Sleeping for ${slowStartInSeconds} seconds while instance running build ${buildIdentifier} warms up..."
+        sleep ${slowStartInSeconds}s
+        echo "Instance running build ${buildIdentifier} should have warmed up by now..."
+
+        STATE=$(aws elbv2 describe-target-health \
+        --target-group-arn ${targetGroup.targetGroupArn} \
+        --region ${region} \
+        --targets Id=$INSTANCE_ID,Port=${applicationPort} \
+        --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+        if [ "$STATE" == "\\"healthy\\"" ]; then
+           echo "Instance running build ${buildIdentifier} is ready to start serving a normal percentage of requests"
+        else
+          echo "Instance running build ${buildIdentifier} was not healthy after warm-up period; a failure signal will be sent"
+          exit 1
+        fi
+        `,
+        `# ${GuEc2AppExperimental.name} SlowStart Wait Period End`
+      );
+    }
 
     autoScalingGroup.userData.addOnExitCommands(
       `
@@ -411,12 +453,12 @@ export class GuUserDataForRollingUpdateExperimental {
 export class GuEc2AppExperimental extends GuEc2App {
   constructor(scope: GuStack, props: GuEc2AppExperimentalProps) {
     const { minimumInstances, maximumInstances = minimumInstances * 2 } = props.scaling;
-    const { applicationPort, buildIdentifier } = props;
+    const { applicationPort, buildIdentifier, slowStartDuration } = props;
 
     super(scope, {
       ...props,
       // Note: if the service uses horizontal scaling, minimumInstances is overridden by an Aspect (to prevent accidental scale downs!)
-      updatePolicy: GuRollingUpdatePolicyExperimental.getPolicy(maximumInstances, minimumInstances),
+      updatePolicy: GuRollingUpdatePolicyExperimental.getPolicy(slowStartDuration ?? Duration.seconds(0), maximumInstances, minimumInstances),
     });
 
     const { autoScalingGroup, targetGroup } = this;
@@ -441,6 +483,7 @@ export class GuEc2AppExperimental extends GuEc2App {
       targetGroup,
       applicationPort,
       buildIdentifier,
+      slowStartDuration
     });
 
     // TODO Once out of experimental, instantiate these `Aspect`s directly in `GuStack`.


### PR DESCRIPTION
## What does this change?

Adds [slow start mode](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/edit-target-group-attributes.html#slow-start-mode) support to the new/experimental deployment mechanism (which was added in https://github.com/guardian/cdk/pull/2417).

## How to test

I've used `cdk-playground` to test this.

There is a successful deployment example [here](https://github.com/guardian/cdk-playground/pull/703).

I've also created a special build that starts failing the healthcheck _whilst the instance is in slow start mode_, to demonstrate the new failure case - an example for that can be found [here](https://github.com/guardian/cdk-playground/pull/704).

## How can we measure success?

This allows high-traffic services to warm-up instances before sending them a full share of requests. The Ophan team have recently found this to be a successful strategy: https://github.com/guardian/ophan/pull/6273.

Teams ([e.g. WebX](https://github.com/guardian/frontend/blob/95f0ffe8857843ca557700f8d1d62294f96078b9/riff-raff.yaml#L13)) who were previously relying on Riff-Raff's ['warm-up grace' feature](https://riffraff.gutools.co.uk/docs/magenta-lib/types#autoscaling), can now use slow-start mode if they migrate to the new deployment mechanism, as this should offer similar benefits.

## Have we considered potential risks?

I don't think there are any particular risks associated with this PR. We are adding an optional prop to an experimental pattern.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
