### PR TITLE
feat(experimental-ec2-pattern): Improve safety of new deployment mechanism

### DIFF
--- a/.changeset/sharp-snakes-glow.md
+++ b/.changeset/sharp-snakes-glow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Improve safety of new deployment mechanism

--- a/.changeset/sharp-snakes-glow.md
+++ b/.changeset/sharp-snakes-glow.md
@@ -2,4 +2,6 @@
 "@guardian/cdk": minor
 ---
 
-Improve safety of new deployment mechanism
+Improves the safety of the new deployment mechanism for services which scale horizontally.
+
+As part of this the `default` and `maxValue` properties of the `MinInstancesInServiceFor<app>` parameter (which is used by Riff-Raff) have been removed.

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -158,8 +158,6 @@ describe("The GuEc2AppExperimental pattern", () => {
     const parameterName = getAsgRollingUpdateCfnParameterName(autoScalingGroup);
     template.hasParameter(parameterName, {
       Type: "Number",
-      Default: 5,
-      MaxValue: 9, // (min * 2) - 1
     });
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
       Properties: {
@@ -223,8 +221,6 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     template.hasParameter(parameterName, {
       Type: "Number",
-      Default: 5,
-      MaxValue: 9, // (min * 2) - 1
     });
 
     template.resourceCountIs("AWS::AutoScaling::AutoScalingGroup", 1);
@@ -300,14 +296,10 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     template.hasParameter("MinInstancesInServiceForappa", {
       Type: "Number",
-      Default: 3,
-      MaxValue: 11,
     });
 
     template.hasParameter("MinInstancesInServiceForappb", {
       Type: "Number",
-      Default: 6,
-      MaxValue: 23,
     });
   });
 
@@ -352,14 +344,10 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     codeTemplate.hasParameter(parameterName, {
       Type: "Number",
-      Default: 1,
-      MaxValue: 1,
     });
 
     prodTemplate.hasParameter(parameterName, {
       Type: "Number",
-      Default: 3,
-      MaxValue: 11,
     });
   });
 
