### PR TITLE
Add support for EC2 versioned deployments to GuLoadBalancedAppExperimental

### DIFF
--- a/.changeset/spotty-ants-arrive.md
+++ b/.changeset/spotty-ants-arrive.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Add support for EC2 versioned deployments to GuLoadBalancedAppExperimental

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -1702,6 +1702,946 @@ exports[`the GuLoadBalancedAppExperimental pattern should support all existing G
 }
 `;
 
+exports[`the GuLoadBalancedAppExperimental pattern should support experimental EC2 versioned deployment functionality should produce the correct snapshot if versioned updates are enabled 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuStack",
+      "GuVpcParameter",
+      "GuSubnetListParameter",
+      "GuSubnetListParameter",
+      "GuLoadBalancedAppExperimental",
+      "GuDistributionBucketParameter",
+      "GuInstanceRole",
+      "GuSsmSshPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuApplicationTargetGroup",
+      "GuRiffRaffDeploymentIdParameterExperimental",
+      "GuCertificate",
+      "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
+      "GuHttpsApplicationListener",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "LoadBalancerTestguDnsName": {
+      "Description": "DNS entry for LoadBalancerTestgu",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerTestgu9DB57B41",
+          "DNSName",
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "AMITestgu": {
+      "Description": "Amazon Machine Image ID for the app test-gu. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "RiffRaffDeploymentId": {
+      "Description": "Used by Riff-Raff to inject the deployment ID.",
+      "Type": "String",
+    },
+    "VpcId": {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "testguPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "testguPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+  },
+  "Resources": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupTestguASG6CDCC0F0": {
+      "CreationPolicy": {
+        "AutoScalingCreationPolicy": {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": {
+          "Count": 1,
+          "Timeout": "PT3M",
+        },
+      },
+      "DependsOn": [
+        "AsgRollingUpdatePolicy2A1DDC6F",
+      ],
+      "Properties": {
+        "DesiredCapacity": "1",
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "teststackTESTtestgu5E2363A5",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "teststackTESTtestgu5E2363A5",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "MaxSize": "2",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+          },
+        ],
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupTestgu1F401467",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "testguPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MaxBatchSize": 2,
+          "MinInstancesInService": 1,
+          "MinSuccessfulInstancesPercent": 100,
+          "PauseTime": "PT3M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+            "AZRebalance",
+            "HealthCheck",
+            "InstanceRefresh",
+            "ReplaceUnhealthy",
+            "ScheduledActions",
+          ],
+          "WaitOnResourceSignals": true,
+        },
+      },
+    },
+    "CertificateTestguA5ACC36C": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "domain-name-for-your-application.example",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Name",
+            "Value": "Test/CertificateTestgu",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyTestgu80E7E62C": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/test-stack/TEST/test-gu/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyTestgu80E7E62C",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupTestgu45CFB979": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupTestgufromTestLoadBalancerTestguSecurityGroup48DFF409300004891897": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupTestgu45CFB979",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguSecurityGroup03CCB607",
+            "GroupId",
+          ],
+        },
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleTestguD5DB5D23": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ListenerTestguCB542308": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateTestguA5ACC36C",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupTestgu1F401467",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerTestgu9DB57B41",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerTestgu9DB57B41": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/TEST/test-stack/test-gu",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerTestguSecurityGroup03CCB607",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "testguPublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerTestguSecurityGroup03CCB607": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB TestLoadBalancerTestguFCD56751",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerTestguSecurityGrouptoTestGuHttpsEgressSecurityGroupTestguC8728D3630002981E674": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupTestgu45CFB979",
+            "GroupId",
+          ],
+        },
+        "FromPort": 3000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerTestguSecurityGroup03CCB607",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 3000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ParameterStoreReadTestgu2D9B3F35": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/test-gu",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/test-stack/test-gu/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupTestgu1F401467": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 3000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "teststackTESTtestgu5E2363A5": {
+      "DependsOn": [
+        "InstanceRoleTestguD5DB5D23",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "teststackTESTtestguProfileB2AA9521",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMITestgu",
+          },
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
+          },
+          "Monitoring": {
+            "Enabled": false,
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupTestgu45CFB979",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "test-gu",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "123",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "test-gu",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "123",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "Test/test-stack-TEST-test-gu",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "test-stack",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupTestguASG6CDCC0F0           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
+mkdir -p $(dirname '/test-gu/test-gu-123.deb')
+aws s3 cp 's3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/test-stack/TEST/test-gu/test-gu-123.deb' '/test-gu/test-gu-123.deb'
+dpkg -i /test-gu/test-gu-123.deb
+echo "Launch template last updated by Riff-Raff deployment ID: ",
+                  {
+                    "Ref": "RiffRaffDeploymentId",
+                  },
+                  ""
+# GuEc2AppExperimental Instance Health Check Start
+
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupTestgu1F401467",
+                  },
+                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=3000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance running build 123 not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupTestgu1F401467",
+                  },
+                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=3000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance running build 123 is healthy in target group."
+      
+# GuEc2AppExperimental Instance Health Check End",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "test-gu",
+              },
+              {
+                "Key": "gu:build-identifier",
+                "Value": "123",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk",
+              },
+              {
+                "Key": "Name",
+                "Value": "Test/test-stack-TEST-test-gu",
+              },
+              {
+                "Key": "Stack",
+                "Value": "test-stack",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "teststackTESTtestguProfileB2AA9521": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleTestguD5DB5D23",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+  },
+}
+`;
+
 exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hybrid functionality should produce a functional ECS app with minimal arguments 1`] = `
 {
   "Metadata": {

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -1,13 +1,23 @@
-import { Duration } from "aws-cdk-lib";
+import { App, Duration } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
-import { BlockDeviceVolume, EbsDeviceVolumeType, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import {
+  BlockDeviceVolume,
+  type CfnAutoScalingGroup,
+  CfnScalingPolicy,
+  EbsDeviceVolumeType,
+  UpdatePolicy,
+} from "aws-cdk-lib/aws-autoscaling";
 import { InstanceClass, InstanceSize, InstanceType, Peer, Port, UserData, Vpc } from "aws-cdk-lib/aws-ec2";
 import type { CfnLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { AccessScope, MetadataKeys } from "../../constants";
-import { GuPrivateConfigBucketParameter } from "../../constructs/core";
+import { GuUserData } from "../../constructs/autoscaling";
+import type { NoMonitoring } from "../../constructs/cloudwatch";
+import { GuPrivateConfigBucketParameter, GuStack, type GuStackProps } from "../../constructs/core";
 import { GuSecurityGroup } from "../../constructs/ec2";
 import { GuDynamoDBWritePolicy } from "../../constructs/iam";
-import { GuTemplate, simpleGuStackForTesting } from "../../utils/test";
+import type { AppAccess, GuAsgCapacity } from "../../types";
+import { getTemplateAfterAspectInvocation, GuTemplate, simpleGuStackForTesting } from "../../utils/test";
+import { RollingUpdateDurations } from "./ec2-app";
 import { GuLoadBalancedAppExperimental } from "./gu-load-balanced-app";
 
 describe("the GuLoadBalancedAppExperimental pattern should support new ECS and hybrid functionality", function () {
@@ -1616,4 +1626,504 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
+  it("should create an ASG with min, max, and desired capacity set", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: { ...initialEc2Props(stack), scaling: { minimumInstances: 5 } },
+    });
+
+    Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+        MaxSize: "10",
+        DesiredCapacity: "5",
+      },
+    });
+  });
+
+  it("should create an ASG with a resource signal count that matches the min instances", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: { ...initialEc2Props(stack), scaling: { minimumInstances: 5 } },
+    });
+
+    Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        MinSize: "5",
+      },
+      CreationPolicy: {
+        ResourceSignal: {
+          Count: 5,
+        },
+      },
+    });
+  });
+
+  it("should have a PauseTime higher than the ASG healthcheck grace period", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: { ...initialEc2Props(stack) },
+    });
+
+    const tenMinutes = Duration.minutes(10);
+    const tenMinutesPlusBuffer = tenMinutes.plus(RollingUpdateDurations.buffer);
+
+    const cfnAsg = autoScalingGroup!.node.defaultChild as CfnAutoScalingGroup;
+    cfnAsg.healthCheckGracePeriod = tenMinutes.toSeconds();
+
+    const template = getTemplateAfterAspectInvocation(stack);
+
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        HealthCheckGracePeriod: tenMinutes.toSeconds(),
+      },
+      CreationPolicy: {
+        ResourceSignal: {
+          Timeout: tenMinutesPlusBuffer.toIsoString(),
+        },
+      },
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          PauseTime: tenMinutesPlusBuffer.toIsoString(),
+        },
+      },
+    });
+  });
+
+  it("should add to the end of the user data", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    const userDataCommand = `echo "Hello there"`;
+    const userData = UserData.forLinux();
+    userData.addCommands(userDataCommand);
+
+    const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: { ...initialEc2Props(stack), userData },
+    });
+
+    const renderedUserData = autoScalingGroup!.userData.render();
+    const splitUserData = renderedUserData.split("\n");
+    const totalLines = splitUserData.length;
+
+    const appCommandPosition = splitUserData.indexOf(userDataCommand);
+    const startMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental Instance Health Check Start");
+    const endMarkerPosition = splitUserData.indexOf("# GuEc2AppExperimental Instance Health Check End");
+
+    // Application user data should be before the target group healthcheck polling.
+    expect(appCommandPosition).toBeLessThan(startMarkerPosition);
+
+    // The target group healthcheck polling should be the last thing in the user data.
+    expect(endMarkerPosition).toEqual(totalLines - 1);
+  });
+
+  it("should only adjust properties of a horizontally scaling service", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    const scalingApp = "my-scaling-app";
+    const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(scalingApp),
+      ec2Props: { ...initialEc2Props(stack, scalingApp), scaling: { minimumInstances: 5 } },
+    });
+    autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 100,
+    });
+
+    const staticApp = "my-static-app";
+    new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(staticApp),
+      ec2Props: { ...initialEc2Props(stack, staticApp) },
+    });
+
+    const template = getTemplateAfterAspectInvocation(stack);
+
+    // The scaling ASG should NOT have `DesiredCapacity` set, and `MinInstancesInService` set via a CFN Parameter
+    const parameterName = "MinInstancesInServiceFormyscalingapp";
+    template.hasParameter(parameterName, {
+      Type: "Number",
+    });
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        DesiredCapacity: Match.absent(),
+        Tags: Match.arrayWith([{ Key: "App", Value: scalingApp, PropagateAtLaunch: true }]),
+      },
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          MinInstancesInService: {
+            Ref: parameterName,
+          },
+        },
+      },
+    });
+
+    // The static ASG SHOULD have `DesiredCapacity` and `MinInstancesInService` explicitly
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      Properties: {
+        DesiredCapacity: "1",
+        Tags: Match.arrayWith([{ Key: "App", Value: staticApp, PropagateAtLaunch: true }]),
+      },
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          MinInstancesInService: 1,
+        },
+      },
+    });
+  });
+
+  it("should add a single CFN Parameter per ASG regardless of how many scaling policies are attached to it", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    const scalingApp = "my-scaling-app";
+    const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(scalingApp),
+      ec2Props: { ...initialEc2Props(stack, scalingApp), scaling: { minimumInstances: 5 } },
+    });
+    autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 100,
+    });
+
+    new CfnScalingPolicy(autoScalingGroup!, "ScaleOut", {
+      autoScalingGroupName: autoScalingGroup!.autoScalingGroupName,
+      policyType: "SimpleScaling",
+      adjustmentType: "ChangeInCapacity",
+      scalingAdjustment: 1,
+    });
+
+    new CfnScalingPolicy(autoScalingGroup!, "ScaleIn", {
+      autoScalingGroupName: autoScalingGroup!.autoScalingGroupName,
+      policyType: "SimpleScaling",
+      adjustmentType: "ChangeInCapacity",
+      scalingAdjustment: -1,
+    });
+
+    const template = getTemplateAfterAspectInvocation(stack);
+
+    const parameterName = `MinInstancesInServiceFor${scalingApp.replaceAll("-", "")}`;
+
+    template.hasParameter(parameterName, {
+      Type: "Number",
+    });
+
+    template.resourceCountIs("AWS::AutoScaling::AutoScalingGroup", 1);
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          MinInstancesInService: {
+            Ref: parameterName,
+          },
+        },
+      },
+    });
+
+    template.resourceCountIs("AWS::AutoScaling::ScalingPolicy", 3);
+  });
+
+  it("should throw an error when a scaling policy is not created with a GuAutoScalingGroup scope", () => {
+    const cdkApp = new App();
+    const stack = new GuStack(cdkApp, "test", {
+      stack: "test-stack",
+      stage: "TEST",
+      env: { region: "eu-west-1" },
+    });
+
+    const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: { ...initialEc2Props(stack) },
+    });
+
+    /**
+     * Should be created like this to avoid the error:
+     *
+     * @example
+     * ```ts
+     * declare const autoScalingGroup: GuAutoScalingGroup;
+     * new CfnScalingPolicy(autoScalingGroup, "ScaleOut", { ... });
+     * ```
+     */
+    new CfnScalingPolicy(stack, "ScaleOut", {
+      autoScalingGroupName: autoScalingGroup!.autoScalingGroupName,
+      policyType: "SimpleScaling",
+      adjustmentType: "ChangeInCapacity",
+      scalingAdjustment: 1,
+    });
+
+    expect(() => {
+      cdkApp.synth();
+    }).toThrow(
+      "Failed to detect the autoscaling group relating to the scaling policy on path test/ScaleOut. Was it created in the scope of a GuAutoScalingGroup?",
+    );
+  });
+
+  it("should add the correct CFN Parameters for more than one EC2 app in the same stack", () => {
+    const app = new App();
+    const stack = new GuStack(app, "test", {
+      stack: "test-stack",
+      stage: "TEST",
+      env: { region: "eu-west-1" },
+    });
+
+    const appA = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps("app-a"),
+      ec2Props: { ...initialEc2Props(stack, "app-a"), scaling: { minimumInstances: 3, maximumInstances: 12 } },
+    });
+    appA.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 99,
+    });
+
+    const appB = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps("app-b"),
+      ec2Props: { ...initialEc2Props(stack, "app-b"), scaling: { minimumInstances: 6, maximumInstances: 24 } },
+    });
+    appB.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
+      targetRequestsPerMinute: 100,
+    });
+
+    const template = getTemplateAfterAspectInvocation(stack);
+
+    template.hasParameter("MinInstancesInServiceForappa", {
+      Type: "Number",
+    });
+
+    template.hasParameter("MinInstancesInServiceForappb", {
+      Type: "Number",
+    });
+  });
+
+  it("should add the correct CFN Parameters for two separate stacks in the same app", () => {
+    const app = new App();
+
+    interface MicroserviceProps extends GuStackProps {
+      scaling: GuAsgCapacity;
+    }
+
+    class Microservice extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- this is a test
+      constructor(scope: App, id: string, props: MicroserviceProps) {
+        super(scope, id, {
+          ...props,
+        });
+        const ec2App = new GuLoadBalancedAppExperimental(this, {
+          ...topLevelProps(),
+          ec2Props: { ...initialEc2Props(this), scaling: props.scaling },
+        });
+        ec2App.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
+          targetRequestsPerMinute: 100,
+        });
+      }
+    }
+
+    const codeStack = new Microservice(app, "CODE", {
+      stack: "playground",
+      stage: "CODE",
+      scaling: { minimumInstances: 1, maximumInstances: 2 },
+      env: { region: "eu-west-1" },
+    });
+    const prodStack = new Microservice(app, "PROD", {
+      stack: "playground",
+      stage: "PROD",
+      scaling: { minimumInstances: 3, maximumInstances: 12 },
+      env: { region: "eu-west-1" },
+    });
+
+    const codeTemplate = getTemplateAfterAspectInvocation(codeStack);
+    const prodTemplate = getTemplateAfterAspectInvocation(prodStack);
+
+    const parameterName = "MinInstancesInServiceFortestguec2app";
+
+    codeTemplate.hasParameter(parameterName, {
+      Type: "Number",
+    });
+
+    prodTemplate.hasParameter(parameterName, {
+      Type: "Number",
+    });
+  });
+
+  it("should only add the relevant CFN Parameters for different services which share the same App", () => {
+    const app = new App();
+
+    interface MicroserviceProps extends GuStackProps {
+      appName: string;
+    }
+
+    class Microservice extends GuStack {
+      // eslint-disable-next-line custom-rules/valid-constructors -- this is a test
+      constructor(scope: App, id: string, props: MicroserviceProps) {
+        super(scope, id, {
+          ...props,
+        });
+        const ec2App = new GuLoadBalancedAppExperimental(this, {
+          ...topLevelProps(props.appName),
+          ec2Props: { ...initialEc2Props(this, props.appName) },
+        });
+        ec2App.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
+          targetRequestsPerMinute: 100,
+        });
+      }
+    }
+
+    const appA = new Microservice(app, "app-a-PROD", {
+      stack: "playground",
+      stage: "PROD",
+      appName: "app-a",
+      env: { region: "eu-west-1" },
+    });
+    const appB = new Microservice(app, "app-b-PROD", {
+      stack: "playground",
+      stage: "PROD",
+      appName: "app-b",
+      env: { region: "eu-west-1" },
+    });
+
+    const templateA = getTemplateAfterAspectInvocation(appA);
+    const templateB = getTemplateAfterAspectInvocation(appB);
+
+    templateA.hasParameter("MinInstancesInServiceForappa", {
+      Type: "Number",
+    });
+
+    expect(templateA.findParameters("*")["MinInstancesInServiceForappb"]).toEqual(undefined);
+
+    templateB.hasParameter("MinInstancesInServiceForappb", {
+      Type: "Number",
+    });
+
+    expect(templateB.findParameters("*")["MinInstancesInServiceForappa"]).toEqual(undefined);
+  });
+
+  it("should add the correct target group attributes if slow start is enabled", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: {
+        ...initialEc2Props(stack),
+        versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(44) },
+      },
+    });
+    const template = getTemplateAfterAspectInvocation(stack);
+    template.hasResource("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      Properties: {
+        TargetGroupAttributes: Match.arrayWith([
+          { Key: "deregistration_delay.timeout_seconds", Value: "30" },
+          { Key: "stickiness.enabled", Value: "false" },
+          { Key: "slow_start.duration_seconds", Value: "44" },
+        ]),
+      },
+    });
+  });
+
+  it("should update the pause time for the rolling update correctly", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: {
+        ...initialEc2Props(stack),
+        versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.minutes(1) },
+      },
+    });
+    const template = getTemplateAfterAspectInvocation(stack);
+    template.hasResource("AWS::AutoScaling::AutoScalingGroup", {
+      UpdatePolicy: {
+        AutoScalingRollingUpdate: {
+          PauseTime: "PT4M",
+        },
+      },
+    });
+  });
+
+  it("should update the script correctly if slow start is enabled", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const userDataCommand = `echo "Hello there"`;
+    const userData = UserData.forLinux();
+    userData.addCommands(userDataCommand);
+
+    const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
+      ...topLevelProps(),
+      ec2Props: {
+        ...initialEc2Props(stack),
+        versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(30) },
+      },
+    });
+
+    const renderedUserData = autoScalingGroup!.userData.render();
+    const splitUserData = renderedUserData.split("\n");
+    const totalLines = splitUserData.length;
+
+    const healthCheckMarkerEnd = splitUserData.indexOf("# GuEc2AppExperimental Instance Health Check End");
+    const slowStartMarkerStart = splitUserData.indexOf("# GuEc2AppExperimental SlowStart Wait Period Start");
+    const slowStartMarkerEnd = splitUserData.indexOf("# GuEc2AppExperimental SlowStart Wait Period End");
+
+    // Health check polling should end just before the slow start pause kicks in
+    expect(healthCheckMarkerEnd).toEqual(slowStartMarkerStart - 1);
+
+    // If slow start is enabled, the logic related to this should be the last thing in the user data script.
+    expect(slowStartMarkerEnd).toEqual(totalLines - 1);
+  });
+
+  it("should throw an error if the slow start value is too low", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    expect(() => {
+      new GuLoadBalancedAppExperimental(stack, {
+        ...topLevelProps(),
+        ec2Props: {
+          ...initialEc2Props(stack),
+          versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(29) },
+        },
+      });
+    }).toThrow("Slow start duration must be between 30 and 900 seconds");
+  });
+
+  it("should throw an error if the slow start value is too high", () => {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    expect(() => {
+      new GuLoadBalancedAppExperimental(stack, {
+        ...topLevelProps(),
+        ec2Props: {
+          ...initialEc2Props(stack),
+          versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(901) },
+        },
+      });
+    }).toThrow("Slow start duration must be between 30 and 900 seconds");
+  });
 });
