### PR TITLE
Disable workflow schedule

### DIFF
--- a/.github/workflows/update-aws-cdk.yaml
+++ b/.github/workflows/update-aws-cdk.yaml
@@ -1,10 +1,5 @@
 name: Update AWS CDK libraries
 on:
-  schedule:
-    # At 10:00 on day-of-month 10.
-    # See https://crontab.guru/#0_10_10_*_*
-    - cron: '0 10 10 * *'
-
   # Allows one to update the version of AWS CDK by simply starting the workflow, as opposed to manually running the update-aws-cdk script.
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
## What does this change?

We've been reviewing how we manage this library's dependencies. Amazon established [the following recommendation](https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html) as part of the migration to cdk v2

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

> For construct libraries, establish the lowest version of aws-cdk-lib you require for your application (2.0.0 here) and update package.json as follows.
```json
{
  "peerDependencies": {
    "aws-cdk-lib": "^2.0.0",
    "constructs": "^10.0.0"
  },
  "devDependencies": {
    "aws-cdk-lib": "^2.0.0",
    "constructs": "^10.0.0",
    "typescript": "~3.9.0"
  }
}
```

It's unclear to me at present if having the lowest version is the right approach for us (it would be version `2.182.0`, released April 2025). The way we expect this library to be used may lend itself to us specifying the cdk version as a direct dependency, rather than a minimum peer dependency. Until we make a final decision on that just disabling the automated library updates for now would reduce a significant amount of toil on clients.