@@ -393,16 +381,12 @@ describe("The GuEc2AppExperimental pattern", () => {
 
     templateA.hasParameter("MinInstancesInServiceForappa", {
       Type: "Number",
-      Default: 1,
-      MaxValue: 1,
     });
 
     expect(templateA.findParameters("*")["MinInstancesInServiceForappb"]).toEqual(undefined);
 
     templateB.hasParameter("MinInstancesInServiceForappb", {
       Type: "Number",
-      Default: 1,
-      MaxValue: 1,
     });
 
     expect(templateB.findParameters("*")["MinInstancesInServiceForappa"]).toEqual(undefined);
@@ -511,16 +495,12 @@ describe("The GuHorizontallyScalingDeploymentPropertiesExperimental construct", 
 
     templateA.hasParameter("MinInstancesInServiceForappa", {
       Type: "Number",
-      Default: 1,
-      MaxValue: 1,
     });
 
     expect(templateA.findParameters("*")["MinInstancesInServiceForappb"]).toEqual(undefined);
 
     templateB.hasParameter("MinInstancesInServiceForappb", {
       Type: "Number",
-      Default: 1,
-      MaxValue: 1,
     });
 
     expect(templateB.findParameters("*")["MinInstancesInServiceForappa"]).toEqual(undefined);

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -1,46 +1,50 @@
-import { App, Duration } from "aws-cdk-lib";
+import { App, Aspects, Duration } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
 import { CfnScalingPolicy } from "aws-cdk-lib/aws-autoscaling";
 import { InstanceClass, InstanceSize, InstanceType, UserData } from "aws-cdk-lib/aws-ec2";
 import { AccessScope } from "../../constants";
 import { GuUserData } from "../../constructs/autoscaling";
+import type { GuStackProps } from "../../constructs/core";
 import { GuStack } from "../../constructs/core";
+import { GuEc2App } from "../../patterns";
+import type { GuAsgCapacity } from "../../types";
 import { getTemplateAfterAspectInvocation, simpleGuStackForTesting } from "../../utils/test";
 import type { GuEc2AppExperimentalProps } from "./ec2-app";
+import { GuHorizontallyScalingDeploymentPropertiesExperimental } from "./ec2-app";
 import { getAsgRollingUpdateCfnParameterName, GuEc2AppExperimental, RollingUpdateDurations } from "./ec2-app";
+
+function initialProps(scope: GuStack, app: string = "test-gu-ec2-app"): GuEc2AppExperimentalProps {
+  const buildNumber = 123;
+
+  const { userData } = new GuUserData(scope, {
+    app,
+    distributable: {
+      fileName: `${app}-${buildNumber}.deb`,
+      executionStatement: `dpkg -i /${app}/${app}-${buildNumber}.deb`,
+    },
+  });
+
+  return {
+    applicationPort: 9000,
+    app,
+    access: { scope: AccessScope.PUBLIC },
+    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+    monitoringConfiguration: { noMonitoring: true },
+    instanceMetricGranularity: "5Minute",
+    userData,
+    certificateProps: {
+      domainName: "domain-name-for-your-application.example",
+    },
+    scaling: {
+      minimumInstances: 1,
+    },
+    buildIdentifier: "TEST",
+  };
+}
 
 // TODO test User Data includes a build number
 describe("The GuEc2AppExperimental pattern", () => {
-  function initialProps(scope: GuStack, app: string = "test-gu-ec2-app"): GuEc2AppExperimentalProps {
-    const buildNumber = 123;
-
-    const { userData } = new GuUserData(scope, {
-      app,
-      distributable: {
-        fileName: `${app}-${buildNumber}.deb`,
-        executionStatement: `dpkg -i /${app}/${app}-${buildNumber}.deb`,
-      },
-    });
-
-    return {
-      applicationPort: 9000,
-      app,
-      access: { scope: AccessScope.PUBLIC },
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-      monitoringConfiguration: { noMonitoring: true },
-      instanceMetricGranularity: "5Minute",
-      userData,
-      certificateProps: {
-        domainName: "domain-name-for-your-application.example",
-      },
-      scaling: {
-        minimumInstances: 1,
-      },
-      buildIdentifier: "TEST",
-    };
-  }
-
   it("matches the snapshot", () => {
     const stack = simpleGuStackForTesting();
     new GuEc2AppExperimental(stack, initialProps(stack));
@@ -269,6 +273,141 @@ describe("The GuEc2AppExperimental pattern", () => {
     );
   });
 
+  it("should add the correct CFN Parameters for more than one EC2 app in the same stack", () => {
+    const app = new App();
+    const stack = new GuStack(app, "test", {
+      stack: "test-stack",
+      stage: "TEST",
+    });
+
+    const appA = new GuEc2AppExperimental(stack, {
+      ...initialProps(stack, "app-a"),
+      scaling: { minimumInstances: 3, maximumInstances: 12 },
+    });
+    appA.autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 99,
+    });
+
+    const appB = new GuEc2AppExperimental(stack, {
+      ...initialProps(stack, "app-b"),
+      scaling: { minimumInstances: 6, maximumInstances: 24 },
+    });
+    appB.autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 100,
+    });
+
+    const template = getTemplateAfterAspectInvocation(stack);
+
+    template.hasParameter("MinInstancesInServiceForappa", {
+      Type: "Number",
+      Default: 3,
+      MaxValue: 11,
+    });
+
+    template.hasParameter("MinInstancesInServiceForappb", {
+      Type: "Number",
+      Default: 6,
+      MaxValue: 23,
+    });
+  });
+
+  it("should add the correct CFN Parameters for two separate stacks in the same app", () => {
+    const app = new App();
+
+    interface MicroserviceProps extends GuStackProps {
+      scaling: GuAsgCapacity;
+    }
+
+    class Microservice extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- this is a test
+      constructor(scope: App, id: string, props: MicroserviceProps) {
+        super(scope, id, {
+          ...props,
+        });
+        const ec2App = new GuEc2AppExperimental(this, {
+          ...initialProps(this),
+          scaling: props.scaling,
+        });
+        ec2App.autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+          targetRequestsPerMinute: 100,
+        });
+      }
+    }
+
+    const codeStack = new Microservice(app, "CODE", {
+      stack: "playground",
+      stage: "CODE",
+      scaling: { minimumInstances: 1, maximumInstances: 2 },
+    });
+    const prodStack = new Microservice(app, "PROD", {
+      stack: "playground",
+      stage: "PROD",
+      scaling: { minimumInstances: 3, maximumInstances: 12 },
+    });
+
+    const codeTemplate = getTemplateAfterAspectInvocation(codeStack);
+    const prodTemplate = getTemplateAfterAspectInvocation(prodStack);
+
+    const parameterName = "MinInstancesInServiceFortestguec2app";
+
+    codeTemplate.hasParameter(parameterName, {
+      Type: "Number",
+      Default: 1,
+      MaxValue: 1,
+    });
+
+    prodTemplate.hasParameter(parameterName, {
+      Type: "Number",
+      Default: 3,
+      MaxValue: 11,
+    });
+  });
+
+  it("should only add the relevant CFN Parameters for different services which share the same App", () => {
+    const app = new App();
+
+    interface MicroserviceProps extends GuStackProps {
+      appName: string;
+    }
+
+    class Microservice extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- this is a test
+      constructor(scope: App, id: string, props: MicroserviceProps) {
+        super(scope, id, {
+          ...props,
+        });
+        const ec2App = new GuEc2AppExperimental(this, {
+          ...initialProps(this, props.appName),
+        });
+        ec2App.autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+          targetRequestsPerMinute: 100,
+        });
+      }
+    }
+
+    const appA = new Microservice(app, "app-a-PROD", { stack: "playground", stage: "PROD", appName: "app-a" });
+    const appB = new Microservice(app, "app-b-PROD", { stack: "playground", stage: "PROD", appName: "app-b" });
+
+    const templateA = getTemplateAfterAspectInvocation(appA);
+    const templateB = getTemplateAfterAspectInvocation(appB);
+
+    templateA.hasParameter("MinInstancesInServiceForappa", {
+      Type: "Number",
+      Default: 1,
+      MaxValue: 1,
+    });
+
+    expect(templateA.findParameters("*")["MinInstancesInServiceForappb"]).toEqual(undefined);
+
+    templateB.hasParameter("MinInstancesInServiceForappb", {
+      Type: "Number",
+      Default: 1,
+      MaxValue: 1,
+    });
+
+    expect(templateB.findParameters("*")["MinInstancesInServiceForappa"]).toEqual(undefined);
+  });
+
   it("should add the correct target group attributes if slow start is enabled", () => {
     const stack = simpleGuStackForTesting();
     new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(44) });