+
+function topLevelProps(app = "test-gu-ec2-app") {
+  return {
+    applicationPort: 9000,
+    app,
+    access: { scope: AccessScope.PUBLIC } as AppAccess,
+    monitoringConfiguration: { noMonitoring: true } as NoMonitoring,
+    certificateProps: {
+      domainName: "domain-name-for-your-application.example",
+    },
+  };
+}
+
+function initialEc2Props(scope: GuStack, app = "test-gu-ec2-app") {
+  const buildNumber = 123;
+  const { userData } = new GuUserData(scope, {
+    app,
+    distributable: {
+      fileName: `${app}-${buildNumber}.deb`,
+      executionStatement: `dpkg -i /${app}/${app}-${buildNumber}.deb`,
+    },
+  });
+
+  return {
+    instanceMetricGranularity: "5Minute" as "1Minute" | "5Minute",
+    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+    userData,
+    scaling: {
+      minimumInstances: 1,
+    },
+    versionedDeployments: {
+      enabled: true,
+      buildIdentifier: "123",
+    },
+  };
+}

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -1626,12 +1626,22 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
+  it("should throw an error if the user passes an updatePolicy whilst using versioned deployments", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    expect(
+      () =>
+        new GuLoadBalancedAppExperimental(stack, {
+          ...topLevelPropsForVersionedDeployment(),
+          ec2Props: { updatePolicy: UpdatePolicy.replacingUpdate(), ...ec2PropsForVersionedDeployment(stack) },
+        }),
+    ).toThrow("If versionedDeployments are enabled then updatePolicy should not be set via ec2Props");
+  });
   it("should create an ASG with min, max, and desired capacity set", () => {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
-      ec2Props: { ...initialEc2Props(stack), scaling: { minimumInstances: 5 } },
+      ...topLevelPropsForVersionedDeployment(),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack), scaling: { minimumInstances: 5 } },
     });
 
     Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
