### PR TITLE
Add ability to deterministically route requests to EC2 or ECS

### DIFF
--- a/.changeset/silver-squids-hang.md
+++ b/.changeset/silver-squids-hang.md
@@ -1,0 +1,14 @@
+---
+"@guardian/cdk": minor
+---
+
+Adds deterministic routing rules for EC2 to ECS migrations.
+
+Allow callers to force a request to a specific target group
+using an HTTP header rather than relying on the default weighted routing.
+
+Example usage:
+
+```
+curl -i -H 'X-Gu-Target-Group: ecs' https://cdk-playground.code.dev-gutools.co.uk
+```

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -118,10 +118,6 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         ec2: 499,
         ecs: 500,
       },
-
-      deterministicRouting: {
-        enabled: true,
-      },
     });
 
     Template.fromStack(stack).resourceCountIs("AWS::ElasticLoadBalancingV2::ListenerRule", 2);
@@ -163,35 +159,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
     });
   });
 
-  it("should throw an error if deterministic routing is enabled without both EC2 and ECS target groups", function () {
-    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
-
-    expect(
-      () =>
-        new GuLoadBalancedAppExperimental(stack, {
-          monitoringConfiguration: { noMonitoring: true },
-          applicationPort: 3000,
-          access: { scope: AccessScope.PUBLIC },
-          app: "test-gu",
-          certificateProps: {
-            domainName: "domain-name-for-your-application.example",
-          },
-          ec2Props: {
-            instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-            instanceMetricGranularity: "5Minute",
-            userData: UserData.forLinux(),
-            scaling: {
-              minimumInstances: 1,
-            },
-          },
-          deterministicRouting: {
-            enabled: true,
-          },
-        }),
-    ).toThrow("Deterministic routing requires both EC2 and ECS target groups");
-  });
-
-  it("should keep weighted forwarding as the default action when deterministic routing is enabled", function () {
+  it("should keep weighted forwarding as the default action", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const { targetGroups } = new GuLoadBalancedAppExperimental(stack, {
       monitoringConfiguration: { noMonitoring: true },
@@ -216,9 +184,6 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
       targetGroupWeights: {
         ec2: 499,
         ecs: 500,
-      },
-      deterministicRouting: {
-        enabled: true,
       },
     });
 
@@ -270,7 +235,6 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         ecs: 500,
       },
       deterministicRouting: {
-        enabled: true,
         headerName: "X-Gu-Test",
         ec2HeaderValue: "ec2test",
         ecsHeaderValue: "ecstest",

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -40,6 +40,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });
+
   it("should be capable of splitting traffic between EC2 and ECS target groups", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     const { targetGroups } = new GuLoadBalancedAppExperimental(stack, {
@@ -88,6 +89,219 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
       ],
     });
   });
