### PR TITLE
fix: Remove unused `RegexPattern.S3ARN`

### DIFF
--- a/.changeset/yummy-points-clap.md
+++ b/.changeset/yummy-points-clap.md
@@ -1,0 +1,7 @@
+---
+"@guardian/cdk": patch
+---
+
+Remove unused `RegexPattern.S3ARN`.
+
+The regex isn't used (other than within tests of this repository), so we can safely remove it.

--- a/src/constants/regex-pattern.test.ts
+++ b/src/constants/regex-pattern.test.ts
@@ -7,13 +7,6 @@ describe("the regex patterns", () => {
     expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeTruthy();
   });
 
-  it("should successfully regex against valid s3 ARNs only", () => {
-    const regex = new RegExp(RegexPattern.S3ARN);
-    expect(regex.test("fooooo")).toBeFalsy();
-    expect(regex.test("arn:aws:rds:us-east-2:123456789012:db:my-mysql-instance-1")).toBeFalsy();
-    expect(regex.test("arn:aws:s3:::examplebucket/my-data/sales-export-2019-q4.json")).toBeTruthy();
-  });
-
   it("should successfully regex against ACM ARNs", () => {
     const regex = new RegExp(RegexPattern.ACM_ARN);
     expect(regex.test("arn:aws:acm:eu-west-1:000000000000:certificate/123abc-0000-0000-0000-123abc")).toBeTruthy();

--- a/src/constants/regex-pattern.ts
+++ b/src/constants/regex-pattern.ts
@@ -1,13 +1,9 @@
 const arnRegex = "arn:aws:[a-z0-9]*:[a-z0-9\\-]*:[0-9]{12}:.*";
 
-const s3BucketRegex = "(?!^(\\d{1,3}\\.){3}\\d{1,3}$)(^[a-z0-9]([a-z0-9-]*(\\.[a-z0-9])?)*$(?<!\\-))";
-const s3ArnRegex = `arn:aws:s3:::${s3BucketRegex}*`;
-
 // TODO be more strict on region?
 const acmRegex = "arn:aws:acm:[0-9a-z\\-]+:[0-9]{12}:certificate/[0-9a-z\\-]+";
 
 export const RegexPattern = {
   ARN: arnRegex,
-  S3ARN: s3ArnRegex,
   ACM_ARN: acmRegex,
 };


### PR DESCRIPTION
## What does this change?
The regex [isn't used](https://github.com/search?q=org%3Aguardian%20RegexPattern.S3ARN&type=code) (other than within tests of this repository), so we can safely remove it.

## How to test
N/A.

## How can we measure success?
Resolves https://github.com/guardian/cdk/security/code-scanning/1.

## Have we considered potential risks?
N/A.

## Checklist

- ~[ ] I have listed any breaking changes, along with a migration path [^1]~
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
