### PR TITLE
feat: Support pulling images across accounts

### DIFF
--- a/.changeset/eager-jeans-wish.md
+++ b/.changeset/eager-jeans-wish.md
@@ -1,0 +1,8 @@
+---
+"@guardian/cdk": minor
+---
+
+Support pulling images across accounts
+
+Currently, we have a central ECR registry in the DeployTools account.
+This change updates how we reference an image, by using the ARN of the registry to support running an ECS service in another account.

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -2680,6 +2680,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
       "Description": "S3 bucket to store your access logs",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "DeployToolsAccountIdParameter": {
+      "Default": "/organisation/accounts/deployTools",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "LoggingStreamName": {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
@@ -2931,7 +2935,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
                 "",
                 [
                   {
-                    "Ref": "AWS::AccountId",
+                    "Ref": "DeployToolsAccountIdParameter",
                   },
                   ".dkr.ecr.eu-west-1.",
                   {
@@ -3113,7 +3117,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
                     },
                     ":ecr:eu-west-1:",
                     {
-                      "Ref": "AWS::AccountId",
+                      "Ref": "DeployToolsAccountIdParameter",
                     },
                     ":repository/guardian/cdk",
                   ],

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -1,4 +1,4 @@
-import { Aspects, Duration, SecretValue, Tags } from "aws-cdk-lib";
+import { ArnFormat, Aspects, Duration, SecretValue, Tags } from "aws-cdk-lib";
 import type { BlockDevice, CfnAutoScalingGroup, UpdatePolicy } from "aws-cdk-lib/aws-autoscaling";
 import { AdditionalHealthCheckType, HealthChecks } from "aws-cdk-lib/aws-autoscaling";
 import {
@@ -580,10 +580,22 @@ export class GuLoadBalancedAppExperimental extends Construct {
 
       const cluster = new Cluster(this, "EcsCluster", { vpc });
 
-      // Need to figure out how to make this cross-account, but this is fine for the simple case where the app and the
-      // ECR repo are both in the Deploy Tools account
       const image = ContainerImage.fromEcrRepository(
-        Repository.fromRepositoryName(scope, "Repo", ecrRepoName),
+        // Images are published to the ECR registry in the DeployTools account, so reference that here
+        Repository.fromRepositoryAttributes(this, "Repo", {
+          repositoryArn: scope.formatArn({
+            account: StringParameter.fromStringParameterName(
+              scope,
+              "DeployToolsAccountId",
+              NAMED_SSM_PARAMETER_PATHS.DeployToolsAccountId.path,
+            ).stringValue,
+            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+            resource: "repository",
+            resourceName: ecrRepoName,
+            service: "ecr",
+          }),
+          repositoryName: ecrRepoName,
+        }),
         imageIdentifier,
       );
 


### PR DESCRIPTION
## What does this change?
Currently, we have a central ECR registry in the DeployTools account. This change updates how we reference an image, by using the ARN of the registry to support running an ECS service in another account.

See also https://aws.amazon.com/blogs/containers/sharing-amazon-ecr-repositories-with-multiple-accounts-using-aws-organizations/.

Requires https://github.com/guardian/riffraff-platform/pull/758.

## How to test
See https://github.com/guardian/cdk-playground/pull/1126.

## How can we measure success?
We're able to run an ECS cluster in another account, referencing an image in the centralised ECR registry.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