+
+  it("should create listener rules to deterministically route requests to EC2 or ECS during migration", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const { targetGroups } = new GuLoadBalancedAppExperimental(stack, {
+      monitoringConfiguration: { noMonitoring: true },
+      applicationPort: 3000,
+      access: { scope: AccessScope.PUBLIC },
+      app: "test-gu",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      ec2Props: {
+        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+        instanceMetricGranularity: "5Minute",
+        userData: UserData.forLinux(),
+        scaling: {
+          minimumInstances: 1,
+        },
+      },
+      ecsProps: {
+        cpu: 1024,
+        memoryLimitMiB: 2048,
+        scaling: { minimumTasks: 3, maximumTasks: 6 },
+        imageIdentifier: "sha256:12345",
+      },
+      targetGroupWeights: {
+        ec2: 499,
+        ecs: 500,
+      },
+
+      deterministicRouting: {
+        enabled: true,
+      },
+    });
+
+    Template.fromStack(stack).resourceCountIs("AWS::ElasticLoadBalancingV2::ListenerRule", 2);
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::ListenerRule", {
+      Conditions: Match.arrayWith([
+        Match.objectLike({
+          Field: "http-header",
+          HttpHeaderConfig: {
+            HttpHeaderName: "X-Gu-Target-Group",
+            Values: ["ec2"],
+          },
+        }),
+      ]),
+      Actions: [
+        Match.objectLike({
+          Type: "forward",
+          TargetGroupArn: stack.resolve(targetGroups.ec2!.targetGroupArn) as string,
+        }),
+      ],
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::ListenerRule", {
+      Conditions: Match.arrayWith([
+        Match.objectLike({
+          Field: "http-header",
+          HttpHeaderConfig: {
+            HttpHeaderName: "X-Gu-Target-Group",
+            Values: ["ecs"],
+          },
+        }),
+      ]),
+      Actions: [
+        Match.objectLike({
+          Type: "forward",
+          TargetGroupArn: stack.resolve(targetGroups.ecs!.targetGroupArn) as string,
+        }),
+      ],
+    });
+  });
+
+  it("should throw an error if deterministic routing is enabled without both EC2 and ECS target groups", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    expect(
+      () =>
+        new GuLoadBalancedAppExperimental(stack, {
+          monitoringConfiguration: { noMonitoring: true },
+          applicationPort: 3000,
+          access: { scope: AccessScope.PUBLIC },
+          app: "test-gu",
+          certificateProps: {
+            domainName: "domain-name-for-your-application.example",
+          },
+          ec2Props: {
+            instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+            instanceMetricGranularity: "5Minute",
+            userData: UserData.forLinux(),
+            scaling: {
+              minimumInstances: 1,
+            },
+          },
+          deterministicRouting: {
+            enabled: true,
+          },
+        }),
+    ).toThrow("Deterministic routing requires both EC2 and ECS target groups");
+  });
+
+  it("should keep weighted forwarding as the default action when deterministic routing is enabled", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    const { targetGroups } = new GuLoadBalancedAppExperimental(stack, {
+      monitoringConfiguration: { noMonitoring: true },
+      applicationPort: 3000,
+      access: { scope: AccessScope.PUBLIC },
+      app: "test-gu",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      ec2Props: {
+        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+        instanceMetricGranularity: "5Minute",
+        userData: UserData.forLinux(),
+        scaling: { minimumInstances: 1 },
+      },
+      ecsProps: {
+        cpu: 1024,
+        memoryLimitMiB: 2048,
+        scaling: { minimumTasks: 3, maximumTasks: 6 },
+        imageIdentifier: "sha256:12345",
+      },
+      targetGroupWeights: {
+        ec2: 499,
+        ecs: 500,
+      },
+      deterministicRouting: {
+        enabled: true,
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::Listener", {
+      DefaultActions: [
+        {
+          ForwardConfig: {
+            TargetGroups: [
+              {
+                TargetGroupArn: stack.resolve(targetGroups.ec2!.targetGroupArn) as string,
+                Weight: 499,
+              },
+              {
+                TargetGroupArn: stack.resolve(targetGroups.ecs!.targetGroupArn) as string,
+                Weight: 500,
+              },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("should use custom deterministic routing header and values when configured", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+
+    new GuLoadBalancedAppExperimental(stack, {
+      monitoringConfiguration: { noMonitoring: true },
+      applicationPort: 3000,
+      access: { scope: AccessScope.PUBLIC },
+      app: "test-gu",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      ec2Props: {
+        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
+        instanceMetricGranularity: "5Minute",
+        userData: UserData.forLinux(),
+        scaling: { minimumInstances: 1 },
+      },
+      ecsProps: {
+        cpu: 1024,
+        memoryLimitMiB: 2048,
+        scaling: { minimumTasks: 3, maximumTasks: 6 },
+        imageIdentifier: "sha256:12345",
+      },
+      targetGroupWeights: {
+        ec2: 499,
+        ecs: 500,
+      },
+      deterministicRouting: {
+        enabled: true,
+        headerName: "X-Gu-Test",
+        ec2HeaderValue: "ec2test",
+        ecsHeaderValue: "ecstest",
+      },
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::ListenerRule", {
+      Conditions: Match.arrayWith([
+        Match.objectLike({
+          Field: "http-header",
+          HttpHeaderConfig: {
+            HttpHeaderName: "X-Gu-Test",
+            Values: ["ec2test"],
+          },
+        }),
+      ]),
+    });
+
+    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::ListenerRule", {
+      Conditions: Match.arrayWith([
+        Match.objectLike({
+          Field: "http-header",
+          HttpHeaderConfig: {
+            HttpHeaderName: "X-Gu-Test",
+            Values: ["ecstest"],
+          },
+        }),
+      ]),
+    });
+  });
+
   it("should throw an error if EC2 and ECS are both present but no weights are provided", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(
@@ -117,6 +331,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         }),
     ).toThrow("EC2 and ECS are both enabled but no target group weights were provided");
   });
+
   it("should throw an error if illegal weights are provided", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(
@@ -150,6 +365,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         }),
     ).toThrow("targetGroupWeights.ec2 must be between 0 and 999");
   });
