### PR TITLE
feat(GuCertificate): Remove `DeletionPolicy` and `UpdateReplacePolicy`

### DIFF
--- a/.changeset/itchy-swans-jump.md
+++ b/.changeset/itchy-swans-jump.md
@@ -1,0 +1,10 @@
+---
+"@guardian/cdk": minor
+---
+
+feat(GuCertificate): Remove `DeletionPolicy` and `UpdateReplacePolicy`
+
+Typically, the `DeletionPolicy` is set to support CloudFormation imports.
+The `AWS::CertificateManager::Certificate` resource does not yet support CFN imports.
+
+See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html.

--- a/src/constructs/acm/__snapshots__/certificate.test.ts.snap
+++ b/src/constructs/acm/__snapshots__/certificate.test.ts.snap
@@ -11,7 +11,6 @@ exports[`The GuCertificate class should create a new certificate (which requires
   },
   "Resources": {
     "CertificateTesting28FCAC6D": {
-      "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "domain-name-for-your-application.example",
         "Tags": [
@@ -43,7 +42,6 @@ exports[`The GuCertificate class should create a new certificate (which requires
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
     },
   },
 }
@@ -60,7 +58,6 @@ exports[`The GuCertificate class should create a new certificate when hosted zon
   },
   "Resources": {
     "CertificateTesting28FCAC6D": {
-      "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "domain-name-for-your-application.example",
         "DomainValidationOptions": [
@@ -98,7 +95,6 @@ exports[`The GuCertificate class should create a new certificate when hosted zon
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
     },
   },
 }

--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -1,4 +1,3 @@
-import { RemovalPolicy } from "aws-cdk-lib";
 import { Certificate, CertificateValidation } from "aws-cdk-lib/aws-certificatemanager";
 import type { CertificateProps } from "aws-cdk-lib/aws-certificatemanager/lib/certificate";
 import { HostedZone } from "aws-cdk-lib/aws-route53";
@@ -32,6 +31,5 @@ export class GuCertificate extends GuAppAwareConstruct(Certificate) {
       app,
     };
     super(scope, "Certificate", awsCertificateProps);
-    this.applyRemovalPolicy(RemovalPolicy.RETAIN);
   }
 }

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -207,7 +207,6 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
       },
     },
     "CertificateTestguec2app86EE2D42": {
-      "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "domain-name-for-your-application.example",
         "Tags": [
@@ -239,7 +238,6 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
     },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {

--- a/src/patterns/__snapshots__/api-lambda.test.ts.snap
+++ b/src/patterns/__snapshots__/api-lambda.test.ts.snap
@@ -49,7 +49,6 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
   },
   "Resources": {
     "CertificateTesting28FCAC6D": {
-      "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "code.theguardian.com",
         "DomainValidationOptions": [
@@ -87,7 +86,6 @@ exports[`The GuApiLambda pattern should allow us to link a domain name to a Lamb
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
     },
     "DNS": {
       "Properties": {

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -145,7 +145,6 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
     "CertificateTestguec2app86EE2D42": {
-      "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "domain-name-for-your-application.example",
         "Tags": [
@@ -177,7 +176,6 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
     },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
@@ -1035,7 +1033,6 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
     "CertificateTestguec2app86EE2D42": {
-      "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "domain-name-for-your-application.example",
         "Tags": [
@@ -1067,7 +1064,6 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
         "ValidationMethod": "DNS",
       },
       "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
     },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {


### PR DESCRIPTION
## What does this change?
Typically, the `DeletionPolicy` is set to support [CloudFormation imports](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html). The `AWS::CertificateManager::Certificate` resource does not yet support CFN imports[^1], so stop setting `DeletionPolicy` and `UpdateReplacePolicy`.

## How to test
See CI and updated snapshots.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^2]
- [x] I have updated the documentation as required for the described changes [^3]

[^1]: See also https://github.com/guardian/cdk/pull/390#discussion_r608459080.
[^2]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^3]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
