### PR TITLE
Pass shell: false to childProcess.spawn

### DIFF
--- a/.changeset/wicked-donuts-hope.md
+++ b/.changeset/wicked-donuts-hope.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Fix warnings around childProcess.spawn and shell: true.

--- a/src/bin/commands/new-project/index.ts
+++ b/src/bin/commands/new-project/index.ts
@@ -161,7 +161,7 @@ export const newCdkProject = async (props: NewProjectProps): CliCommandResponse 
   console.log(chalk.green("  ✅ Successfully synthesized CDK app"));
 
   console.log(chalk.green("Success! Here's a summary of the created files:"));
-  const tree = await execute("tree", ["-I 'node_modules|cdk.out'"], {
+  const tree = await execute("tree", ["-I", "node_modules|cdk.out"], {
     cwd: config.cdkDir,
   });
   console.log(tree);

--- a/src/bin/commands/new-project/utils/utils.ts
+++ b/src/bin/commands/new-project/utils/utils.ts
@@ -6,8 +6,8 @@ export interface Name {
   pascal: string;
 }
 
-async function runTask(packageManager: PackageManager, cwd: string, task: string): Promise<string> {
-  return await execute(`${packageManager} ${task}`, [], { cwd });
+async function runTask(packageManager: PackageManager, cwd: string, args: string[]): Promise<string> {
+  return await execute(packageManager, args, { cwd });
 }
 
 export function getCommands(
@@ -20,9 +20,9 @@ export function getCommands(
   test: () => Promise<string>;
 } {
   return {
-    installDependencies: () => runTask(packageManager, cwd, "install"),
-    lint: () => runTask(packageManager, cwd, "run lint"),
-    test: () => runTask(packageManager, cwd, "test -- -u"),
-    synth: () => runTask(packageManager, cwd, "run synth"),
+    installDependencies: () => runTask(packageManager, cwd, ["install"]),
+    lint: () => runTask(packageManager, cwd, ["run", "lint"]),
+    test: () => runTask(packageManager, cwd, ["test", "--", "-u"]),
+    synth: () => runTask(packageManager, cwd, ["run", "synth"]),
   };
 }

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -4,7 +4,7 @@ import childProcess from "child_process";
 export async function execute(cmd: string, args: string[], { cwd }: { cwd: string }): Promise<string> {
   const child = childProcess.spawn(cmd, args, {
     cwd,
-    shell: true,
+    shell: false,
     stdio: ["ignore", "pipe", "inherit"],
   });
 

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -29,7 +29,7 @@ export async function execute(cmd: string, args: string[], { cwd }: { cwd: strin
 export function executeSync(cmd: string, args: string[], { cwd }: { cwd: string }): string {
   const { stdout, status } = childProcess.spawnSync(cmd, args, {
     cwd,
-    shell: true,
+    shell: false,
     stdio: ["ignore", "pipe", "inherit"],
   });
 


### PR DESCRIPTION
## What does this change?

Pass `shell: false` to `childProcess.spawn` when running commands.

This is more secure. After upgrading a project to Node 24 I started seeing deprecation warnings like this, coming from @guardian/cdk:

`DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.`

## How to test

Verify that build checks/CI pass.

If it's possible to release a BETA version to npm then checking that against a real project would be a good way to verify.

## How can we measure success?

The deprecation warning mentioned above should disappear after updating to a version of `@guardian/cdk` with this change.

## Have we considered potential risks?

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1] (No breaking changes)
- [x] I have updated the documentation as required for the described changes [^2] (This is an internal change, I don't think documentation changes are required)

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
