### PR TITLE
fix: Correct Riff-Raff project tag key

### DIFF
--- a/.changeset/vast-women-rush.md
+++ b/.changeset/vast-women-rush.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Correct Riff-Raff project tag key to match the one previously introduced in https://github.com/guardian/riff-raff/pull/1374/changes: `gu:riff-raff:project`.

--- a/src/constructs/core/stack.ts
+++ b/src/constructs/core/stack.ts
@@ -159,7 +159,7 @@ export class GuStack extends Stack implements StackStageIdentity {
       }
 
       if (this.riffRaffProjectName) {
-        this.addTag("gu:riff-raff-project", this.riffRaffProjectName);
+        this.addTag("gu:riff-raff:project", this.riffRaffProjectName);
       }
 
       if (this.repositoryName) {


### PR DESCRIPTION
## What does this change?
The tag added in https://github.com/guardian/cdk/pull/2872 is incorrect. The key should match the one previously introduced in https://github.com/guardian/riff-raff/pull/1374/changes.

The following [Service Catalogue query](https://metrics.gutools.co.uk/goto/PVfDVnJvR?orgId=1) shows we do have mixed usage now:

```sql
SELECT  'gu:riff-raff:project' as tag
        , COUNT(*)
FROM    aws_resources
WHERE   tags ->> 'gu:riff-raff:project' IS NOT NULL

UNION

SELECT  'gu:riff-raff-project' as tag
        , COUNT(*)
FROM    aws_resources
WHERE   tags ->> 'gu:riff-raff-project' IS NOT NULL
```

With:
- `gu:riff-raff:project` = 7874
- `gu:riff-raff-project` = 1122

However, as the (incorrect) `gu:riff-raff-project` tag is only added when `riffRaffProjectName` is set on `GuStack` we can see this is [currently only done within DevX owned services](https://github.com/search?q=org%3Aguardian+riffRaffProjectName+language%3ATypeScript&type=code&l=TypeScript). That is, rolling out the fix should be quick/easy.

## How to test
N/A.

## How can we measure success?
Consistency. The `gu:riff-raff:project` tag is used on a number of dashboards.

## Have we considered potential risks?
N/A.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
