### PR TITLE
fix(ecs): Apply custom healthcheck settings to ECS target group too

### DIFF
--- a/.changeset/many-readers-attack.md
+++ b/.changeset/many-readers-attack.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+fix(ecs): Apply custom healthcheck settings to ECS target group too

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -216,6 +216,72 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         }),
     ).toThrow("Could not determine an ECR repository name; please set this manually via ecsProps");
   });
+  it("allows a custom healthcheck to be used for the ECS target group", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuLoadBalancedAppExperimental(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app",
+      access: { scope: AccessScope.PUBLIC },
+      monitoringConfiguration: { noMonitoring: true },
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      healthcheck: {
+        path: "/custom-healthcheck",
+      },
+      ecsProps: {
+        cpu: 1024,
+        memoryLimitMiB: 2048,
+        scaling: { minimumTasks: 3, maximumTasks: 6 },
+        imageIdentifier: "sha256:12345",
+      },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckPath: "/custom-healthcheck",
+      TargetType: "ip", // This target type helps to confirm that its the ECS target group
+    });
+  });
+  it("applies the custom healthcheck settings to both target groups when operating in hybrid mode", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuLoadBalancedAppExperimental(stack, {
+      applicationPort: 3000,
+      app: "test-gu-ec2-app",
+      access: { scope: AccessScope.PUBLIC },
+      monitoringConfiguration: { noMonitoring: true },
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      healthcheck: {
+        path: "/custom-healthcheck",
+      },
+      ec2Props: {
+        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+        instanceMetricGranularity: "5Minute",
+        userData: UserData.forLinux(),
+        scaling: {
+          minimumInstances: 1,
+        },
+      },
+      ecsProps: {
+        cpu: 1024,
+        memoryLimitMiB: 2048,
+        scaling: { minimumTasks: 3, maximumTasks: 6 },
+        imageIdentifier: "sha256:12345",
+      },
+      targetGroupWeights: {
+        ec2: 499,
+        ecs: 500,
+      },
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckPath: "/custom-healthcheck",
+      TargetType: "instance", // The EC2 target group
+    });
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::TargetGroup", {
+      HealthCheckPath: "/custom-healthcheck",
+      TargetType: "ip", // The ECS target group
+    });
+  });
   // Because this has not been tested thoroughly yet
   it("should throw an error if there is an ECS backend and the Google Auth feature is being used", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
@@ -1348,7 +1414,7 @@ UserData from accessed construct`);
     });
   });
 
-  it("allows a custom healthcheck", function () {
+  it("allows a custom healthcheck to be used for the EC2 target group", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuLoadBalancedAppExperimental(stack, {
       applicationPort: 3000,
@@ -1376,6 +1442,7 @@ UserData from accessed construct`);
       HealthCheckProtocol: "HTTP",
       HealthCheckTimeoutSeconds: 5,
       HealthyThresholdCount: 5,
+      TargetType: "instance", // This target type helps to confirm that it's the EC2 target group
     });
   });
 

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -201,7 +201,7 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
   };
 
   /**
-   * Specify custom healthcheck
+   * Specify custom healthcheck settings for your load balancer's target group(s).
    */
   healthcheck?: ALBHealthCheck;
   /**
@@ -419,6 +419,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
       privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app }),
       publicSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       waf,
+      healthcheck,
       ec2Props,
       ecsProps,
       targetGroupWeights,
@@ -509,7 +510,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
         protocol: ApplicationProtocol.HTTP,
         targets: [autoScalingGroup],
         port: applicationPort,
-        healthCheck: props.healthcheck,
+        healthCheck: healthcheck,
       });
 
       targetGroups = {
@@ -731,6 +732,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
         app,
         port: applicationPort,
         targets: [ecsService],
+        healthCheck: healthcheck,
       });
 
       targetGroups = {


### PR DESCRIPTION
## What does this change?
This PR fixes a bug in the new `GuLoadBalancedAppExperimental` pattern (added in https://github.com/guardian/cdk/pull/2904). We allow users to specify custom healthcheck settings via a top-level `healthcheck` prop. This PR ensures that any custom settings are applied to EC2 _and_ ECS target groups (previously they were only applied to EC2).

## How to test
I've added new unit tests to cover this.

## How can we measure success?
This will make it easier/less confusing to migrate service which override the default healthcheck settings (e.g. [`dotcom-rendering`](https://github.com/guardian/dotcom-rendering/blob/c8abeb6608b4cbfeff2053ad9989769d32201aa9/dotcom-rendering/cdk/lib/renderingStack.ts#L221)).

## Have we considered potential risks?
I don't think there are any particular risks here. 

Another alternative would have been to nest a `healthcheck` prop under `ec2Props` _and_ `ecsProps` so that users could choose different values depending on the compute type. I don't think there is a known use-case for supporting this level of customisation and it'll increase duplication/the chance of making errors, so I think keeping this at the top-level is appropriate for now.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
