### PR TITLE
fix(GuParameterStoreReadPolicy): Remove hard-coded `PolicyName`

### DIFF
--- a/.changeset/plain-colts-jam.md
+++ b/.changeset/plain-colts-jam.md
@@ -1,0 +1,6 @@
+---
+"@guardian/cdk": minor
+---
+
+Update the `GuParameterStoreReadPolicy` construct to remove the hard-coded `PolicyName` property.
+This allows the `GuParameterStoreReadPolicy` singleton to be instantiated multiple times in a single `GuStack` when there are multiple apps.

--- a/src/constructs/iam/policies/parameter-store-read.test.ts
+++ b/src/constructs/iam/policies/parameter-store-read.test.ts
@@ -13,7 +13,6 @@ describe("GuParameterStoreReadPolicy", () => {
     Template.fromStack(stack).resourceCountIs("AWS::IAM::Policy", 1);
 
     Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
-      PolicyName: "parameter-store-read-policy",
       PolicyDocument: {
         Version: "2012-10-17",
         Statement: [

--- a/src/constructs/iam/policies/parameter-store-read.ts
+++ b/src/constructs/iam/policies/parameter-store-read.ts
@@ -47,7 +47,6 @@ export class GuParameterStoreReadPolicy extends GuAppAwareConstruct(GuPolicy) {
 
   private constructor(scope: GuStack, props: AppIdentity) {
     super(scope, "ParameterStoreRead", {
-      policyName: "parameter-store-read-policy",
       statements: [new ReadParametersByPath(scope, props), new ReadParametersByName(scope, props)],
       ...props,
     });

--- a/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
+++ b/src/constructs/iam/roles/__snapshots__/instance-role.test.ts.snap
@@ -192,7 +192,7 @@ exports[`The GuInstanceRole construct should allow additional policies to be spe
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTesting0F3B634A",
         "Roles": [
           {
             "Ref": "InstanceRoleTestingCB7BD146",
@@ -541,7 +541,7 @@ exports[`The GuInstanceRole construct should be possible to create multiple inst
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadMyfirstappE5C5C329",
         "Roles": [
           {
             "Ref": "InstanceRoleMyfirstapp5C11A22B",
@@ -600,7 +600,7 @@ exports[`The GuInstanceRole construct should be possible to create multiple inst
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadMysecondapp76C0E32C",
         "Roles": [
           {
             "Ref": "InstanceRoleMysecondapp48DD15D7",
@@ -871,7 +871,7 @@ exports[`The GuInstanceRole construct should create an additional logging policy
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTesting0F3B634A",
         "Roles": [
           {
             "Ref": "InstanceRoleTestingCB7BD146",
@@ -1090,7 +1090,7 @@ exports[`The GuInstanceRole construct should create the correct resources with m
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTesting0F3B634A",
         "Roles": [
           {
             "Ref": "InstanceRoleTestingCB7BD146",

--- a/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/ec2-app.test.ts.snap
@@ -635,7 +635,7 @@ exports[`The GuEc2AppExperimental pattern matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestguec2app072DCDE1",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguec2appC325BE42",

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -591,7 +591,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support all existing G
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestguec2app072DCDE1",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguec2appC325BE42",
@@ -1463,7 +1463,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support all existing G
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestgu2D9B3F35",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguD5DB5D23",
@@ -2337,7 +2337,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support experimental E
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestgu2D9B3F35",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguD5DB5D23",
@@ -3519,7 +3519,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestgu2D9B3F35",
         "Roles": [
           {
             "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",

--- a/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
+++ b/src/patterns/ec2-app/__snapshots__/base.test.ts.snap
@@ -591,7 +591,7 @@ exports[`the GuEC2App pattern can produce a restricted EC2 app locked to specifi
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestguec2app072DCDE1",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguec2appC325BE42",
@@ -1463,7 +1463,7 @@ exports[`the GuEC2App pattern should produce a functional EC2 app with minimal a
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "parameter-store-read-policy",
+        "PolicyName": "ParameterStoreReadTestguec2app072DCDE1",
         "Roles": [
           {
             "Ref": "InstanceRoleTestguec2appC325BE42",


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/cdk/pull/2929 `GuParameterStoreReadPolicy` became a singleton scoped to an `App`. This change stops hard-coding the `PolicyName` property, reverting to AWS default behaviour. This is because `AWS::IAM::Policy` resources in a CFN stack must have a unique policy name. If a CFN stack has two applications (e.g. `api` and `frontend`) we need two `AWS::IAM::Policy`'s each with their own `PolicyName`.

## How to test
See updated snapshots.

## How can we measure success?
Supporting multiple apps in a single CFN stack. For example https://github.com/guardian/cdk-playground/blob/main/cdk/lib/cdk-playground.ts.

## Have we considered potential risks?
This is a functional no-op, however clients would need to update their snapshots.

## Checklist

- [x] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
