### PR TITLE
Bump auth lambda runtime to Amazon Linux 2023

### DIFF
--- a/.changeset/bump-auth-lambda-al2023.md
+++ b/.changeset/bump-auth-lambda-al2023.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Bump the Cognito auth lambda runtime from `PROVIDED_AL2` to `PROVIDED_AL2023` in the `GuEc2App` pattern.

--- a/.changeset/bump-auth-lambda-al2023.md
+++ b/.changeset/bump-auth-lambda-al2023.md
@@ -2,4 +2,5 @@
 "@guardian/cdk": patch
 ---
 
-Bump the Cognito auth lambda runtime from `PROVIDED_AL2` to `PROVIDED_AL2023` in the `GuEc2App` pattern.
+Bump the Cognito auth lambda runtime from `PROVIDED_AL2` (deprecated) to `PROVIDED_AL2023` in the `GuEc2App` pattern.
+No client changes needed.

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -584,7 +584,7 @@ export class GuEc2App extends Construct {
         app: app,
         memorySize: 128,
         handler: "bootstrap",
-        runtime: Runtime.PROVIDED_AL2,
+        runtime: Runtime.PROVIDED_AL2023,
         fileName: `deploy/${cognitoAuthStage}/cognito-lambda/devx-cognito-lambda-amd64-v2.zip`,
         withoutFilePrefix: true,
         withoutArtifactUpload: true,


### PR DESCRIPTION
## What does this change?

Bumps the Cognito auth lambda runtime from `PROVIDED_AL2` to `PROVIDED_AL2023` in the `GuEc2App` pattern.

## How has this change been tested?

Testing was done as part of https://github.com/guardian/cognito-auth-lambdas/pull/299