### PR TITLE
fix(GuLoadBalancedAppExperimental): Validate each target group weight individually

### DIFF
--- a/.changeset/shy-pumas-itch.md
+++ b/.changeset/shy-pumas-itch.md
@@ -1,0 +1,17 @@
+---
+"@guardian/cdk": patch
+---
+
+Adjust validation of `targetGroupWeights` property in `GuLoadBalancedAppExperimental`.
+
+Previously, we asserted the sum total weight was 999. From the [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-elasticloadbalancingv2-listener-targetgrouptuple.html), each ALB target group weight must be between 0 and 999.
+From there, AWS will work out the percentage of traffic to send to each target group.
+
+This creates a simpler interface as, for example, to route 1% of traffic to ECS we can:
+
+```ts
+targetGroupWeights: {
+  ecs: 1,
+  ec2: 99
+}
+```

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -144,11 +144,11 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
             imageIdentifier: "sha256:12345",
           },
           targetGroupWeights: {
-            ec2: 999,
+            ec2: 1000, // Outside of limit
             ecs: 1,
           },
         }),
-    ).toThrow("Combined target group weights for EC2 and ECS must be equal to 999");
+    ).toThrow("targetGroupWeights.ec2 must be between 0 and 999");
   });
   it("should throw an error if EC2 and ECS props are both omitted", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -357,8 +357,17 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
     };
   };
   /**
-   * If you are specifying `ec2Props` and `ecsProps` use these weights to distribute traffic across the different compute
-   * types. The weights must sum to 999.
+   * If you are specifying `ec2Props` and `ecsProps` use these weights to distribute traffic across the different compute types.
+   * Each weight must be between 0 and 999. AWS will work out the relative percentage.
+   *
+   * @example - Send 10% of traffic to ECS:
+   *
+   * ```ts
+   * targetGroupWeights: {
+   *   ecs: 1,
+   *   ec2: 9
+   * }
+   * ```
    */
   targetGroupWeights?: {
     ecs: number;
@@ -992,17 +1001,30 @@ function configureListenerActions(
     ec2: number;
   },
 ): ListenerAction {
+  // No ECS target, so forward all traffic to EC2
   if (targetGroups.ec2 && !targetGroups.ecs) {
     return ListenerAction.forward([targetGroups.ec2]);
-  } else if (targetGroups.ecs && !targetGroups.ec2) {
+  }
+
+  // No EC2 target, so forward all traffic to ECS
+  if (targetGroups.ecs && !targetGroups.ec2) {
     return ListenerAction.forward([targetGroups.ecs]);
-  } else if (targetGroups.ec2 && targetGroups.ecs) {
+  }
+
+  if (targetGroups.ec2 && targetGroups.ecs) {
     if (!targetGroupWeights) {
       throw new Error("EC2 and ECS are both enabled but no target group weights were provided");
     }
-    if (targetGroupWeights.ec2 + targetGroupWeights.ecs !== 999) {
-      throw new Error("Combined target group weights for EC2 and ECS must be equal to 999");
+
+    // An individual target can have a weight between 0 and 999. AWS will work out the relative percentage.
+    const isBetween = (n: number, min: number, max: number): boolean => n >= min && n <= max;
+    if (!isBetween(targetGroupWeights.ecs, 0, 999)) {
+      throw new Error("targetGroupWeights.ecs must be between 0 and 999");
     }
+    if (!isBetween(targetGroupWeights.ec2, 0, 999)) {
+      throw new Error("targetGroupWeights.ec2 must be between 0 and 999");
+    }
+
     return ListenerAction.weightedForward([
       { targetGroup: targetGroups.ec2, weight: targetGroupWeights.ec2 },
       { targetGroup: targetGroups.ecs, weight: targetGroupWeights.ecs },


### PR DESCRIPTION
## What does this change?
The [AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-elasticloadbalancingv2-listener-targetgrouptuple.html) and the AWS console suggests each target group weight must be between 0 and 999. Previously we incorrectly asserted the sum total weight was 999. Now we check each weight independently. This format is easier to convert to a percentage too. For example:

```ts
// Route 0.1% of traffic to ECS
targetGroupWeights: {
  ecs: 1,
  ec2: 999
}

// Route 1% of traffic to ECS
targetGroupWeights: {
  ecs: 1,
  ec2: 99
}

// Evenly route traffic
targetGroupWeights: {
  ecs: 1,
  ec2: 1
}
```

## How to test
See updated unit test.

## How can we measure success?
Providing a simpler API.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
