### PR TITLE
feat!: Enable access logging by default on Application Load Balancers 

### DIFF
--- a/.changeset/great-eyes-tan.md
+++ b/.changeset/great-eyes-tan.md
@@ -1,0 +1,49 @@
+---
+"@guardian/cdk": major
+---
+
+Access logging for Application Load Balancers (ALBs) is now enabled by default.
+
+[Application Load Balancer (ALB) access logs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html) describe, in detail, each request processed by a load balancer, including request paths and status codes.
+They are helpful during incident response and are now enabled by default.
+
+Previously users of the `GuEc2App`, `GuNodeApp`, `GuPlayApp `, `GuPlayWorkerApp` and `GuEc2AppExperimental` patterns could opt-in to this logging via the `accessLogging` property and configure the S3 prefix.
+
+This property is now removed and replaced with a new optional boolean property `withAccessLogging` which defaults to `true`.
+- When `true` the ALB will have access logs enabled, configured to write to the account's S3 bucket using a specific prefix for compatibility with the `gucdk_access_logs` database created in Athena via https://github.com/guardian/aws-account-setup.
+- When `false` the [`access_logs.s3.enabled` attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-elasticloadbalancingv2-loadbalancer-loadbalancerattribute.html) is now explicitly set to `false`.
+
+A `withAccessLogging` property is also added to the `GuApplicationLoadBalancer` construct, with the same behaviour.
+
+NOTE: This feature requires a region to be set at the `GuStack` level, else the following error will be thrown:
+
+> ValidationError: Region is required to enable ELBv2 access logging
+
+Here's an example of how to set the region:
+
+```typescript
+class MyStack extends GuStack {
+  constructor(scope: App, id: string, props: GuStackProps) {
+    super(scope, id, props);
+  }
+}
+
+const stackInstance = new MyStack(app, 'MyStack', {
+  env: {
+    region: 'eu-west-1'
+  },
+});
+```
+
+There are three cost areas to this feature:
+- Writing to S3.
+
+  AWS absorbs these costs.
+
+- S3 data storage.
+
+  This cost will vary depending on the volume of traffic received; more traffic, more logs. To somewhat mitigate this, the target S3 bucket has already been configured to retain logs for 14 days.
+
+- Reading from S3 using Athena.
+
+  This cost will vary depending on the volume of logs queried.

--- a/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
+++ b/src/constructs/cloudwatch/__snapshots__/ec2-alarms.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The GuAlb4xxPercentageAlarm construct should create the correct alarm r
     "gu:cdk:constructs": [
       "GuStack",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuAlb4xxPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
@@ -19,6 +20,13 @@ exports[`The GuAlb4xxPercentageAlarm construct should create the correct alarm r
           "DNSName",
         ],
       },
+    },
+  },
+  "Parameters": {
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
@@ -36,6 +44,20 @@ exports[`The GuAlb4xxPercentageAlarm construct should create the correct alarm r
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/testing",
           },
         ],
         "Scheme": "internal",
