### PR TITLE
feat(GuLoadBalancedAppExperimental): Apply `additionalPolicies` to ECS task role

### DIFF
--- a/.changeset/famous-laws-sneeze.md
+++ b/.changeset/famous-laws-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@guardian/cdk": minor
+---
+
+Apply `additionalPolicies` to ECS task role created for `GuLoadBalancedAppExperimental` so the ECS task role inherits any custom permissions needed to run the application.
+These are already applied to the EC2 instance role.

--- a/.changeset/sweet-chicken-travel.md
+++ b/.changeset/sweet-chicken-travel.md
@@ -1,0 +1,8 @@
+---
+"@guardian/cdk": major
+---
+
+Implement `GuParameterStoreReadPolicy` as a singleton to support `GuLoadBalancedAppExperimental` instantiating it once for the EC2 app and once for the ECS app.
+The result is a single `AWS::IAM::Policy` resource in the CloudFormation template, which is attached to both the EC2 and ECS roles, keeping the diff small.
+
+A [GitHub search](https://github.com/search?q=org%3Aguardian+GuParameterStoreReadPolicy+NOT+repo%3Aguardian%2Fcdk++NOT+is%3Aarchived&type=code) shows `GuParameterStoreReadPolicy` is never directly instantiated by clients.

--- a/.changeset/violet-pigs-rule.md
+++ b/.changeset/violet-pigs-rule.md
@@ -1,0 +1,57 @@
+---
+"@guardian/cdk": major
+---
+
+Removes the `roleConfiguration` property when instantiating a `GuEc2App` or `GuLoadBalancedAppExperimental` in favour of declaring `additionalPolicies` as a top level property.
+As a consequence, it is no longer possible to opt-out of log shipping with `withoutLogShipping`; the IAM Policy will always grant PutRecord to the account's logging Kinesis stream.
+
+To migrate, remove the `roleConfiguration` property and move any policies declared in `roleConfiguration.additionalPolicies` to the top level `additionalPolicies` property:
+
+```ts
+// Before
+new GuEc2App(this, {
+  // other props
+  roleConfiguration: {
+    additionalPolicies: [
+      new GuAllowPolicy(this, 'AllowPolicyCloudwatchLogs', {
+        actions: ['cloudwatch:*', 'logs:*'],
+        resources: ['*'],
+      }),
+      new GuAllowPolicy(
+        this,
+        'AllowPolicyDescribeDecryptKms',
+        {
+          actions: ['kms:Decrypt', 'kms:DescribeKey'],
+          resources: [
+            `arn:aws:kms:${region}:${account}:FrontendConfigKey`,
+          ],
+        },
+      ),
+    ],
+  },
+});
+
+// After
+new GuEc2App(this, {
+  // other props
+  additionalPolicies: [
+    new GuAllowPolicy(this, 'AllowPolicyCloudwatchLogs', {
+      actions: ['cloudwatch:*', 'logs:*'],
+      resources: ['*'],
+    }),
+    new GuAllowPolicy(
+      this,
+      'AllowPolicyDescribeDecryptKms',
+      {
+        actions: ['kms:Decrypt', 'kms:DescribeKey'],
+        resources: [
+          `arn:aws:kms:${region}:${account}:FrontendConfigKey`,
+        ],
+      },
+    ),
+  ],
+});
+```
+
+A [GitHub search](https://github.com/search?q=org%3Aguardian+withoutLogShipping+NOT+repo%3Aguardian%2Fcdk++NOT+is%3Aarchived+NOT+repo%3Aguardian%2Faws-account-setup&type=code)
+shows the `withoutLogShipping` property is never set by clients when instantiating a `GuEc2App` or `GuLoadBalancedAppExperimental`.

--- a/src/constructs/iam/policies/parameter-store-read.test.ts
+++ b/src/constructs/iam/policies/parameter-store-read.test.ts
@@ -2,13 +2,15 @@ import { Template } from "aws-cdk-lib/assertions";
 import { attachPolicyToTestRole, simpleGuStackForTesting } from "../../../utils/test";
 import { GuParameterStoreReadPolicy } from "./parameter-store-read";
 
-describe("ParameterStoreReadPolicy", () => {
-  it("should constrain the policy to the patch of a stack's identity", () => {
+describe("GuParameterStoreReadPolicy", () => {
+  it("should constrain the policy to the path of a stack's identity", () => {
     const stack = simpleGuStackForTesting();
 
-    const policy = new GuParameterStoreReadPolicy(stack, { app: "MyApp" });
+    const policy = GuParameterStoreReadPolicy.getInstance(stack, { app: "MyApp" });
 
     attachPolicyToTestRole(stack, policy);
+
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
 
     Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
       PolicyName: "parameter-store-read-policy",
@@ -58,5 +60,17 @@ describe("ParameterStoreReadPolicy", () => {
         ],
       },
     });
+  });
+
+  it("can be instantiated for multiple apps", () => {
+    const stack = simpleGuStackForTesting();
+
+    const policy1 = GuParameterStoreReadPolicy.getInstance(stack, { app: "MyApp1" });
+    const policy2 = GuParameterStoreReadPolicy.getInstance(stack, { app: "MyApp2" });
+
+    attachPolicyToTestRole(stack, policy1, "MyRole1");
+    attachPolicyToTestRole(stack, policy2, "MyRole2");
+
+    Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 2);
   });
 });

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -38,11 +38,43 @@ export class ReadParametersByName extends PolicyStatement {
  * configuration. See [[`ReadParametersByPath`]] and [[`ReadParametersByName`]] for more details.
  */
 export class GuParameterStoreReadPolicy extends GuAppAwareConstruct(GuPolicy) {
-  constructor(scope: GuStack, props: AppIdentity) {
+  /**
+   * A record of existing instances of this construct, per {@link GuStack}.
+   * This allows us to implement singleton like behaviour.
+   * @private
+   */
+  private static instances: WeakMap<GuStack, Record<string, GuParameterStoreReadPolicy>> = new WeakMap();
+
+  private constructor(scope: GuStack, props: AppIdentity) {
     super(scope, "ParameterStoreRead", {
       policyName: "parameter-store-read-policy",
       statements: [new ReadParametersByPath(scope, props), new ReadParametersByName(scope, props)],
       ...props,
     });
+  }
+
+  public static getInstance(stack: GuStack, props: AppIdentity): GuParameterStoreReadPolicy {
+    const maybeStackInstances = this.instances.get(stack);
+
+    if (!maybeStackInstances) {
+      const instance = new GuParameterStoreReadPolicy(stack, props);
+      this.instances.set(stack, { [props.app]: instance });
+      return instance;
+    }
+
+    const maybeInstance = maybeStackInstances[props.app];
+
+    if (!maybeInstance) {
+      const instance = new GuParameterStoreReadPolicy(stack, props);
+
+      this.instances.set(stack, {
+        ...maybeStackInstances,
+        [props.app]: instance,
+      });
+
+      return instance;
+    }
+
+    return maybeInstance;
   }
 }

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -43,7 +43,7 @@ export class GuParameterStoreReadPolicy extends GuAppAwareConstruct(GuPolicy) {
    * This allows us to implement singleton like behaviour.
    * @private
    */
-  private static instances: WeakMap<GuStack, Record<string, GuParameterStoreReadPolicy>> = new WeakMap();
+  private static instances: Map<GuStack, Map<string, GuParameterStoreReadPolicy>> = new Map();
 
   private constructor(scope: GuStack, props: AppIdentity) {
     super(scope, "ParameterStoreRead", {
@@ -55,23 +55,16 @@ export class GuParameterStoreReadPolicy extends GuAppAwareConstruct(GuPolicy) {
 
   public static getInstance(stack: GuStack, props: AppIdentity): GuParameterStoreReadPolicy {
     const maybeStackInstances = this.instances.get(stack);
-
     if (!maybeStackInstances) {
       const instance = new GuParameterStoreReadPolicy(stack, props);
-      this.instances.set(stack, { [props.app]: instance });
+      this.instances.set(stack, new Map([[props.app, instance]]));
       return instance;
     }
 
-    const maybeInstance = maybeStackInstances[props.app];
-
+    const maybeInstance = maybeStackInstances.get(props.app);
     if (!maybeInstance) {
       const instance = new GuParameterStoreReadPolicy(stack, props);
-
-      this.instances.set(stack, {
-        ...maybeStackInstances,
-        [props.app]: instance,
-      });
-
+      this.instances.set(stack, maybeStackInstances.set(props.app, instance));
       return instance;
     }
 

--- a/src/constructs/iam/roles/instance-role.ts
+++ b/src/constructs/iam/roles/instance-role.ts
@@ -56,7 +56,7 @@ export class GuInstanceRole extends GuAppAwareConstruct(GuRole) {
     const policies = [
       ...sharedPolicies,
       new GuGetDistributablePolicy(scope, props),
-      new GuParameterStoreReadPolicy(scope, props),
+      GuParameterStoreReadPolicy.getInstance(scope, props),
       ...(props.additionalPolicies ?? []),
     ];
 

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -2653,6 +2653,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
       "GuLoadBalancedAppExperimental",
       "GuLoggingStreamNameParameter",
       "GuRiffRaffDeploymentIdParameterExperimental",
+      "GuLogShippingPolicy",
       "GuParameterStoreReadPolicy",
       "GuHttpsEgressSecurityGroup",
       "GuApplicationTargetGroup",
@@ -2747,7 +2748,6 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
     },
     "EcsService81FC6EF6": {
       "DependsOn": [
-        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
         "ListenerTestguCB542308",
       ],
@@ -2826,7 +2826,6 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
     },
     "EcsServiceTaskCountTarget02FCCE22": {
       "DependsOn": [
-        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
       ],
       "Properties": {
@@ -3224,48 +3223,6 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
       },
       "Type": "AWS::IAM::Role",
     },
-    "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":kinesis:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/",
-                    {
-                      "Ref": "LoggingStreamName",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
-        "Roles": [
-          {
-            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "GuHttpsEgressSecurityGroupTestguecs783F2306": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",
@@ -3326,6 +3283,44 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         "ToPort": 3000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "ListenerTestguCB542308": {
       "Properties": {

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -3477,7 +3477,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "ParameterStoreReadTestguecsBA57BA08": {
+    "ParameterStoreReadTestgu2D9B3F35": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -3492,7 +3492,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/test-gu-ecs",
+                    ":parameter/TEST/test-stack/test-gu",
                   ],
                 ],
               },
@@ -3511,7 +3511,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/test-stack/test-gu-ecs/*",
+                    ":parameter/TEST/test-stack/test-gu/*",
                   ],
                 ],
               },

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -732,6 +732,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support all existing 
         domainName: "domain-name-for-your-application.example",
       },
       monitoringConfiguration: { noMonitoring: true },
+      additionalPolicies: [new GuDynamoDBWritePolicy(stack, "DynamoTable", { tableName: "my-dynamo-table" })],
       ec2Props: {
         instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
         scaling: {
@@ -739,10 +740,6 @@ describe("the GuLoadBalancedAppExperimental pattern should support all existing 
         },
         instanceMetricGranularity: "5Minute",
         userData: UserData.forLinux(),
-        roleConfiguration: {
-          withoutLogShipping: true,
-          additionalPolicies: [new GuDynamoDBWritePolicy(stack, "DynamoTable", { tableName: "my-dynamo-table" })],
-        },
       },
     });
 
@@ -1188,37 +1185,6 @@ UserData from accessed construct`);
         { Key: MetadataKeys.SYSTEMD_UNIT, Value: "not-my-app-name.service" },
       ],
     });
-  });
-
-  it("throws an error if users attempt to ship application logs without the appropriate IAM permissions", function () {
-    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
-    const app = "test-gu-ec2-app";
-    expect(() => {
-      new GuLoadBalancedAppExperimental(stack, {
-        applicationPort: 3000,
-        access: { scope: AccessScope.PUBLIC },
-        app,
-        certificateProps: {
-          domainName: "domain-name-for-your-application.example",
-        },
-        monitoringConfiguration: { noMonitoring: true },
-        ec2Props: {
-          instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-          scaling: {
-            minimumInstances: 1,
-          },
-          instanceMetricGranularity: "5Minute",
-          userData: UserData.forLinux(),
-          applicationLogging: { enabled: true },
-          roleConfiguration: {
-            withoutLogShipping: true,
-          },
-        },
-      });
-    }).toThrow(
-      "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-        "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`",
-    );
   });
 
   it("adds a tag to aid visibility of stacks using the pattern", () => {

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -46,7 +46,7 @@ import type { GuStack } from "../../constructs/core";
 import { AppIdentity } from "../../constructs/core";
 import { GuLoggingStreamNameParameter } from "../../constructs/core";
 import { GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
-import type { GuInstanceRoleProps } from "../../constructs/iam";
+import type { GuInstanceRoleProps, GuPolicy } from "../../constructs/iam";
 import { GuInstanceRole } from "../../constructs/iam";
 import { GuGetPrivateConfigPolicy } from "../../constructs/iam";
 import { GuParameterStoreReadPolicy } from "../../constructs/iam";
@@ -204,6 +204,12 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
    * Specify custom healthcheck settings for your load balancer's target group(s).
    */
   healthcheck?: ALBHealthCheck;
+
+  /**
+   * Any additional permissions needed to run the application.
+   */
+  additionalPolicies?: GuPolicy[];
+
   /**
    * You can specify if the arn of this load balancer should be exposed for protection via WAF
    *
@@ -249,10 +255,7 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
      * Enable and configures application logs.
      */
     applicationLogging?: ApplicationLoggingProps;
-    /**
-     * Configure IAM roles for autoscaling group EC2 instances.
-     */
-    roleConfiguration?: GuInstanceRoleProps;
+
     /**
      * Add block devices (additional storage).
      */
@@ -432,6 +435,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
       ec2Props,
       ecsProps,
       targetGroupWeights,
+      additionalPolicies = [],
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
@@ -444,7 +448,6 @@ export class GuLoadBalancedAppExperimental extends Construct {
         applicationLogging = { enabled: false },
         blockDevices,
         instanceType,
-        roleConfiguration = { withoutLogShipping: false, additionalPolicies: [] },
         scaling: { minimumInstances, maximumInstances = minimumInstances * 2 },
         userData: userDataLike,
         imageRecipe,
@@ -455,12 +458,6 @@ export class GuLoadBalancedAppExperimental extends Construct {
         instanceMetricGranularity,
       } = ec2Props;
 
-      if (applicationLogging.enabled && roleConfiguration.withoutLogShipping) {
-        throw new Error(
-          "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-            "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`",
-        );
-      }
       const userData =
         userDataLike instanceof UserData ? userDataLike : new GuUserData(scope, { ...userDataLike, app });
       const maybePrivateConfigPolicy =
@@ -468,8 +465,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
           ? [new GuGetPrivateConfigPolicy(scope, "GetPrivateConfigFromS3Policy", userData.configuration)]
           : [];
       const mergedRoleConfiguration: GuInstanceRoleProps = {
-        withoutLogShipping: roleConfiguration.withoutLogShipping,
-        additionalPolicies: maybePrivateConfigPolicy.concat(roleConfiguration.additionalPolicies ?? []),
+        additionalPolicies: maybePrivateConfigPolicy.concat(additionalPolicies),
       };
 
       if (versionedDeployments?.enabled && updatePolicy) {

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -631,9 +631,19 @@ export class GuLoadBalancedAppExperimental extends Construct {
         readonlyRootFilesystem: true,
       });
 
-      // Grant standard log shipping and config read permissions to the app
-      GuLogShippingPolicy.getInstance(scope).attachToRole(taskDefinition.taskRole);
-      new GuParameterStoreReadPolicy(scope, { app: `${app}-ecs` }).attachToRole(taskDefinition.taskRole);
+      // Permissions passed to the ECS task...
+      const applicationPermissions: GuPolicy[] = [
+        // ...to allow writing logs to Kinesis
+        GuLogShippingPolicy.getInstance(scope),
+
+        // ...to allow reading application config from SSM
+        new GuParameterStoreReadPolicy(scope, { app: `${app}-ecs` }),
+
+        // ...permissions specific for this application (provided by client)
+        ...additionalPolicies,
+      ];
+
+      applicationPermissions.forEach((policy) => policy.attachToRole(taskDefinition.taskRole));
 
       /*
       GuardDuty is enabled at the organisation level and runs as a sidecar.

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -47,6 +47,7 @@ import { AppIdentity } from "../../constructs/core";
 import { GuLoggingStreamNameParameter } from "../../constructs/core";
 import { GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
 import type { GuInstanceRoleProps, GuPolicy } from "../../constructs/iam";
+import { GuLogShippingPolicy } from "../../constructs/iam";
 import { GuInstanceRole } from "../../constructs/iam";
 import { GuGetPrivateConfigPolicy } from "../../constructs/iam";
 import { GuParameterStoreReadPolicy } from "../../constructs/iam";
@@ -631,19 +632,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
       });
 
       // Grant standard log shipping and config read permissions to the app
-      const logShippingPolicy = new PolicyStatement({
-        actions: ["kinesis:Describe*", "kinesis:Put*"],
-        effect: Effect.ALLOW,
-        resources: [
-          scope.formatArn({
-            service: "kinesis",
-            resource: "stream",
-            resourceName: loggingStreamName,
-          }),
-        ],
-      });
-      taskDefinition.addToTaskRolePolicy(logShippingPolicy);
-
+      GuLogShippingPolicy.getInstance(scope).attachToRole(taskDefinition.taskRole);
       new GuParameterStoreReadPolicy(scope, { app: `${app}-ecs` }).attachToRole(taskDefinition.taskRole);
 
       /*

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -637,7 +637,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
         GuLogShippingPolicy.getInstance(scope),
 
         // ...to allow reading application config from SSM
-        new GuParameterStoreReadPolicy(scope, { app: `${app}-ecs` }),
+        GuParameterStoreReadPolicy.getInstance(scope, { app }),
 
         // ...permissions specific for this application (provided by client)
         ...additionalPolicies,

--- a/src/patterns/ec2-app/base.test.ts
+++ b/src/patterns/ec2-app/base.test.ts
@@ -400,10 +400,7 @@ describe("the GuEC2App pattern", function () {
       monitoringConfiguration: { noMonitoring: true },
       instanceMetricGranularity: "5Minute",
       userData: UserData.forLinux(),
-      roleConfiguration: {
-        withoutLogShipping: true,
-        additionalPolicies: [new GuDynamoDBWritePolicy(stack, "DynamoTable", { tableName: "my-dynamo-table" })],
-      },
+      additionalPolicies: [new GuDynamoDBWritePolicy(stack, "DynamoTable", { tableName: "my-dynamo-table" })],
     });
 
     const template = Template.fromStack(stack);
@@ -826,35 +823,6 @@ UserData from accessed construct`);
         { Key: MetadataKeys.SYSTEMD_UNIT, Value: "not-my-app-name.service" },
       ],
     });
-  });
-
-  it("throws an error if users attempt to ship application logs without the appropriate IAM permissions", function () {
-    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
-    const app = "test-gu-ec2-app";
-    expect(() => {
-      new GuEc2App(stack, {
-        applicationPort: 3000,
-        access: { scope: AccessScope.PUBLIC },
-        app,
-        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-        certificateProps: {
-          domainName: "domain-name-for-your-application.example",
-        },
-        scaling: {
-          minimumInstances: 1,
-        },
-        monitoringConfiguration: { noMonitoring: true },
-        instanceMetricGranularity: "5Minute",
-        userData: UserData.forLinux(),
-        applicationLogging: { enabled: true },
-        roleConfiguration: {
-          withoutLogShipping: true,
-        },
-      });
-    }).toThrow(
-      "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-        "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`",
-    );
   });
 
   it("adds a tag to aid visibility of stacks using the pattern", () => {

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -30,7 +30,7 @@ import {
 import type { GuStack } from "../../constructs/core";
 import { AppIdentity, GuLoggingStreamNameParameter } from "../../constructs/core";
 import { GuHttpsEgressSecurityGroup, GuSecurityGroup, GuVpc, SubnetType } from "../../constructs/ec2";
-import type { GuInstanceRoleProps } from "../../constructs/iam";
+import type { GuInstanceRoleProps, GuPolicy } from "../../constructs/iam";
 import { GuGetPrivateConfigPolicy, GuInstanceRole } from "../../constructs/iam";
 import { GuLambdaFunction } from "../../constructs/lambda";
 import {
@@ -126,10 +126,12 @@ export interface GuEc2AppProps extends AppIdentity {
    * The port your application runs on.
    */
   applicationPort: number;
+
   /**
-   * Configure IAM roles for autoscaling group EC2 instances.
+   * Any additional permissions needed to run the application.
    */
-  roleConfiguration?: GuInstanceRoleProps;
+  additionalPolicies?: GuPolicy[];
+
   /**
    * Enable and configure alarms.
    */
@@ -387,7 +389,7 @@ export class GuEc2App extends Construct {
       certificateProps,
       instanceType,
       monitoringConfiguration,
-      roleConfiguration = { withoutLogShipping: false, additionalPolicies: [] },
+      additionalPolicies = [],
       scaling: { minimumInstances, maximumInstances = minimumInstances * 2 },
       userData: userDataLike,
       imageRecipe,
@@ -402,15 +404,6 @@ export class GuEc2App extends Construct {
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
-
-    // We should really prevent users from doing this via the type system,
-    // but that requires a breaking change to the API
-    if (applicationLogging.enabled && roleConfiguration.withoutLogShipping) {
-      throw new Error(
-        "Application logging has been enabled (via the `applicationLogging` prop) but your `roleConfiguration` sets " +
-          "`withoutLogShipping` to true. Please turn off application logging or remove `withoutLogShipping`",
-      );
-    }
 
     const userData = userDataLike instanceof UserData ? userDataLike : new GuUserData(scope, { ...userDataLike, app });
 
@@ -431,8 +424,7 @@ export class GuEc2App extends Construct {
         : [];
 
     const mergedRoleConfiguration: GuInstanceRoleProps = {
-      withoutLogShipping: roleConfiguration.withoutLogShipping,
-      additionalPolicies: maybePrivateConfigPolicy.concat(roleConfiguration.additionalPolicies ?? []),
+      additionalPolicies: maybePrivateConfigPolicy.concat(additionalPolicies),
     };
 
     const autoScalingGroup = new GuAutoScalingGroup(scope, "AutoScalingGroup", {


### PR DESCRIPTION
> [!NOTE]
> Recommended to review [commit by commit](https://github.com/guardian/cdk/pull/2929/commits).

## What does this change?
Updates `GuLoadBalancedAppExperimental` to add the IAM Policies declared in the `additionalPolicies` prop to the ECS task role.

To achieve this, a couple of major changes are needed:
- The `props` interface has changed, removing the `roleConfiguration` object option, placing `additionalPolicies` at the root of the `props` and removing `withoutLogShipping`. As noted, a [GitHub search](https://github.com/search?q=org%3Aguardian+withoutLogShipping+NOT+repo%3Aguardian%2Fcdk++NOT+is%3Aarchived+NOT+repo%3Aguardian%2Faws-account-setup&type=code)
shows the `withoutLogShipping` property is never set by clients when instantiating a `GuEc2App` or `GuLoadBalancedAppExperimental`. That is, I don't expect clients to be directly impacted here.
- The `GuParameterStoreReadPolicy` construct, which provides permissions to read config from SSM Parameter Store, is implemented as a singleton. Previously, the ECS version erroneously changed the `app` path being granted; see also https://github.com/guardian/cdk-playground/pull/1145#pullrequestreview-4598913165. As noted, a [GitHub search](https://github.com/search?q=org%3Aguardian+GuParameterStoreReadPolicy+NOT+repo%3Aguardian%2Fcdk++NOT+is%3Aarchived&type=code) shows `GuParameterStoreReadPolicy` is never directly instantiated by clients. That is, I don't expect clients to be directly impacted here.

## How to test
See updated unit tests.

The snapshot changes are isolated to the ECS resources added in `GuLoadBalancedAppExperimental`. This demonstrates a no-op for all other infrastructure.

## How can we measure success?
The ECS flavour of an application can obtain the necessary AWS permissions to run.

## Have we considered potential risks?
There are breaking changes to the public API. However I think the impact is isolated to one scenario: within the constructor of `GuEc2App` and `GuLoadBalancedAppExperimental`, the `additionalPolicies` are no longer nested under `roleConfiguration`.

### Before

```ts
new GuEc2App(this, {
  // other props
  roleConfiguration: {
    additionalPolicies: [
      new GuAllowPolicy(this, 'AllowPolicyCloudwatchLogs', {
        actions: ['cloudwatch:*', 'logs:*'],
        resources: ['*'],
      }),
      new GuAllowPolicy(
        this,
        'AllowPolicyDescribeDecryptKms',
        {
          actions: ['kms:Decrypt', 'kms:DescribeKey'],
          resources: [
            `arn:aws:kms:${region}:${account}:FrontendConfigKey`,
          ],
        },
      ),
    ],
  },
});
```

### After

```ts
new GuEc2App(this, {
  // other props
  additionalPolicies: [
    new GuAllowPolicy(this, 'AllowPolicyCloudwatchLogs', {
      actions: ['cloudwatch:*', 'logs:*'],
      resources: ['*'],
    }),
    new GuAllowPolicy(
      this,
      'AllowPolicyDescribeDecryptKms',
      {
        actions: ['kms:Decrypt', 'kms:DescribeKey'],
        resources: [
          `arn:aws:kms:${region}:${account}:FrontendConfigKey`,
        ],
      },
    ),
  ],
});
```

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