+
   it("should throw an error if EC2 and ECS props are both omitted", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(
@@ -165,6 +381,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         }),
     ).toThrow("At least one of 'ec2Props' or 'ecsProps' must be specified");
   });
+
   it("should use the ECR repo name from ecsProps if the user sets this explicitly", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuLoadBalancedAppExperimental(stack, {
@@ -193,6 +410,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
       ]),
     });
   });
+
   it("should throw an error if we cannot determine the right repository for ECR", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     // Remove the repositoryName
@@ -216,6 +434,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
         }),
     ).toThrow("Could not determine an ECR repository name; please set this manually via ecsProps");
   });
+
   it("allows a custom healthcheck to be used for the ECS target group", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuLoadBalancedAppExperimental(stack, {
@@ -241,6 +460,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
       TargetType: "ip", // This target type helps to confirm that its the ECS target group
     });
   });
+
   it("applies the custom healthcheck settings to both target groups when operating in hybrid mode", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     new GuLoadBalancedAppExperimental(stack, {
@@ -282,6 +502,7 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
       TargetType: "ip", // The ECS target group
     });
   });
+
   // Because this has not been tested thoroughly yet
   it("should throw an error if there is an ECS backend and the Google Auth feature is being used", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -207,65 +207,6 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
     });
   });
 