@@ -1647,8 +1657,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
 
     new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
-      ec2Props: { ...initialEc2Props(stack), scaling: { minimumInstances: 5 } },
+      ...topLevelPropsForVersionedDeployment(),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack), scaling: { minimumInstances: 5 } },
     });
 
     Template.fromStack(stack).hasResource("AWS::AutoScaling::AutoScalingGroup", {
@@ -1666,8 +1676,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
   it("should have a PauseTime higher than the ASG healthcheck grace period", () => {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
-      ec2Props: { ...initialEc2Props(stack) },
+      ...topLevelPropsForVersionedDeployment(),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack) },
     });
 
     const tenMinutes = Duration.minutes(10);
@@ -1703,8 +1713,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     userData.addCommands(userDataCommand);
 
     const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
-      ec2Props: { ...initialEc2Props(stack), userData },
+      ...topLevelPropsForVersionedDeployment(),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack), userData },
     });
 
     const renderedUserData = autoScalingGroup!.userData.render();
@@ -1727,8 +1737,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
 
     const scalingApp = "my-scaling-app";
     const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(scalingApp),
-      ec2Props: { ...initialEc2Props(stack, scalingApp), scaling: { minimumInstances: 5 } },
+      ...topLevelPropsForVersionedDeployment(scalingApp),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack, scalingApp), scaling: { minimumInstances: 5 } },
     });
     autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
       targetRequestsPerMinute: 100,
