### PR TITLE
fix(GuEcsTask): Update import path of `ContainerInsights`

### DIFF
--- a/.changeset/lovely-onions-relate.md
+++ b/.changeset/lovely-onions-relate.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Update import path of `ContainerInsights`.

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -3,7 +3,6 @@ import { Alarm, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 import type { ISecurityGroup, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import type { IRepository } from "aws-cdk-lib/aws-ecr";
-import type { ContainerDefinition, RepositoryImageProps } from "aws-cdk-lib/aws-ecs";
 import {
   Cluster,
   Compatibility,
@@ -14,7 +13,7 @@ import {
   OperatingSystemFamily,
   TaskDefinition,
 } from "aws-cdk-lib/aws-ecs";
-import type { ContainerInsights } from "aws-cdk-lib/aws-ecs/lib/cluster";
+import type { ContainerDefinition, ContainerInsights, RepositoryImageProps } from "aws-cdk-lib/aws-ecs";
 import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { DefinitionBody, IntegrationPattern, JsonPath, StateMachine, Timeout } from "aws-cdk-lib/aws-stepfunctions";


### PR DESCRIPTION
## What does this change?
Updates the import path to resolve the following in clients CI builds:

```
error TS2307: Cannot find module 'aws-cdk-lib/aws-ecs/lib/cluster' or its corresponding type declarations.
```

## How to test
Observe CI, it should pass.

## How can we measure success?
N/A.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