-  it("should use custom deterministic routing header and values when configured", function () {
-    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
-
-    new GuLoadBalancedAppExperimental(stack, {
-      monitoringConfiguration: { noMonitoring: true },
-      applicationPort: 3000,
-      access: { scope: AccessScope.PUBLIC },
-      app: "test-gu",
-      certificateProps: {
-        domainName: "domain-name-for-your-application.example",
-      },
-      ec2Props: {
-        instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
-        instanceMetricGranularity: "5Minute",
-        userData: UserData.forLinux(),
-        scaling: { minimumInstances: 1 },
-      },
-      ecsProps: {
-        cpu: 1024,
-        memoryLimitMiB: 2048,
-        scaling: { minimumTasks: 3, maximumTasks: 6 },
-        imageIdentifier: "sha256:12345",
-      },
-      targetGroupWeights: {
-        ec2: 499,
-        ecs: 500,
-      },
-      deterministicRouting: {
-        headerName: "X-Gu-Test",
-        ec2HeaderValue: "ec2test",
-        ecsHeaderValue: "ecstest",
-      },
-    });
-
-    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::ListenerRule", {
-      Conditions: Match.arrayWith([
-        Match.objectLike({
-          Field: "http-header",
-          HttpHeaderConfig: {
-            HttpHeaderName: "X-Gu-Test",
-            Values: ["ec2test"],
-          },
-        }),
-      ]),
-    });
-
-    Template.fromStack(stack).hasResourceProperties("AWS::ElasticLoadBalancingV2::ListenerRule", {
-      Conditions: Match.arrayWith([
-        Match.objectLike({
-          Field: "http-header",
-          HttpHeaderConfig: {
-            HttpHeaderName: "X-Gu-Test",
-            Values: ["ecstest"],
-          },
-        }),
-      ]),
-    });
-  });
-
   it("should throw an error if EC2 and ECS are both present but no weights are provided", function () {
     const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
     expect(

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -375,30 +375,6 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
     ecs: number;
     ec2: number;
   };
-  /**
-   *  Adds deterministic routing rules for EC2 to ECS migrations.
-   *
-   * Enable to allow callers to force a request to a specific target group
-   * using an HTTP header rather than relying on the default weighted routing.
-   * Both `ec2Props` and `ecsProps` have to be configured.
-   *
-   */
-  deterministicRouting?: {
-    /**
-     * The HTTP header used to select a target group.
-     * @defaultValue X-Gu-Target-Group
-     */
-    headerName?: string;
-    /**
-     * The header value which routes traffic to EC2.
-     * @defaultValue ec2
-     */
-    ec2HeaderValue?: string;
-    /**
-     * The header value which routes traffic to ECS.
-     * @defaultValue ecs     */
-    ecsHeaderValue?: string;
-  };
 }
 
 interface TargetGroups {
@@ -459,7 +435,6 @@ export class GuLoadBalancedAppExperimental extends Construct {
       ecsProps,
       targetGroupWeights,
       additionalPolicies = [],
-      deterministicRouting,
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
@@ -815,7 +790,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
       open: access.scope === AccessScope.PUBLIC && typeof certificate !== "undefined",
     });
     if (targetGroups.ec2 && targetGroups.ecs) {
-      configureDeterministicRouting(listener, targetGroups.ec2, targetGroups.ecs, deterministicRouting);
+      configureDeterministicRouting(listener, targetGroups.ec2, targetGroups.ecs);
     }
 
     // Since AWS won't create a security group automatically when open=false, we need to add our own
@@ -1055,21 +1030,14 @@ function configureListenerActions(
   }
 }
 
-type DeterministicRoutingConfig = {
-  headerName?: string;
-  ec2HeaderValue?: string;
-  ecsHeaderValue?: string;
-};
-
 function configureDeterministicRouting(
   listener: GuHttpsApplicationListener,
   ec2TargetGroup: GuApplicationTargetGroup,
   ecsTargetGroup: GuApplicationTargetGroup,
-  deterministicRouting?: DeterministicRoutingConfig,
 ): void {
-  const headerName = deterministicRouting?.headerName ?? "X-Gu-Target-Group";
-  const ec2HeaderValue = deterministicRouting?.ec2HeaderValue ?? "ec2";
-  const ecsHeaderValue = deterministicRouting?.ecsHeaderValue ?? "ecs";
+  const headerName = "X-Gu-Target-Group";
+  const ec2HeaderValue = "ec2";
+  const ecsHeaderValue = "ecs";
 
   listener.addAction("DeterministicRouteToEc2", {
     priority: 10,

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -23,8 +23,7 @@ import {
   VersionConsistency,
 } from "aws-cdk-lib/aws-ecs";
 import type { HealthCheck as ALBHealthCheck } from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import { ApplicationProtocol } from "aws-cdk-lib/aws-elasticloadbalancingv2";
-import { ListenerAction } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ApplicationProtocol, ListenerAction, ListenerCondition } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { AuthenticateCognitoAction } from "aws-cdk-lib/aws-elasticloadbalancingv2-actions";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Architecture, Runtime } from "aws-cdk-lib/aws-lambda";
@@ -256,7 +255,6 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
      * Enable and configures application logs.
      */
     applicationLogging?: ApplicationLoggingProps;
-
     /**
      * Add block devices (additional storage).
      */
@@ -377,6 +375,31 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
     ecs: number;
     ec2: number;
   };
