### PR TITLE
fix(update-aws-cdk): Keep peerDependencies in sync with devDependencies

### DIFF
--- a/script/update-aws-cdk
+++ b/script/update-aws-cdk
@@ -8,10 +8,34 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR=$DIR/..
 
-updateAwsCdk() {
-  # `npx` to avoid a devDependency (and the Dependabot PRs)
+updateDependency() {
+  DEPENDENCY_NAME=$1
+
+  echo "Updating $DEPENDENCY_NAME (if available)"
+
+  # `npx` to avoid a devDependency (and the Dependabot PRs).
   # See https://www.npmjs.com/package/npm-check-updates
-  npx npm-check-updates@16.3.25 "aws-cdk-lib" "aws-cdk" "constructs" --upgrade --deep --target minor
+  npx npm-check-updates "$DEPENDENCY_NAME" --upgrade --deep --target minor
+
+  FILE=package.json
+  TMP_FILE=package.json.tmp
+
+  NEW_VERSION=$(jq -r ".devDependencies.\"${DEPENDENCY_NAME}\"" < "$ROOT_DIR/$FILE")
+
+  # Peer dependencies describe the version clients need.
+  # The ^ allows them to use a matching or higher minor/patch version.
+  # The means clients can use Dependabot.
+  NEW_PEER_VERSION="^${NEW_VERSION}"
+
+  # Synchronise the version within peerDependencies in package.json.
+  # As jq doesn't support in-place editing, write to a temp file and move it back.
+  jq ".peerDependencies.\"${DEPENDENCY_NAME}\" |= \"${NEW_PEER_VERSION}\"" $FILE > $TMP_FILE && mv $TMP_FILE $FILE
+}
+
+updateAwsCdk() {
+  updateDependency aws-cdk
+  updateDependency aws-cdk-lib
+  updateDependency constructs
 
   # Deliberately NOT `npm ci` as we're going to raise a PR with the resulting changes to package-lock.json
   # --ignore-scripts for speed


### PR DESCRIPTION
## What does this change?
As I understand it:
  - `devDependencies` are what's used when developing a library
  - `peerDependencies` are requirements for consumers of the library

[Currently](https://github.com/guardian/cdk/blob/e52c956df26fc50787a65785c4baaf1e0e1ca08f/package.json) the `devDependencies` and `peerDependencies` are out of sync:

```json
"devDependencies": {
  "aws-cdk": "2.1024.0",
  "aws-cdk-lib": "2.210.0",
  "constructs": "10.4.2"
},
"peerDependencies": {
  "aws-cdk": "^2.1018.0",
  "aws-cdk-lib": "^2.200.1",
  "constructs": "^10.4.2"
}
```

Whist the differing values are valid and doesn't break anything, it is a bit confusing. This change ensures the two are kept in sync whenever the [update automation](https://github.com/guardian/cdk/blob/main/.github/workflows/update-aws-cdk.yaml) runs to make things easier to reason about.

Confusingly, this used to be the default behaviour (see https://github.com/guardian/cdk/pull/2653). Maybe https://github.com/guardian/cdk/pull/2698 changed the behaviour, though I can't see how.

## How to test
After running `./script/update-aws-cdk` locally, the `package.json` file has the following diff:

```diff
diff --git a/package.json b/package.json
index 798926fb5..87b9a365e 100644
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "22.15.30",
     "@types/yargs": "^17.0.33",
-    "aws-cdk": "2.1024.0",
-    "aws-cdk-lib": "2.210.0",
+    "aws-cdk": "2.1029.1",
+    "aws-cdk-lib": "2.214.0",
     "constructs": "10.4.2",
     "eslint": "^9.34.0",
     "eslint-plugin-custom-rules": "file:tools/eslint",
@@ -62,8 +62,8 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "aws-cdk": "^2.1018.0",
-    "aws-cdk-lib": "^2.200.1",
+    "aws-cdk": "^2.1029.1",
+    "aws-cdk-lib": "^2.214.0",
     "constructs": "^10.4.2"
   }
 }
```