### PR TITLE
refactor(cd): Replace PAT with a GitHub App

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,6 +33,23 @@ jobs:
       - name: Test
         run: npm run test
 
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -42,15 +59,11 @@ jobs:
           commit: "Bump package version"
 
         env:
-          # This action will raise a PR to edit package.json and package-lock.json.
-          # PRs raised by the default `secrets.GITHUB_TOKEN` will not trigger CI, so we need to provide a different token.
-          # This is a PAT for the guardian-ci user.
-          # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
-          GITHUB_TOKEN: ${{ secrets.GU_GUARDIAN_CI_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Release docs
         if: (github.ref == 'refs/heads/main')
         run: |
-          git remote set-url origin https://git:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          git remote set-url origin https://git:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
           npm run release:docs


### PR DESCRIPTION
## What does this change?
Follows on from #2677, replacing the PAT used by the [CD workflow](https://github.com/guardian/cdk/blob/main/.github/workflows/cd.yaml).

## How to test
I've [added](https://github.com/guardian/cdk/commit/7b347c642c7fa2e83b3851cf08acb08f5c31028d) (and then removed) a blank changeset file. [Running the CD workflow from this branch](https://github.com/guardian/cdk/actions/runs/15446764215/job/43478474750) with this change created https://github.com/guardian/cdk/pull/2680. This demonstrates the changes for the majority of the workflow; the ["release docs" section](https://github.com/guardian/cdk/blob/ccc5b1df9f4ca3ac5bde44473d2e962864710cee/.github/workflows/cd.yaml#L52-L56) can only be tested on `main`.

## How can we measure success?
Once merged, we can remove the `GU_GUARDIAN_CI_TOKEN` repository secret and revoke the PAT.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