+  /**
+   *  Adds deterministic routing rules for EC2 to ECS migrations.
+   *
+   * Enable to allow callers to force a request to a specific target group
+   * using an HTTP header rather than relying on the default weighted routing.
+   * Both `ec2Props` and `ecsProps` have to be configured.
+   *
+   */
+  deterministicRouting?: {
+    enabled: boolean;
+    /**
+     * The HTTP header used to select a target group.
+     * @defaultValue X-Gu-Target-Group
+     */
+    headerName?: string;
+    /**
+     * The header value which routes traffic to EC2.
+     * @defaultValue ec2
+     */
+    ec2HeaderValue?: string;
+    /**
+     * The header value which routes traffic to ECS.
+     * @defaultValue ecs     */
+    ecsHeaderValue?: string;
+  };
 }
 
 interface TargetGroups {
@@ -437,6 +460,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
       ecsProps,
       targetGroupWeights,
       additionalPolicies = [],
+      deterministicRouting,
     } = props;
 
     super(scope, app); // The assumption is `app` is unique
@@ -792,6 +816,8 @@ export class GuLoadBalancedAppExperimental extends Construct {
       open: access.scope === AccessScope.PUBLIC && typeof certificate !== "undefined",
     });
 
+    configureDeterministicRouting(listener, targetGroups, deterministicRouting);
+
     // Since AWS won't create a security group automatically when open=false, we need to add our own
     if (access.scope !== AccessScope.PUBLIC) {
       loadBalancer.addSecurityGroup(
@@ -1027,4 +1053,41 @@ function configureListenerActions(
   } else {
     throw new Error("At least one of 'ec2Props' or 'ecsProps' must be specified");
   }
+}
+
+type DeterministicRoutingConfig = {
+  enabled: boolean;
+  headerName?: string;
+  ec2HeaderValue?: string;
+  ecsHeaderValue?: string;
+};
+
+function configureDeterministicRouting(
+  listener: GuHttpsApplicationListener,
+  targetGroups: TargetGroups,
+  deterministicRouting?: DeterministicRoutingConfig,
+): void {
+  if (!deterministicRouting?.enabled) {
+    return;
+  }
+
+  if (!targetGroups.ec2 || !targetGroups.ecs) {
+    throw new Error("Deterministic routing requires both EC2 and ECS target groups");
+  }
+
+  const headerName = deterministicRouting.headerName ?? "X-Gu-Target-Group";
+  const ec2HeaderValue = deterministicRouting.ec2HeaderValue ?? "ec2";
+  const ecsHeaderValue = deterministicRouting.ecsHeaderValue ?? "ecs";
+
+  listener.addAction("DeterministicRouteToEc2", {
+    priority: 10,
+    conditions: [ListenerCondition.httpHeader(headerName, [ec2HeaderValue])],
+    action: ListenerAction.forward([targetGroups.ec2]),
+  });
+
+  listener.addAction("DeterministicRouteToEcs", {
+    priority: 11,
+    conditions: [ListenerCondition.httpHeader(headerName, [ecsHeaderValue])],
+    action: ListenerAction.forward([targetGroups.ecs]),
+  });
 }

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -384,7 +384,6 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
    *
    */
   deterministicRouting?: {
-    enabled: boolean;
     /**
      * The HTTP header used to select a target group.
      * @defaultValue X-Gu-Target-Group
@@ -815,8 +814,9 @@ export class GuLoadBalancedAppExperimental extends Construct {
       // When open=true, AWS will create a security group which allows all inbound traffic over HTTPS
       open: access.scope === AccessScope.PUBLIC && typeof certificate !== "undefined",
     });
-
-    configureDeterministicRouting(listener, targetGroups, deterministicRouting);
+    if (targetGroups.ec2 && targetGroups.ecs) {
+      configureDeterministicRouting(listener, targetGroups.ec2, targetGroups.ecs, deterministicRouting);
+    }
 
     // Since AWS won't create a security group automatically when open=false, we need to add our own
     if (access.scope !== AccessScope.PUBLIC) {
@@ -1056,7 +1056,6 @@ function configureListenerActions(
 }
 
 type DeterministicRoutingConfig = {
-  enabled: boolean;
   headerName?: string;
   ec2HeaderValue?: string;
   ecsHeaderValue?: string;
@@ -1064,30 +1063,23 @@ type DeterministicRoutingConfig = {
 
 function configureDeterministicRouting(
   listener: GuHttpsApplicationListener,
-  targetGroups: TargetGroups,
+  ec2TargetGroup: GuApplicationTargetGroup,
+  ecsTargetGroup: GuApplicationTargetGroup,
   deterministicRouting?: DeterministicRoutingConfig,
 ): void {
-  if (!deterministicRouting?.enabled) {
-    return;
-  }
-
-  if (!targetGroups.ec2 || !targetGroups.ecs) {
-    throw new Error("Deterministic routing requires both EC2 and ECS target groups");
-  }
-
-  const headerName = deterministicRouting.headerName ?? "X-Gu-Target-Group";
-  const ec2HeaderValue = deterministicRouting.ec2HeaderValue ?? "ec2";
-  const ecsHeaderValue = deterministicRouting.ecsHeaderValue ?? "ecs";
+  const headerName = deterministicRouting?.headerName ?? "X-Gu-Target-Group";
+  const ec2HeaderValue = deterministicRouting?.ec2HeaderValue ?? "ec2";
+  const ecsHeaderValue = deterministicRouting?.ecsHeaderValue ?? "ecs";
 
   listener.addAction("DeterministicRouteToEc2", {
     priority: 10,
     conditions: [ListenerCondition.httpHeader(headerName, [ec2HeaderValue])],
-    action: ListenerAction.forward([targetGroups.ec2]),
+    action: ListenerAction.forward([ec2TargetGroup]),
   });
 
   listener.addAction("DeterministicRouteToEcs", {
     priority: 11,
     conditions: [ListenerCondition.httpHeader(headerName, [ecsHeaderValue])],
-    action: ListenerAction.forward([targetGroups.ecs]),
+    action: ListenerAction.forward([ecsTargetGroup]),
   });
 }


### PR DESCRIPTION
## What does this change?
This PR adds deterministic request routing support to GuLoadBalancedAppExperimental to allow easier testing during EC2 to ECS migration.

When both ec2Props and ecsProps are configured, users can now optionally add listener rules that force traffic to one target group based on request headers, while preserving existing weighted routing as the default behaviour.

The existing weighted default action remains unchanged.

## Why are we introducing this change
During a migration the GuLoadBalancedAppExperimental [pattern](https://github.com/guardian/cdk/blob/main/src/experimental/patterns/gu-load-balanced-app.ts) will route requests to an EC2 or ECS target group based on specified ['weights'](https://github.com/guardian/cdk/blob/1b239d551c2657a2d27e13fe9f40fa2a3d545555/src/experimental/patterns/gu-load-balanced-app.ts#L359-L366). Therefore clients/users cannot at the moment deterministically send their request to a specific target group and it is often difficult to be sure whether a response has been served by EC2 or ECS during testing.

## How to test
Use https://github.com/guardian/cdk-playground/pull/1161
which has deterministic routing enabled

curl -i -H 'X-Gu-Target-Group: ec2' https://cdk-playground.code.dev-gutools.co.uk
curl -i -H 'X-Gu-Target-Group: ecs' https://cdk-playground.code.dev-gutools.co.uk
curl -i -H https://cdk-playground.code.dev-gutools.co.uk

Test: See "backend":"ecs" or "backend":"ec2" in json output to verify
```
36824_mac:cdk julia_branke$ curl -i -H 'X-Gu-Target-Group: ec2' https://cdk-playground.code.dev-gutools.co.uk
HTTP/2 200 
date: Wed, 08 Jul 2026 12:34:23 GMT
content-type: application/json
content-length: 284
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
x-frame-options: DENY
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-permitted-cross-domain-policies: master-only

{"name":"cdk-playground","buildTime":"2026-07-08T11:23:35Z","branch":"jb/test-route-deterministically-to-ecs-or-ec2","gitCommitId":"50dd9a91da3e2ad3e54f376f994fb3b1ebf51acc","scalaVersion":"2.13.18","version":"1.0-SNAPSHOT","sbtVersion":"1.12.13","buildNumber":"2520","backend":"ec2"}36824_mac:cdk julia_branke$ 
36824_mac:cdk julia_branke$ curl -i -H 'X-Gu-Target-Group: ecs' https://cdk-playground.code.dev-gutools.co.uk
HTTP/2 200 
date: Wed, 08 Jul 2026 12:34:27 GMT
content-type: application/json
content-length: 284
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
x-frame-options: DENY
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-permitted-cross-domain-policies: master-only

{"name":"cdk-playground","buildTime":"2026-07-08T11:23:35Z","branch":"jb/test-route-deterministically-to-ecs-or-ec2","gitCommitId":"50dd9a91da3e2ad3e54f376f994fb3b1ebf51acc","scalaVersion":"2.13.18","version":"1.0-SNAPSHOT","sbtVersion":"1.12.13","buildNumber":"2520","backend":"ecs"}36824_mac:cdk julia_branke$ 
36824_mac:cdk julia_branke$ curl -i https://cdk-playground.code.dev-gutools.co.uk
HTTP/2 200 
date: Wed, 08 Jul 2026 12:34:31 GMT
content-type: application/json
content-length: 284
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
x-frame-options: DENY
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-permitted-cross-domain-policies: master-only

{"name":"cdk-playground","buildTime":"2026-07-08T11:23:35Z","branch":"jb/test-route-deterministically-to-ecs-or-ec2","gitCommitId":"50dd9a91da3e2ad3e54f376f994fb3b1ebf51acc","scalaVersion":"2.13.18","version":"1.0-SNAPSHOT","sbtVersion":"1.12.13","buildNumber":"2520","backend":"ec2"}36824_mac:cdk julia_branke$ 
36824_mac:cdk julia_branke$ curl -i https://cdk-playground.code.dev-gutools.co.uk
HTTP/2 200 
date: Wed, 08 Jul 2026 12:34:34 GMT
content-type: application/json
content-length: 284
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
x-frame-options: DENY
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-permitted-cross-domain-policies: master-only

{"name":"cdk-playground","buildTime":"2026-07-08T11:23:35Z","branch":"jb/test-route-deterministically-to-ecs-or-ec2","gitCommitId":"50dd9a91da3e2ad3e54f376f994fb3b1ebf51acc","scalaVersion":"2.13.18","version":"1.0-SNAPSHOT","sbtVersion":"1.12.13","buildNumber":"2520","backend":"ecs"}36824_mac:cdk julia_branke$ 
36824_mac:cdk julia_branke$ curl -i https://cdk-playground.code.dev-gutools.co.uk
HTTP/2 200 
date: Wed, 08 Jul 2026 12:34:42 GMT
content-type: application/json
content-length: 284
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
x-frame-options: DENY
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
x-permitted-cross-domain-policies: master-only

{"name":"cdk-playground","buildTime":"2026-07-08T11:23:35Z","branch":"jb/test-route-deterministically-to-ecs-or-ec2","gitCommitId":"50dd9a91da3e2ad3e54f376f994fb3b1ebf51acc","scalaVersion":"2.13.18","version":"1.0-SNAPSHOT","sbtVersion":"1.12.13","buildNumber":"2520","backend":"ecs"}36824_mac:cdk julia_branke$ 

```

## How can we measure success?
- There should be no behaviour change unless deterministicRouting.enabled is set.
- Existing EC2-only, ECS-only, and weighted hybrid behaviour remains as before.
- Deterministic routing does succeed if enabled

## Have we considered potential risks?
In PROD we might want to protect the deterministic routing option with a token

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215431700752924