@@ -1736,8 +1746,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
 
     const staticApp = "my-static-app";
     new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(staticApp),
-      ec2Props: { ...initialEc2Props(stack, staticApp) },
+      ...topLevelPropsForVersionedDeployment(staticApp),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack, staticApp) },
     });
 
     const template = getTemplateAfterAspectInvocation(stack);
@@ -1780,8 +1790,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
 
     const scalingApp = "my-scaling-app";
     const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(scalingApp),
-      ec2Props: { ...initialEc2Props(stack, scalingApp), scaling: { minimumInstances: 5 } },
+      ...topLevelPropsForVersionedDeployment(scalingApp),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack, scalingApp), scaling: { minimumInstances: 5 } },
     });
     autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
       targetRequestsPerMinute: 100,
@@ -1832,8 +1842,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     });
 
     const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
-      ec2Props: { ...initialEc2Props(stack) },
+      ...topLevelPropsForVersionedDeployment(),
+      ec2Props: { ...ec2PropsForVersionedDeployment(stack) },
     });
 
     /**
@@ -1868,16 +1878,22 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     });
 
     const appA = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps("app-a"),
-      ec2Props: { ...initialEc2Props(stack, "app-a"), scaling: { minimumInstances: 3, maximumInstances: 12 } },
+      ...topLevelPropsForVersionedDeployment("app-a"),
+      ec2Props: {
+        ...ec2PropsForVersionedDeployment(stack, "app-a"),
+        scaling: { minimumInstances: 3, maximumInstances: 12 },
+      },
     });
     appA.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
       targetRequestsPerMinute: 99,
     });
 
     const appB = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps("app-b"),
-      ec2Props: { ...initialEc2Props(stack, "app-b"), scaling: { minimumInstances: 6, maximumInstances: 24 } },
+      ...topLevelPropsForVersionedDeployment("app-b"),
+      ec2Props: {
+        ...ec2PropsForVersionedDeployment(stack, "app-b"),
+        scaling: { minimumInstances: 6, maximumInstances: 24 },
+      },
     });
     appB.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
       targetRequestsPerMinute: 100,
@@ -1908,8 +1924,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
           ...props,
         });
         const ec2App = new GuLoadBalancedAppExperimental(this, {
-          ...topLevelProps(),
-          ec2Props: { ...initialEc2Props(this), scaling: props.scaling },
+          ...topLevelPropsForVersionedDeployment(),
+          ec2Props: { ...ec2PropsForVersionedDeployment(this), scaling: props.scaling },
         });
         ec2App.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
           targetRequestsPerMinute: 100,
@@ -1958,8 +1974,8 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
           ...props,
         });
         const ec2App = new GuLoadBalancedAppExperimental(this, {
-          ...topLevelProps(props.appName),
-          ec2Props: { ...initialEc2Props(this, props.appName) },
+          ...topLevelPropsForVersionedDeployment(props.appName),
+          ec2Props: { ...ec2PropsForVersionedDeployment(this, props.appName) },
         });
         ec2App.autoScalingGroup!.scaleOnRequestCount("ScaleOnRequests", {
           targetRequestsPerMinute: 100,
@@ -1999,9 +2015,9 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
   it("should add the correct target group attributes if slow start is enabled", () => {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
+      ...topLevelPropsForVersionedDeployment(),
       ec2Props: {
-        ...initialEc2Props(stack),
+        ...ec2PropsForVersionedDeployment(stack),
         versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(44) },
       },
     });
@@ -2020,9 +2036,9 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
   it("should update the pause time for the rolling update correctly", () => {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
+      ...topLevelPropsForVersionedDeployment(),
       ec2Props: {
-        ...initialEc2Props(stack),
+        ...ec2PropsForVersionedDeployment(stack),
         versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.minutes(1) },
       },
     });
@@ -2043,9 +2059,9 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     userData.addCommands(userDataCommand);
 
     const { autoScalingGroup } = new GuLoadBalancedAppExperimental(stack, {
-      ...topLevelProps(),
+      ...topLevelPropsForVersionedDeployment(),
       ec2Props: {
-        ...initialEc2Props(stack),
+        ...ec2PropsForVersionedDeployment(stack),
         versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(30) },
       },
     });
@@ -2069,9 +2085,9 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(() => {
       new GuLoadBalancedAppExperimental(stack, {
-        ...topLevelProps(),
+        ...topLevelPropsForVersionedDeployment(),
         ec2Props: {
-          ...initialEc2Props(stack),
+          ...ec2PropsForVersionedDeployment(stack),
           versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(29) },
         },
       });
@@ -2082,9 +2098,9 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(() => {
       new GuLoadBalancedAppExperimental(stack, {
-        ...topLevelProps(),
+        ...topLevelPropsForVersionedDeployment(),
         ec2Props: {
-          ...initialEc2Props(stack),
+          ...ec2PropsForVersionedDeployment(stack),
           versionedDeployments: { enabled: true, buildIdentifier: "123", slowStartDuration: Duration.seconds(901) },
         },
       });
@@ -2092,7 +2108,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support experimental 
   });
 });
 
-function topLevelProps(app = "test-gu-ec2-app") {
+function topLevelPropsForVersionedDeployment(app = "test-gu-ec2-app") {
   return {
     applicationPort: 9000,
     app,
@@ -2104,7 +2120,7 @@ function topLevelProps(app = "test-gu-ec2-app") {
   };
 }
 
-function initialEc2Props(scope: GuStack, app = "test-gu-ec2-app") {
+function ec2PropsForVersionedDeployment(scope: GuStack, app = "test-gu-ec2-app") {
   const buildNumber = 123;
   const { userData } = new GuUserData(scope, {
     app,

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -1582,3 +1582,38 @@ UserData from accessed construct`);
     expect(resourceId).toBe("ssm param escape hatch");
   });
 });
+
+describe("the GuLoadBalancedAppExperimental pattern should support experimental EC2 versioned deployment functionality", function () {
+  it("should produce the correct snapshot if versioned updates are enabled", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "test-gu";
+    const buildIdentifier = "123";
+    new GuLoadBalancedAppExperimental(stack, {
+      applicationPort: 3000,
+      app,
+      access: { scope: AccessScope.PUBLIC },
+      monitoringConfiguration: { noMonitoring: true },
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      ec2Props: {
+        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+        instanceMetricGranularity: "5Minute",
+        userData: {
+          distributable: {
+            fileName: `${app}-${buildIdentifier}.deb`,
+            executionStatement: `dpkg -i /${app}/${app}-${buildIdentifier}.deb`,
+          },
+        },
+        scaling: {
+          minimumInstances: 1,
+        },
+        versionedDeployments: {
+          enabled: true,
+          buildIdentifier,
+        },
+      },
+    });
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -1539,3 +1539,38 @@ UserData from accessed construct`);
     expect(resourceId).toBe("ssm param escape hatch");
   });
 });
+
+describe("the GuLoadBalancedAppExperimental pattern should support experimental EC2 versioned deployment functionality", function () {
+  it("should produce the correct snapshot if versioned updates are enabled", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const app = "test-gu";
+    const buildIdentifier = "123";
+    new GuLoadBalancedAppExperimental(stack, {
+      applicationPort: 3000,
+      app,
+      access: { scope: AccessScope.PUBLIC },
+      monitoringConfiguration: { noMonitoring: true },
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      ec2Props: {
+        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+        instanceMetricGranularity: "5Minute",
+        userData: {
+          distributable: {
+            fileName: `${app}-${buildIdentifier}.deb`,
+            executionStatement: `dpkg -i /${app}/${app}-${buildIdentifier}.deb`,
+          },
+        },
+        scaling: {
+          minimumInstances: 1,
+        },
+        versionedDeployments: {
+          enabled: true,
+          buildIdentifier,
+        },
+      },
+    });
+    expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -514,6 +514,11 @@ export class GuLoadBalancedAppExperimental extends Construct {
       };
 
       if (versionedDeployments?.enabled) {
+        const slowStartDurationInSeconds = versionedDeployments.slowStartDuration?.toSeconds();
+        if (slowStartDurationInSeconds && (slowStartDurationInSeconds < 30 || slowStartDurationInSeconds > 900)) {
+          throw new Error("Slow start duration must be between 30 and 900 seconds");
+        }
+
         const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
         // Note: if the service uses horizontal scaling, this property is unset by an Aspect (to prevent accidental scale downs!)
         cfnAutoScalingGroup.desiredCapacity = minimumInstances.toString();
@@ -524,6 +529,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
           targetGroup: ec2TargetGroup,
           applicationPort: applicationPort,
           buildIdentifier: versionedDeployments.buildIdentifier,
+          slowStartDuration: versionedDeployments.slowStartDuration,
         });
 
         // This is used when an ASG is first created; it is not needed to support the new deployment mechanism but we

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -1,5 +1,5 @@
-import { Duration, SecretValue, Tags } from "aws-cdk-lib";
-import type { BlockDevice, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import { Aspects, Duration, SecretValue, Tags } from "aws-cdk-lib";
+import type { BlockDevice, CfnAutoScalingGroup, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
 import { AdditionalHealthCheckType, HealthChecks } from "aws-cdk-lib/aws-autoscaling";
 import {
   ProviderAttribute,
@@ -64,6 +64,13 @@ import type { GuAsgCapacity, GuDomainName } from "../../types";
 import type { AmigoProps } from "../../types/amigo";
 import { getUserPoolDomainPrefix } from "../../utils/cognito/cognito";
 import { GuRiffRaffDeploymentIdParameterExperimental } from "../constructs/riff-raff-deployment-id";
+import {
+  GuAutoScalingRollingUpdateTimeoutExperimental,
+  GuHorizontallyScalingDeploymentPropertiesExperimental,
+  GuRoleForRollingUpdateExperimental,
+  GuRollingUpdatePolicyExperimental,
+  GuUserDataForRollingUpdateExperimental,
+} from "./ec2-app";
 
 export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
   /**
@@ -269,7 +276,17 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
      * and must rely on riffraff to do so.
      */
     updatePolicy?: UpdatePolicy;