@@ -335,5 +474,55 @@ describe("The GuEc2AppExperimental pattern", () => {
     expect(() => {
       new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(901) });
     }).toThrowError("Slow start duration must be between 30 and 900 seconds");
+  });
+});
+
+describe("The GuHorizontallyScalingDeploymentPropertiesExperimental construct", () => {
+  it("should ignore scaling policies and ASGs from other stacks if it is applied at App level", () => {
+    const app = new App();
+
+    interface MicroserviceProps extends GuStackProps {
+      appName: string;
+    }
+
+    class Microservice extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- this is a test
+      constructor(app: App, id: string, props: MicroserviceProps) {
+        super(app, id, {
+          ...props,
+        });
+        const ec2App = new GuEc2App(this, {
+          ...initialProps(this, props.appName),
+        });
+        ec2App.autoScalingGroup.scaleOnRequestCount("ScaleOnRequests", {
+          targetRequestsPerMinute: 100,
+        });
+        const cfnAsg = ec2App.autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+        cfnAsg.cfnOptions.updatePolicy = { autoScalingRollingUpdate: {} };
+        Aspects.of(app).add(GuHorizontallyScalingDeploymentPropertiesExperimental.getInstance(this));
+      }
+    }
+
+    const appA = new Microservice(app, "app-a-PROD", { stack: "playground", stage: "PROD", appName: "app-a" });
+    const appB = new Microservice(app, "app-b-PROD", { stack: "playground", stage: "PROD", appName: "app-b" });
+
+    const templateA = getTemplateAfterAspectInvocation(appA);
+    const templateB = getTemplateAfterAspectInvocation(appB);
+
+    templateA.hasParameter("MinInstancesInServiceForappa", {
+      Type: "Number",
+      Default: 1,
+      MaxValue: 1,
+    });
+
+    expect(templateA.findParameters("*")["MinInstancesInServiceForappb"]).toEqual(undefined);
+
+    templateB.hasParameter("MinInstancesInServiceForappb", {
+      Type: "Number",
+      Default: 1,
+      MaxValue: 1,
+    });
+
+    expect(templateB.findParameters("*")["MinInstancesInServiceForappa"]).toEqual(undefined);
   });
 });

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -176,8 +176,6 @@ export class GuHorizontallyScalingDeploymentPropertiesExperimental implements IA
             asgNodeId,
             new CfnParameter(this.stack, cfnParameterName, {
               type: "Number",
-              default: parseInt(cfnAutoScalingGroup.minSize),
-              maxValue: parseInt(cfnAutoScalingGroup.maxSize) - 1,
             }),
           );
         }

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -131,8 +131,7 @@ export class GuHorizontallyScalingDeploymentPropertiesExperimental implements IA
   }
 
   public visit(construct: IConstruct) {
-    //if (construct instanceof CfnScalingPolicy && construct.stack.stackId === this.stack.stackId) {
-    if (construct instanceof CfnScalingPolicy) {
+    if (construct instanceof CfnScalingPolicy && construct.stack.stackName === this.stack.stackName) {
       const { node } = construct;
       const { scopes, path } = node;
 

--- a/src/experimental/patterns/ec2-app.ts
+++ b/src/experimental/patterns/ec2-app.ts
@@ -131,6 +131,7 @@ export class GuHorizontallyScalingDeploymentPropertiesExperimental implements IA
   }
 
   public visit(construct: IConstruct) {
+    //if (construct instanceof CfnScalingPolicy && construct.stack.stackId === this.stack.stackId) {
     if (construct instanceof CfnScalingPolicy) {
       const { node } = construct;
       const { scopes, path } = node;

--- a/src/utils/test/template.ts
+++ b/src/utils/test/template.ts
@@ -19,7 +19,8 @@ export function getTemplateAfterAspectInvocation(stack: GuStack): Template {
   }
 
   const { artifacts } = app.synth();
-  const cfnStack = artifacts.find((_): _ is CloudFormationStackArtifact => _ instanceof CloudFormationStackArtifact);
+  const cfnStacks = artifacts.filter((_): _ is CloudFormationStackArtifact => _ instanceof CloudFormationStackArtifact);
+  const cfnStack = cfnStacks.find((artifact) => artifact.id === stack.node.id);
 
   if (!cfnStack) {
     throw new Error("Unable to locate a CloudFormationStackArtifact");


### PR DESCRIPTION
## What does this change?

We recently [attempted](https://github.com/guardian/mobile-apps-api/pull/3610) to use the new deployment mechanism (introduced in https://github.com/guardian/cdk/pull/2417) with a service which [scales horizontally (based on CPU)](https://github.com/guardian/mobile-apps-api/blob/d20ad7030afcc07c86c64aef54e413611a60a8e1/cdk/lib/microservice.ts#L208-L210).

Although testing in `CODE` worked as expected and the [snapshot tests looked correct](https://github.com/guardian/mobile-apps-api/blob/32da5bb899d007e1720291d4f859d6911bf155bf/cdk/lib/__snapshots__/microservice.test.ts.snap#L16871-L16875), the deployment to `PROD` did not work as desired because:

a) I had forgotten to add [some important Riff-Raff config](https://github.com/guardian/mobile-apps-api/pull/3818/commits/df56488afac795ddf6e4f970276e9a8f553f2707)
b) I had [accidentally applied an Aspect to an `App` (which is shared by many microservices), instead of a `GuStack`](https://github.com/guardian/mobile-apps-api/pull/3818/commits/f4694d4f9a7a15ef889e08ce22c592431a8a022e)

The `GuHorizontallyScalingDeploymentPropertiesExperimental` Aspect is responsible for creating a CloudFormation parameter that [Riff-Raff can use](https://github.com/guardian/riff-raff/pull/1383) to inject an important property ([MinInstancesInService](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice)). 

When this Aspect was applied to an `App` it was able to search across scaling policies and autoscaling groups from _all_  linked CloudFormation stacks[^1]. In this case, when running against the `PROD` stack the Aspect was mistakenly select a scaling policy and autoscaling group that belonged to the `CODE` stack. This meant that it set up the `MinInstancesInService` parameter (that Riff-Raff is supposed to use) incorrectly. 

Unfortunately, as part of this it was setting the default value for `MinInstancesInService` to 1 (an incorrect value taken from `CODE`!), which meant that the Riff-Raff deployment was able to run/succeed, even though some important config had been forgotten. We didn't notice this when testing in `CODE` because the default value happened to be correct, but when it ran in `PROD` it temporarily scaled the service down to a single instance, which is highly undesirable[^2].

This PR makes things safer by:

1) Adding a check to the `GuHorizontallyScalingDeploymentPropertiesExperimental` so that it only works with scaling policies in the relevant CFN stack
1) Removing the default value from the parameter[^3]
1) Adding some more unit tests which will help us to avoid introducing more potential issues like this

I've also removed the max value from the parameter to simplify things as this [should be checked elsewhere anyway](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate-mininstancesinservice).

## How to test

New unit tests should cover this but I will also thoroughly re-test with MAPI.

## How can we measure success?

This PR should unblock the work to enable the new deployment mechanism for services which scale horizontally.

## Have we considered potential risks?

I don't think there are any particular risks associated with this PR.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^4]
- [x] I have updated the documentation as required for the described changes [^5]

Neither of these are really applicable here as this is an experimental class that most users should not interact with directly.

[^1]: This is different from the tests, which [instantiate an `App` per microservice](https://github.com/guardian/mobile-apps-api/blob/d20ad7030afcc07c86c64aef54e413611a60a8e1/cdk/lib/microservice.test.ts#L177-L188). This is why the snapshots looked correctly even though the generated template was wrong.
[^2]: Fortunately there was no user impact in this case but it would have done this for every deployment and it's very likely that it would have caused an incident if left in place.
[^3]: If there was no default we would have failed fast and we'd have identified this problem when testing in `CODE` instead of when deploying to `PROD`. Furthermore this value can change at any time (based on traffic), so I don't think having a default really makes sense here.
[^4]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^5]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?