@@ -122,11 +144,7 @@ exports[`The GuAlb4xxPercentageAlarm construct should create the correct alarm r
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -249,6 +267,7 @@ exports[`The GuAlb5xxPercentageAlarm construct should create the correct alarm r
     "gu:cdk:constructs": [
       "GuStack",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuAlb5xxPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
@@ -262,6 +281,13 @@ exports[`The GuAlb5xxPercentageAlarm construct should create the correct alarm r
           "DNSName",
         ],
       },
+    },
+  },
+  "Parameters": {
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
@@ -279,6 +305,20 @@ exports[`The GuAlb5xxPercentageAlarm construct should create the correct alarm r
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/testing",
           },
         ],
         "Scheme": "internal",
@@ -365,11 +405,7 @@ exports[`The GuAlb5xxPercentageAlarm construct should create the correct alarm r
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -492,6 +528,7 @@ exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm
     "gu:cdk:constructs": [
       "GuStack",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuUnhealthyInstancesAlarm",
     ],
@@ -506,6 +543,13 @@ exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm
           "DNSName",
         ],
       },
+    },
+  },
+  "Parameters": {
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
@@ -541,6 +585,20 @@ exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/testing",
           },
         ],
         "Scheme": "internal",
@@ -682,11 +740,7 @@ exports[`The GuUnhealthyInstancesAlarm construct should create the correct alarm
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },

--- a/src/constructs/cloudwatch/ec2-alarms.test.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.test.ts
@@ -19,8 +19,11 @@ const app: AppIdentity = {
 
 describe("The GuAlb5xxPercentageAlarm construct", () => {
   it("should create the correct alarm resource with minimal config", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       tolerated5xxPercentage: 1,
       snsTopicName: "test-topic",
@@ -30,8 +33,11 @@ describe("The GuAlb5xxPercentageAlarm construct", () => {
   });
 
   it("should use a custom description if one is provided", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       alarmDescription: "test-custom-alarm-description",
       tolerated5xxPercentage: 1,
@@ -44,8 +50,11 @@ describe("The GuAlb5xxPercentageAlarm construct", () => {
   });
 
   it("should use a custom alarm name if one is provided", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       alarmName: "test-custom-alarm-name",
       tolerated5xxPercentage: 1,
@@ -58,8 +67,11 @@ describe("The GuAlb5xxPercentageAlarm construct", () => {
   });
 
   it("should adjust the number of evaluation periods if a custom value is provided", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       tolerated5xxPercentage: 1,
       numberOfMinutesAboveThresholdBeforeAlarm: 3,
@@ -74,8 +86,11 @@ describe("The GuAlb5xxPercentageAlarm construct", () => {
 
 describe("The GuAlb4xxPercentageAlarm construct", () => {
   it("should create the correct alarm resource with minimal config", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       tolerated4xxPercentage: 1,
       snsTopicName: "test-topic",
@@ -85,8 +100,11 @@ describe("The GuAlb4xxPercentageAlarm construct", () => {
   });
 
   it("should use a custom description if one is provided", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       alarmDescription: "test-custom-alarm-description",
       tolerated4xxPercentage: 1,
@@ -99,8 +117,11 @@ describe("The GuAlb4xxPercentageAlarm construct", () => {
   });
 
   it("should use a custom alarm name if one is provided", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       alarmName: "test-custom-alarm-name",
       tolerated4xxPercentage: 1,
@@ -113,8 +134,11 @@ describe("The GuAlb4xxPercentageAlarm construct", () => {
   });
 
   it("should adjust the number of evaluation periods if a custom value is provided", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const props = {
       tolerated4xxPercentage: 1,
       numberOfMinutesAboveThresholdBeforeAlarm: 3,
@@ -129,8 +153,11 @@ describe("The GuAlb4xxPercentageAlarm construct", () => {
 
 describe("The GuUnhealthyInstancesAlarm construct", () => {
   it("should create the correct alarm resource with minimal config", () => {
-    const stack = simpleGuStackForTesting();
-    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const alb = new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
+      ...app,
+      vpc,
+    });
     const targetGroup = new GuApplicationTargetGroup(stack, "ApplicationTargetGroup", { ...app, vpc });
     new ApplicationListener(stack, "ApplicationListener", {
       protocol: ApplicationProtocol.HTTP,

--- a/src/constructs/loadbalancing/alb/application-listener.test.ts
+++ b/src/constructs/loadbalancing/alb/application-listener.test.ts
@@ -38,7 +38,7 @@ const getAppTargetGroup = (stack: GuStack): GuApplicationTargetGroup => {
 
 describe("The GuApplicationListener class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
@@ -54,7 +54,7 @@ describe("The GuApplicationListener class", () => {
   });
 
   test("sets default props", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
@@ -70,7 +70,7 @@ describe("The GuApplicationListener class", () => {
   });
 
   test("merges default and passed in props", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationListener(stack, "ApplicationListener", {
       ...app,
@@ -87,7 +87,7 @@ describe("The GuApplicationListener class", () => {
   });
 
   test("Can override default protocol with prop", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationListener(stack, "Listener", {
       loadBalancer: getLoadBalancer(stack),
@@ -104,7 +104,7 @@ describe("The GuApplicationListener class", () => {
 
 describe("The GuHttpsApplicationListener class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuHttpsApplicationListener(stack, "HttpsApplicationListener", {
       ...app,
@@ -120,7 +120,7 @@ describe("The GuHttpsApplicationListener class", () => {
   });
 
   test("sets default props", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       certificate: getCertificate(stack),
@@ -144,7 +144,7 @@ describe("The GuHttpsApplicationListener class", () => {
   });
 
   test("wires up the certificate which is passed in correctly", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       certificate: getCertificate(stack),
@@ -164,7 +164,7 @@ describe("The GuHttpsApplicationListener class", () => {
   });
 
   test("sets the port to 8080 if a certificate is not supplied", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       loadBalancer: getLoadBalancer(stack),
@@ -177,7 +177,7 @@ describe("The GuHttpsApplicationListener class", () => {
   });
 
   test("sets the protocol to http if a certificate is not supplied", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuHttpsApplicationListener(stack, "ApplicationListener", {
       loadBalancer: getLoadBalancer(stack),

--- a/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
@@ -104,4 +104,42 @@ describe("The GuApplicationLoadBalancer class", () => {
       ]),
     });
   });
+
+  it("has access logging enabled by default", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      LoadBalancerAttributes: Match.arrayWith([
+        {
+          Key: "access_logs.s3.enabled",
+          Value: "true",
+        },
+        {
+          Key: "access_logs.s3.bucket",
+          Value: {
+            Ref: "AccessLoggingBucket",
+          },
+        },
+        {
+          Key: "access_logs.s3.prefix",
+          Value: `application-load-balancer/TEST/test-stack/${app.app}`,
+        },
+      ]),
+    });
+  });
+
+  it("can have access logging disabled", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc, withAccessLogging: false });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
+      LoadBalancerAttributes: Match.arrayWith([
+        {
+          Key: "access_logs.s3.enabled",
+          Value: "false",
+        },
+      ]),
+    });
+  });
 });

--- a/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.test.ts
@@ -21,7 +21,7 @@ const app: AppIdentity = {
 
 describe("The GuApplicationLoadBalancer class", () => {
   it("should use the AppIdentity to form its auto-generated logicalId", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
 
     GuTemplate.fromStack(stack).hasResourceWithLogicalId(
@@ -31,7 +31,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   it("should apply the App tag", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
 
     GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::ElasticLoadBalancingV2::LoadBalancer", {
@@ -41,7 +41,7 @@ describe("The GuApplicationLoadBalancer class", () => {
 
   test("deletes the Type property if the removeType prop is set to true", () => {
     // not using an auto-generated logicalId to make the expectation notation easier
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", {
       ...app,
       vpc,
@@ -54,7 +54,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   test("sets the deletion protection value to true by default", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
@@ -68,7 +68,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   it("creates an cloudformation output of the dns name", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
 
@@ -76,7 +76,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   it("adds headers that include the TLS version and the cipher suite used during negotiation", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
 
@@ -91,7 +91,7 @@ describe("The GuApplicationLoadBalancer class", () => {
   });
 
   it("drops invalid headers before forwarding requests to the target", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuApplicationLoadBalancer(stack, "ApplicationLoadBalancer", { ...app, vpc });
 

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -22,6 +22,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuRiffRaffDeploymentIdParameter",
@@ -43,6 +44,11 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
     "AMITestguec2app": {
       "Description": "Amazon Machine Image ID for the app test-gu-ec2-app. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
@@ -363,11 +369,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -471,6 +473,20 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/test-gu-ec2-app",
           },
         ],
         "Scheme": "internet-facing",
@@ -583,11 +599,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -606,11 +618,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -830,11 +838,7 @@ exitCode=$?
                   {
                     "Ref": "AWS::StackId",
                   },
-                  "           --resource AutoScalingGroupTestguec2appASG49EA1878           --region ",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  "           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+                  "           --resource AutoScalingGroupTestguec2appASG49EA1878           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
         
 }
 trap exitTrap EXIT
@@ -859,11 +863,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
                   {
                     "Ref": "TargetGroupTestguec2app9F67D503",
                   },
-                  "         --region ",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  "         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
 
       until [ "$STATE" == "\\"healthy\\"" ]; do
         echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
@@ -872,11 +872,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
                   {
                     "Ref": "TargetGroupTestguec2app9F67D503",
                   },
-                  "           --region ",
-                  {
-                    "Ref": "AWS::Region",
-                  },
-                  "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
       done
 
       echo "Instance running build TEST is healthy in target group."

--- a/src/experimental/patterns/ec2-app.test.ts
+++ b/src/experimental/patterns/ec2-app.test.ts
@@ -46,13 +46,13 @@ function initialProps(scope: GuStack, app: string = "test-gu-ec2-app"): GuEc2App
 // TODO test User Data includes a build number
 describe("The GuEc2AppExperimental pattern", () => {
   it("matches the snapshot", () => {
-    const stack = simpleGuStackForTesting();
-    new GuEc2AppExperimental(stack, initialProps(stack));
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuEc2AppExperimental(stack, { ...initialProps(stack), withAccessLogging: true });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
 
   it("should create an ASG with min, max, and desired capacity set", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuEc2AppExperimental(stack, { ...initialProps(stack), scaling: { minimumInstances: 5 } });
 
@@ -66,7 +66,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should create an ASG with a resource signal count that matches the min instances", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuEc2AppExperimental(stack, { ...initialProps(stack), scaling: { minimumInstances: 5 } });
 
@@ -83,7 +83,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should have a PauseTime higher than the ASG healthcheck grace period", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const { autoScalingGroup } = new GuEc2AppExperimental(stack, initialProps(stack));
 
     const tenMinutes = Duration.minutes(10);
@@ -112,7 +112,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should add to the end of the user data", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     const userDataCommand = `echo "Hello there"`;
     const userData = UserData.forLinux();
@@ -136,7 +136,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should only adjust properties of a horizontally scaling service", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     const scalingApp = "my-scaling-app";
     const { autoScalingGroup } = new GuEc2AppExperimental(stack, {
@@ -188,7 +188,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should add a single CFN Parameter per ASG regardless of how many scaling policies are attached to it", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     const scalingApp = "my-scaling-app";
     const { autoScalingGroup } = new GuEc2AppExperimental(stack, {
@@ -242,6 +242,7 @@ describe("The GuEc2AppExperimental pattern", () => {
     const stack = new GuStack(cdkApp, "test", {
       stack: "test-stack",
       stage: "TEST",
+      env: { region: "eu-west-1" },
     });
 
     const { autoScalingGroup } = new GuEc2AppExperimental(stack, initialProps(stack));
@@ -274,6 +275,7 @@ describe("The GuEc2AppExperimental pattern", () => {
     const stack = new GuStack(app, "test", {
       stack: "test-stack",
       stage: "TEST",
+      env: { region: "eu-west-1" },
     });
 
     const appA = new GuEc2AppExperimental(stack, {
@@ -330,11 +332,13 @@ describe("The GuEc2AppExperimental pattern", () => {
       stack: "playground",
       stage: "CODE",
       scaling: { minimumInstances: 1, maximumInstances: 2 },
+      env: { region: "eu-west-1" },
     });
     const prodStack = new Microservice(app, "PROD", {
       stack: "playground",
       stage: "PROD",
       scaling: { minimumInstances: 3, maximumInstances: 12 },
+      env: { region: "eu-west-1" },
     });
 
     const codeTemplate = getTemplateAfterAspectInvocation(codeStack);
@@ -373,8 +377,18 @@ describe("The GuEc2AppExperimental pattern", () => {
       }
     }
 
-    const appA = new Microservice(app, "app-a-PROD", { stack: "playground", stage: "PROD", appName: "app-a" });
-    const appB = new Microservice(app, "app-b-PROD", { stack: "playground", stage: "PROD", appName: "app-b" });
+    const appA = new Microservice(app, "app-a-PROD", {
+      stack: "playground",
+      stage: "PROD",
+      appName: "app-a",
+      env: { region: "eu-west-1" },
+    });
+    const appB = new Microservice(app, "app-b-PROD", {
+      stack: "playground",
+      stage: "PROD",
+      appName: "app-b",
+      env: { region: "eu-west-1" },
+    });
 
     const templateA = getTemplateAfterAspectInvocation(appA);
     const templateB = getTemplateAfterAspectInvocation(appB);
@@ -393,7 +407,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should add the correct target group attributes if slow start is enabled", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(44) });
     const template = getTemplateAfterAspectInvocation(stack);
     template.hasResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
@@ -408,7 +422,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should update the pause time for the rolling update correctly", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.minutes(1) });
     const template = getTemplateAfterAspectInvocation(stack);
     template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
@@ -421,7 +435,7 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should update the script correctly if slow start is enabled", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const userDataCommand = `echo "Hello there"`;
     const userData = UserData.forLinux();
     userData.addCommands(userDataCommand);
@@ -447,14 +461,14 @@ describe("The GuEc2AppExperimental pattern", () => {
   });
 
   it("should throw an error if the slow start value is too low", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(() => {
       new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(29) });
     }).toThrowError("Slow start duration must be between 30 and 900 seconds");
   });
 
   it("should throw an error if the slow start value is too high", () => {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(() => {
       new GuEc2AppExperimental(stack, { ...initialProps(stack), slowStartDuration: Duration.seconds(901) });
     }).toThrowError("Slow start duration must be between 30 and 900 seconds");
@@ -487,8 +501,18 @@ describe("The GuHorizontallyScalingDeploymentPropertiesExperimental construct", 
       }
     }
 
-    const appA = new Microservice(app, "app-a-PROD", { stack: "playground", stage: "PROD", appName: "app-a" });
-    const appB = new Microservice(app, "app-b-PROD", { stack: "playground", stage: "PROD", appName: "app-b" });
+    const appA = new Microservice(app, "app-a-PROD", {
+      stack: "playground",
+      stage: "PROD",
+      appName: "app-a",
+      env: { region: "eu-west-1" },
+    });
+    const appB = new Microservice(app, "app-b-PROD", {
+      stack: "playground",
+      stage: "PROD",
+      appName: "app-b",
+      env: { region: "eu-west-1" },
+    });
 
     const templateA = getTemplateAfterAspectInvocation(appA);
     const templateB = getTemplateAfterAspectInvocation(appB);

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -22,6 +22,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuSecurityGroup",
@@ -43,6 +44,11 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
     "AMITestguec2app": {
       "Description": "Amazon Machine Image ID for the app test-gu-ec2-app. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
@@ -327,11 +333,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -435,6 +437,20 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/test-gu-ec2-app",
           },
         ],
         "Scheme": "internet-facing",
@@ -544,11 +560,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -567,11 +579,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -905,6 +913,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
     ],
@@ -925,6 +934,11 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
     "AMITestguec2app": {
       "Description": "Amazon Machine Image ID for the app test-gu-ec2-app. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
@@ -1188,11 +1202,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1296,6 +1306,20 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/test-gu-ec2-app",
           },
         ],
         "Scheme": "internet-facing",
@@ -1408,11 +1432,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1431,11 +1451,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -691,13 +691,14 @@ UserData from accessed construct`);
       monitoringConfiguration: { noMonitoring: true },
       instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
+      withAccessLogging: false,
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
       LoadBalancerAttributes: Match.arrayWith([
         {
-          Key: "deletion_protection.enabled",
-          Value: "true",
+          Key: "access_logs.s3.enabled",
+          Value: "false",
         },
       ]),
     });

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -12,7 +12,7 @@ import { GuEc2App } from "./base";
 
 describe("the GuEC2App pattern", function () {
   it("should produce a functional EC2 app with minimal arguments", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -32,7 +32,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("can produce a restricted EC2 app locked to specific CIDR ranges", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -52,7 +52,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("can produce an EC2 app with an internal load balancer (located in private subnets)", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -77,7 +77,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("adds the correct permissions for apps which need to fetch private config from s3", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -143,7 +143,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("creates a High5xxPercentageAlarm if the relevant monitoringConfiguration is provided", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -172,7 +172,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("creates a High4xxPercentageAlarm if the relevant monitoringConfiguration is provided", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -201,7 +201,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("creates an UnhealthyInstancesAlarm if the user enables it", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -227,7 +227,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("Skips alarm creation if the user explicitly opts-out", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -252,7 +252,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("creates the appropriate ingress rules for a restricted access application", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -302,7 +302,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("allows all connections if set to public", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -334,7 +334,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("errors if specifying open access as well as specific CIDR ranges", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     expect(
       () =>
@@ -359,7 +359,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("errors if specifying public CIDR ranges with internal access scope", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     expect(
       () =>
@@ -384,7 +384,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("correctly wires up custom role configuration", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -422,11 +422,7 @@ describe("the GuEC2App pattern", function () {
               "Fn::Join": [
                 "",
                 [
-                  "arn:aws:kinesis:",
-                  {
-                    Ref: "AWS::Region",
-                  },
-                  ":",
+                  "arn:aws:kinesis:eu-west-1:",
                   {
                     Ref: "AWS::AccountId",
                   },
@@ -454,11 +450,7 @@ describe("the GuEC2App pattern", function () {
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:dynamodb:",
-                    {
-                      Ref: "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:dynamodb:eu-west-1:",
                     {
                       Ref: "AWS::AccountId",
                     },
@@ -470,11 +462,7 @@ describe("the GuEC2App pattern", function () {
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:dynamodb:",
-                    {
-                      Ref: "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:dynamodb:eu-west-1:",
                     {
                       Ref: "AWS::AccountId",
                     },
@@ -490,7 +478,7 @@ describe("the GuEC2App pattern", function () {
   });
 
   it("sub-constructs can be accessed and modified after declaring the pattern", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     const pattern = new GuEc2App(stack, {
       applicationPort: 3000,
@@ -517,7 +505,7 @@ UserData from accessed construct`);
   });
 
   it("users can optionally configure block devices", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -559,7 +547,7 @@ UserData from accessed construct`);
   });
 
   it("users can override resources and constructs if desired", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     const pattern = new GuEc2App(stack, {
       applicationPort: 3000,
@@ -606,7 +594,7 @@ UserData from accessed construct`);
   });
 
   it("can handle multiple EC2 apps in a single stack", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "NodeApp",
@@ -654,7 +642,7 @@ UserData from accessed construct`);
     });
   });
 
-  it("can be configured with access logging", function () {
+  it("has access logging enabled by default", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const app = "test-gu-ec2-app";
     new GuEc2App(stack, {
@@ -671,7 +659,6 @@ UserData from accessed construct`);
       monitoringConfiguration: { noMonitoring: true },
       instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
-      accessLogging: { enabled: true, prefix: "access-logging-prefix" },
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
@@ -679,7 +666,10 @@ UserData from accessed construct`);
         { Key: "deletion_protection.enabled", Value: "true" },
         { Key: "access_logs.s3.enabled", Value: "true" },
         { Key: "access_logs.s3.bucket", Value: { Ref: "AccessLoggingBucket" } },
-        { Key: "access_logs.s3.prefix", Value: "access-logging-prefix" },
+        {
+          Key: "access_logs.s3.prefix",
+          Value: `application-load-balancer/TEST/test-stack/${app}`,
+        },
       ]),
     });
   });
@@ -701,7 +691,6 @@ UserData from accessed construct`);
       monitoringConfiguration: { noMonitoring: true },
       instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
-      accessLogging: { enabled: false },
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
@@ -820,7 +809,6 @@ UserData from accessed construct`);
       monitoringConfiguration: { noMonitoring: true },
       instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
-      accessLogging: { enabled: false },
     });
 
     GuTemplate.fromStack(stack).hasGuTaggedResource("AWS::AutoScaling::AutoScalingGroup", {
@@ -849,7 +837,6 @@ UserData from accessed construct`);
       monitoringConfiguration: { noMonitoring: true },
       instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
-      accessLogging: { enabled: false },
       googleAuth: {
         enabled: true,
         domain,
@@ -891,7 +878,6 @@ UserData from accessed construct`);
           monitoringConfiguration: { noMonitoring: true },
           instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
-          accessLogging: { enabled: false },
           googleAuth: {
             enabled: true,
             domain,
@@ -922,7 +908,6 @@ UserData from accessed construct`);
           monitoringConfiguration: { noMonitoring: true },
           instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
-          accessLogging: { enabled: false },
           googleAuth: {
             enabled: true,
             domain,
@@ -953,7 +938,6 @@ UserData from accessed construct`);
           monitoringConfiguration: { noMonitoring: true },
           instanceMetricGranularity: "5Minute",
           userData: UserData.forLinux(),
-          accessLogging: { enabled: false },
           googleAuth: {
             enabled: true,
             domain,
@@ -964,7 +948,7 @@ UserData from accessed construct`);
   });
 
   it("should provides a default healthcheck", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -990,7 +974,7 @@ UserData from accessed construct`);
   });
 
   it("allows a custom healthcheck", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -1019,7 +1003,7 @@ UserData from accessed construct`);
   });
 
   it("can specify instance metadata hop limit", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -1068,10 +1052,6 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       instanceMetadataHopLimit: 2,
-      accessLogging: {
-        enabled: true,
-        prefix: "test-1",
-      },
     });
 
     new GuEc2App(stack, {
@@ -1089,25 +1069,31 @@ UserData from accessed construct`);
         minimumInstances: 1,
       },
       instanceMetadataHopLimit: 2,
-      accessLogging: {
-        enabled: true,
-        prefix: "test-2",
-      },
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
       Tags: Match.arrayWith([Match.objectLike({ Key: "App", Value: "test-gu-ec2-app-1" })]),
-      LoadBalancerAttributes: Match.arrayWith([Match.objectLike({ Key: "access_logs.s3.prefix", Value: "test-1" })]),
+      LoadBalancerAttributes: Match.arrayWith([
+        Match.objectLike({
+          Key: "access_logs.s3.prefix",
+          Value: "application-load-balancer/TEST/test-stack/test-gu-ec2-app-1",
+        }),
+      ]),
     });
 
     Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::LoadBalancer", {
       Tags: Match.arrayWith([Match.objectLike({ Key: "App", Value: "test-gu-ec2-app-2" })]),
-      LoadBalancerAttributes: Match.arrayWith([Match.objectLike({ Key: "access_logs.s3.prefix", Value: "test-2" })]),
+      LoadBalancerAttributes: Match.arrayWith([
+        Match.objectLike({
+          Key: "access_logs.s3.prefix",
+          Value: "application-load-balancer/TEST/test-stack/test-gu-ec2-app-2",
+        }),
+      ]),
     });
   });
 
   it("uses the latest security policy", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -1131,7 +1117,7 @@ UserData from accessed construct`);
   });
 
   it("has a defined UpdatePolicy when provided with one", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuEc2App(stack, {
       applicationPort: 3000,
@@ -1161,7 +1147,7 @@ UserData from accessed construct`);
   });
 
   it("set detailed monitoring on the ASG launch template when set", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",
@@ -1189,7 +1175,7 @@ UserData from accessed construct`);
   });
 
   it("set defaultInstanceWarmup on the ASG when set", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuEc2App(stack, {
       applicationPort: 3000,
       app: "test-gu-ec2-app",

--- a/src/patterns/ec2-app/framework.test.ts
+++ b/src/patterns/ec2-app/framework.test.ts
@@ -6,7 +6,7 @@ import { GuNodeApp, GuPlayApp, GuPlayWorkerApp } from "./framework";
 
 describe("Framework level EC2 app patterns", () => {
   test("GuNodeApp exposes port 3000", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuNodeApp(stack, {
       app: "NodeApp",
       access: { scope: AccessScope.PUBLIC },
@@ -29,7 +29,7 @@ describe("Framework level EC2 app patterns", () => {
   });
 
   it("GuPlayApp exposes port 9000", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuPlayApp(stack, {
       app: "PlayApp",
       access: { scope: AccessScope.RESTRICTED, cidrRanges: [] },
@@ -52,7 +52,7 @@ describe("Framework level EC2 app patterns", () => {
   });
 
   it("GuPlayWorkerApp has no internal or external access", function () {
-    const stack = simpleGuStackForTesting();
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuPlayWorkerApp(stack, {
       app: "PlayApp",
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),


### PR DESCRIPTION
> [!NOTE]
> - This is an alternative to https://github.com/guardian/cdk/pull/2739. This change does not default the region as there were a bit too many edge-cases to this at the moment.
> - Easiest to review [commit by commit](https://github.com/guardian/cdk/pull/2742/commits).

## What does this change?
The `access_logs.s3.enabled` Application Load Balancer attribute is now explicitly set, with a default value of `true`, enabling access logs by default. Previously this was opt-in behaviour. These logs are written to an S3 bucket in the same AWS account as the ALB and are queryable with Athena.

Consequently, the optional `accessLogging` object property for a `GuEc2` app (and it subclasses) has been removed. In its place is a `withAccessLogging` boolean property with a default value of `true`.

### Why drop `accessLogging`?
The `accessLogging` property had the following type:

```ts
export interface AccessLoggingProps {
  /**
   * Enable (load balancer) access logs.
   *
   * Note, you will need to specify a region in your stack declaration to use
   * this.
   * See`https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-elasticloadbalancingv2.ApplicationLoadBalancer.html#logwbraccesswbrlogsbucket-prefix`
   */
  enabled: boolean;
  /**
   * S3 prefix for the logs.
   *
   * @defaultValue no prefix
   */
  prefix?: string;
}
```

It allowed the `prefix` to be set. DevX RelOps have recently updated https://github.com/guardian/aws-account-setup to provision an Athena database, table and saved query for this data. These Athena resources assume a specific prefix which is now hardcoded in GuCDK.

If a service doesn't want to use the RelOps solution, they still can by setting `withAccessLogging: false` and manually configuring the load balancer.

## How to test
See the updated unit tests.

## How can we measure success?
Access logs are another datasource that can be used during incident triage. Success is that incident triage becomes easier, though this is hard to measure!

## Have we considered potential risks?
This change should only impact clients that use `GuEc2App` or its sub-classes. The changes require a snapshot update before passing CI and being deployed. The risk (if it can be considered a risk) is that team's won't understand why their snapshot is failing; the release notes should help there.

## Checklist

- [X] I have listed any breaking changes, along with a migration path [^1]
- [X] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