-
+    /**
+     * Enable CloudFormation-only deployments for EC2.
+     *
+     * In order to use this feature you must include the build number in the name of the artifact that you upload to
+     * Riff-Raff. Your userData should also refer to this versioned artifact.
+     */
+    versionedDeployments?: {
+      enabled: boolean;
+      buildIdentifier: string;
+      slowStartDuration?: Duration;
+    };
     /**
      * You can specify how long after an instance reaches the InService state it waits before contributing
      * usage data to the aggregated metrics. This specified time is called the default instance warmup.
@@ -352,6 +369,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
         userData: userDataLike,
         imageRecipe,
         instanceMetadataHopLimit,
+        versionedDeployments,
         updatePolicy,
         defaultInstanceWarmup,
         instanceMetricGranularity,
@@ -374,6 +392,17 @@ export class GuLoadBalancedAppExperimental extends Construct {
         additionalPolicies: maybePrivateConfigPolicy.concat(roleConfiguration.additionalPolicies ?? []),
       };
 
+      if (versionedDeployments?.enabled && updatePolicy) {
+        throw new Error("If versionedDeployments are enabled then updatePolicy should not be set via ec2Props");
+      }
+      const asgUpdatePolicy = versionedDeployments
+        ? GuRollingUpdatePolicyExperimental.getPolicy(
+            maximumInstances,
+            minimumInstances,
+            versionedDeployments.slowStartDuration,
+          )
+        : updatePolicy;
+
       const autoScalingGroup = new GuAutoScalingGroup(scope, "AutoScalingGroup", {
         app,
         vpc,
@@ -392,12 +421,10 @@ export class GuLoadBalancedAppExperimental extends Construct {
         ...(blockDevices && { blockDevices }),
         imageRecipe,
         httpPutResponseHopLimit: instanceMetadataHopLimit,
-        updatePolicy,
+        updatePolicy: asgUpdatePolicy,
         defaultInstanceWarmup,
         instanceMetricGranularity,
       });
-
-      this.autoScalingGroup = autoScalingGroup;
 
       // This allows automatic shipping of instance Cloud Init logs when using the
       // `cdk-base` Amigo role on your AMI.
@@ -419,6 +446,40 @@ export class GuLoadBalancedAppExperimental extends Construct {
         ec2: ec2TargetGroup,
       };
 
+      if (versionedDeployments?.enabled) {
+        const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+        // Note: if the service uses horizontal scaling, this property is unset by an Aspect (to prevent accidental scale downs!)
+        cfnAutoScalingGroup.desiredCapacity = minimumInstances.toString();
+
+        new GuRoleForRollingUpdateExperimental(scope, { autoScalingGroup });
+        new GuUserDataForRollingUpdateExperimental(scope, {
+          autoScalingGroup: autoScalingGroup,
+          targetGroup: ec2TargetGroup,
+          applicationPort: applicationPort,
+          buildIdentifier: versionedDeployments.buildIdentifier,
+        });
+
+        // This is used when an ASG is first created; it is not needed to support the new deployment mechanism but we
+        // include it here to avoid creating an unnecessary snapshot diff for existing users of this feature
+        cfnAutoScalingGroup.cfnOptions.creationPolicy = {
+          autoScalingCreationPolicy: {
+            minSuccessfulInstancesPercent: 100,
+          },
+          resourceSignal: {
+            count: minimumInstances,
+          },
+        };
+
+        const allAspects = Aspects.of(scope).all;
+        const maybeRollingUpdateTimeoutAspect = allAspects.find(
+          (_) => _ instanceof GuAutoScalingRollingUpdateTimeoutExperimental,
+        );
+        if (!maybeRollingUpdateTimeoutAspect) {
+          Aspects.of(scope).add(new GuAutoScalingRollingUpdateTimeoutExperimental());
+        }
+        Aspects.of(scope).add(new GuHorizontallyScalingDeploymentPropertiesExperimental());
+      }
+
       if (applicationLogging.enabled) {
         // This allows automatic shipping of application logs when using the
         // `cdk-base` Amigo role on your AMI.
@@ -427,6 +488,8 @@ export class GuLoadBalancedAppExperimental extends Construct {
           applicationLogging.systemdUnitName ? `${applicationLogging.systemdUnitName}.service` : `${app}.service`,
         );
       }
+
+      this.autoScalingGroup = autoScalingGroup;
     }
 
     // Setup ECS-specific infrastructure

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -1,5 +1,5 @@
-import { Duration, SecretValue, Tags } from "aws-cdk-lib";
-import type { BlockDevice, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
+import { Aspects, Duration, SecretValue, Tags } from "aws-cdk-lib";
+import type { BlockDevice, CfnAutoScalingGroup, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
 import { AdditionalHealthCheckType, HealthChecks } from "aws-cdk-lib/aws-autoscaling";
 import {
   ProviderAttribute,
@@ -64,6 +64,13 @@ import type { GuAsgCapacity, GuDomainName } from "../../types";
 import type { AmigoProps } from "../../types/amigo";
 import { getUserPoolDomainPrefix } from "../../utils/cognito/cognito";
 import { GuRiffRaffDeploymentIdParameterExperimental } from "../constructs/riff-raff-deployment-id";
+import {
+  GuAutoScalingRollingUpdateTimeoutExperimental,
+  GuHorizontallyScalingDeploymentPropertiesExperimental,
+  GuRoleForRollingUpdateExperimental,
+  GuRollingUpdatePolicyExperimental,
+  GuUserDataForRollingUpdateExperimental,
+} from "./ec2-app";
 
 export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
   /**
@@ -274,7 +281,17 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
      * and must rely on riffraff to do so.
      */
     updatePolicy?: UpdatePolicy;
