### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'quarterly'
     commit-message:
       prefix: "chore(deps): "
     groups:
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'quarterly'
     commit-message:
       prefix: "chore(deps): "
     # force the lockfile and package.json to be updated
@@ -67,7 +67,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/tools/integration-test'
     schedule:
-      interval: 'monthly'
+      interval: 'quarterly'
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

