### PR TITLE
Fix guard duty runtime monitoring policy

### DIFF
--- a/.changeset/quiet-states-pump.md
+++ b/.changeset/quiet-states-pump.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Fix resource property of guard duty IAM role for ECS task pattern

--- a/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
+++ b/src/constructs/ecs/__snapshots__/ecs-task.test.ts.snap
@@ -552,14 +552,18 @@ exports[`The GuEcsTask pattern should create the correct resources with lots of 
               },
             },
             {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
               "Action": [
-                "ecr:GetAuthorizationToken",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",
                 "ecr:BatchGetImage",
               ],
               "Effect": "Allow",
-              "Resource": "694911143906.dkr.ecr.eu-west-1.amazonaws.com/aws-guardduty-agent-fargate",
+              "Resource": "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate",
             },
           ],
           "Version": "2012-10-17",
@@ -1274,14 +1278,18 @@ exports[`The GuEcsTask pattern should support overriding the subnets used by the
               },
             },
             {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
               "Action": [
-                "ecr:GetAuthorizationToken",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",
                 "ecr:BatchGetImage",
               ],
               "Effect": "Allow",
-              "Resource": "694911143906.dkr.ecr.eu-west-1.amazonaws.com/aws-guardduty-agent-fargate",
+              "Resource": "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate",
             },
           ],
           "Version": "2012-10-17",

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -245,16 +245,10 @@ export class GuEcsTask extends Construct {
     });
     const guardDutyContainerPolicy = new PolicyStatement({
       effect: Effect.ALLOW,
-      actions: [
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:BatchGetImage",
-      ],
+      actions: ["ecr:BatchCheckLayerAvailability", "ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage"],
       // See https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring-ecr-repository-gdu-agent.html
       // note that if you are using a region other than eu-west-1 you'll need to add extra repositories here
-      resources: [
-        "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate"
-      ],
+      resources: ["arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate"],
     });
 
     taskDefinition.addToExecutionRolePolicy(getAuthTokenPolicy);

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -236,21 +236,29 @@ export class GuEcsTask extends Construct {
       taskDefinition.addToTaskRolePolicy(distPolicy);
     }
 
+    // these policies are needed for guard duty runtime monitoring
     // See https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs
-    const guardDutyPolicy = new PolicyStatement({
+    const getAuthTokenPolicy = new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["ecr:GetAuthorizationToken"],
+      resources: ["*"],
+    });
+    const guardDutyContainerPolicy = new PolicyStatement({
       effect: Effect.ALLOW,
       actions: [
-        "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
         "ecr:GetDownloadUrlForLayer",
         "ecr:BatchGetImage",
       ],
       // See https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring-ecr-repository-gdu-agent.html
       // note that if you are using a region other than eu-west-1 you'll need to add extra repositories here
-      resources: ["694911143906.dkr.ecr.eu-west-1.amazonaws.com/aws-guardduty-agent-fargate"],
+      resources: [
+        "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate"
+      ],
     });
 
-    taskDefinition.addToExecutionRolePolicy(guardDutyPolicy);
+    taskDefinition.addToExecutionRolePolicy(getAuthTokenPolicy);
+    taskDefinition.addToExecutionRolePolicy(guardDutyContainerPolicy);
 
     (customTaskPolicies ?? []).forEach((p) => taskDefinition.addToTaskRolePolicy(p));
 


### PR DESCRIPTION
## What does this change?
I made a mistake in https://github.com/guardian/cdk/pull/2703 - specifying the repository url rather than the ARN when trying to limit access to the fargate repository in eu-west-1. In addition, `ecr:GetAuthorizationToken` is a global policy so shouldn't be scoped to a single resource.

Currently, using this pattern results in a cloudformation error `Resource handler returned message: "Resource 694911143906.dkr.ecr.eu-west-1.amazonaws.com/aws-guardduty-agent-fargate must be in ARN format or "*". `

## How to test
I've tested this using lurch (I know I said I'd done that for https://github.com/guardian/cdk/pull/2703!) I'm not certain what happened there but this time I verified that the iam execution role had been updated as expected. 