-
+    /**
+     * Enable CloudFormation-only deployments for EC2.
+     *
+     * In order to use this feature you must include the build number in the name of the artifact that you upload to
+     * Riff-Raff. Your userData should also refer to this versioned artifact.
+     */
+    versionedDeployments?: {
+      enabled: boolean;
+      buildIdentifier: string;
+      slowStartDuration?: Duration;
+    };
     /**
      * You can specify how long after an instance reaches the InService state it waits before contributing
      * usage data to the aggregated metrics. This specified time is called the default instance warmup.
@@ -419,6 +436,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
         userData: userDataLike,
         imageRecipe,
         instanceMetadataHopLimit,
+        versionedDeployments,
         updatePolicy,
         defaultInstanceWarmup,
         instanceMetricGranularity,
@@ -441,6 +459,17 @@ export class GuLoadBalancedAppExperimental extends Construct {
         additionalPolicies: maybePrivateConfigPolicy.concat(roleConfiguration.additionalPolicies ?? []),
       };
 
+      if (versionedDeployments?.enabled && updatePolicy) {
+        throw new Error("If versionedDeployments are enabled then updatePolicy should not be set via ec2Props");
+      }
+      const asgUpdatePolicy = versionedDeployments
+        ? GuRollingUpdatePolicyExperimental.getPolicy(
+            maximumInstances,
+            minimumInstances,
+            versionedDeployments.slowStartDuration,
+          )
+        : updatePolicy;
+
       const autoScalingGroup = new GuAutoScalingGroup(scope, "AutoScalingGroup", {
         app,
         vpc,
@@ -459,12 +488,10 @@ export class GuLoadBalancedAppExperimental extends Construct {
         ...(blockDevices && { blockDevices }),
         imageRecipe,
         httpPutResponseHopLimit: instanceMetadataHopLimit,
-        updatePolicy,
+        updatePolicy: asgUpdatePolicy,
         defaultInstanceWarmup,
         instanceMetricGranularity,
       });
-
-      this.autoScalingGroup = autoScalingGroup;
 
       // This allows automatic shipping of instance Cloud Init logs when using the
       // `cdk-base` Amigo role on your AMI.
@@ -486,6 +513,40 @@ export class GuLoadBalancedAppExperimental extends Construct {
         ec2: ec2TargetGroup,
       };
 
+      if (versionedDeployments?.enabled) {
+        const cfnAutoScalingGroup = autoScalingGroup.node.defaultChild as CfnAutoScalingGroup;
+        // Note: if the service uses horizontal scaling, this property is unset by an Aspect (to prevent accidental scale downs!)
+        cfnAutoScalingGroup.desiredCapacity = minimumInstances.toString();
+
+        new GuRoleForRollingUpdateExperimental(scope, { autoScalingGroup });
+        new GuUserDataForRollingUpdateExperimental(scope, {
+          autoScalingGroup: autoScalingGroup,
+          targetGroup: ec2TargetGroup,
+          applicationPort: applicationPort,
+          buildIdentifier: versionedDeployments.buildIdentifier,
+        });
+
+        // This is used when an ASG is first created; it is not needed to support the new deployment mechanism but we
+        // include it here to avoid creating an unnecessary snapshot diff for existing users of this feature
+        cfnAutoScalingGroup.cfnOptions.creationPolicy = {
+          autoScalingCreationPolicy: {
+            minSuccessfulInstancesPercent: 100,
+          },
+          resourceSignal: {
+            count: minimumInstances,
+          },
+        };
+
+        const allAspects = Aspects.of(scope).all;
+        const maybeRollingUpdateTimeoutAspect = allAspects.find(
+          (_) => _ instanceof GuAutoScalingRollingUpdateTimeoutExperimental,
+        );
+        if (!maybeRollingUpdateTimeoutAspect) {
+          Aspects.of(scope).add(new GuAutoScalingRollingUpdateTimeoutExperimental());
+        }
+        Aspects.of(scope).add(new GuHorizontallyScalingDeploymentPropertiesExperimental());
+      }
+
       if (applicationLogging.enabled) {
         // This allows automatic shipping of application logs when using the
         // `cdk-base` Amigo role on your AMI.
@@ -494,6 +555,8 @@ export class GuLoadBalancedAppExperimental extends Construct {
           applicationLogging.systemdUnitName ? `${applicationLogging.systemdUnitName}.service` : `${app}.service`,
         );
       }
+
+      this.autoScalingGroup = autoScalingGroup;
     }
 
     // Setup ECS-specific infrastructure

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -286,6 +286,9 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
      *
      * In order to use this feature you must include the build number in the name of the artifact that you upload to
      * Riff-Raff. Your userData should also refer to this versioned artifact.
+     *
+     * Users migrating from the `GuEc2AppExperimental` pattern can keep existing deployment behaviour by configuring
+     * these props.
      */
     versionedDeployments?: {
       enabled: boolean;


### PR DESCRIPTION
## What does this change?

This PR is a follow-up to https://github.com/guardian/cdk/pull/2904. It unblocks the EC2 to ECS migration for users who currently rely on `GuEc2AppExperimental` (i.e. the [versioned deployment mechanism](https://docs.google.com/document/d/18M6nW6bknvFYjICMaSmDwkIisAuHsn4y_HSTdKu7Z-o/edit?tab=t.0#heading=h.fg4plmhts30o)).

## How to test

Similarly to https://github.com/guardian/cdk/pull/2904, I've brought across the existing test suite (with the slight amendments needed) to ensure that this functionality will be identical for users of the new pattern.

This has also been tested with a real app [here](https://github.com/guardian/cdk-playground/pull/1115) - only the [Metadata section](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html) is changing (no resources are modified).

## How can we measure success?
We can support migrations for users who currently rely on versioned EC2 deployments. Users who want to adopt this feature _before_ moving to ECS (in order to keep deployments as fast as possible during the migration) are now also free to do this.

## Have we considered potential risks?
As with https://github.com/guardian/cdk/pull/2904, this PR is introducing a bit of duplication. To mitigate this risk, I've run the existing test suite against this new pattern. We should also pick up any edge cases / accidental changes via snapshot test failures when users migrate to this new pattern.

It's less clear to me how we should remove this duplication again in the future - we could consider removing `GuEc2AppExperimental` entirely at this stage so that we don't have to maintain this feature for 2 patterns? However, I think that would make it more challenging to advertise the deployment mechanism as stable without also marking this new pattern (including ECS functionality) as stable.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?