### PR TITLE
fix(update-aws-cdk): Ensure a valid git branch name

### DIFF
--- a/script/update-aws-cdk
+++ b/script/update-aws-cdk
@@ -51,11 +51,17 @@ raisePR() {
   AWSCDKLIB_VERSION=$(jq -r '.peerDependencies."aws-cdk-lib"' < "$ROOT_DIR/package.json")
   CONSTRUCT_VERSION=$(jq -r '.peerDependencies.constructs' < "$ROOT_DIR/package.json")
 
-  BRANCH_NAME="update-aws-cdk-$AWSCDK_VERSION"
+  AWSCDK_VERSION_CLEANED=$(
+    echo "$AWSCDK_VERSION" \
+    | sed 's/\^//g' # Remove ^ to ensure a valid branch name. See https://git-scm.com/docs/git-check-ref-format.
+  )
+
+  BRANCH_NAME="update-aws-cdk-$AWSCDK_VERSION_CLEANED"
+
   COMMIT_SUBJECT="fix(deps): Update AWS CDK libraries to $AWSCDK_VERSION, and constructs to $CONSTRUCT_VERSION"
   COMMIT_BODY="Update aws-cdk to $AWSCDK_VERSION, aws-cdk-lib to $AWSCDKLIB_VERSION, constructs to $CONSTRUCT_VERSION"
 
-  addChangeset "$AWSCDK_VERSION" "$COMMIT_BODY"
+  addChangeset "$AWSCDK_VERSION_CLEANED" "$COMMIT_BODY"
 
   git checkout -b "$BRANCH_NAME"
 


### PR DESCRIPTION
## What does this change?
Remove invalid `^` character from branch name as described in the spec - https://git-scm.com/docs/git-check-ref-format.

See also https://github.com/guardian/cdk/pull/2698.

## How to test
I've run the `update-aws-cdk` script locally from this branch and it created https://github.com/guardian/cdk/pull/2713.

## How can we measure success?
The `update-aws-cdk` script runs on the 10th of every month. The invocation for August 2025 failed at the point of creating a branch:

<img width="554" height="81" alt="image" src="https://github.com/user-attachments/assets/e88fd009-a90b-48cd-8ed0-74aebc24730e" />

This change should allow the script to run to completion.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
