### PR TITLE
feat: Enable ECS "SSH"

### DIFF
--- a/.changeset/four-bananas-speak.md
+++ b/.changeset/four-bananas-speak.md
@@ -1,0 +1,11 @@
+---
+"@guardian/cdk": minor
+---
+
+Update `GuLoadBalancedAppExperimental` with an option to enable "ssh" onto the application container.
+See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec-run.html.
+
+Capabilities in the container is dictated by the image.
+For example, if the image doesn't have `curl` available, you won't be able to `curl localhost:9000`.
+
+NOTE: When enabled, FSBP ECS.5 is actively violated.

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -2772,6 +2772,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
           "Type": "ECS",
         },
         "EnableECSManagedTags": false,
+        "EnableExecuteCommand": false,
         "HealthCheckGracePeriodSeconds": 60,
         "LaunchType": "FARGATE",
         "LoadBalancers": [

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -11,6 +11,7 @@ import type { InstanceType, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { UserData } from "aws-cdk-lib/aws-ec2";
 import { Repository } from "aws-cdk-lib/aws-ecr";
 import type { Volume } from "aws-cdk-lib/aws-ecs";
+import { LinuxParameters } from "aws-cdk-lib/aws-ecs";
 import { PropagatedTagSource } from "aws-cdk-lib/aws-ecs";
 import {
   Cluster,
@@ -357,6 +358,20 @@ export interface GuLoadBalancedAppExperimentalProps extends AppIdentity {
        */
       maximumTasks: number;
     };
+
+    /**
+     * Whether to enable "ssh" to the container via AWS ECS Exec.
+     *
+     * When enabled, FSBP ECS.5 is actively violated.
+     * Capabilities in the container is dictated by the image.
+     * For example, if the image doesn't have `curl` available, you won't be able to `curl localhost:9000`.
+     *
+     * @default false
+     *
+     * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec-run.html
+     * @see https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-5
+     */
+    enableExecuteCommand?: boolean;
   };
   /**
    * If you are specifying `ec2Props` and `ecsProps` use these weights to distribute traffic across the different compute types.
@@ -577,7 +592,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
 
     // Setup ECS-specific infrastructure
     if (ecsProps) {
-      const { cpu, memoryLimitMiB, imageIdentifier, scaling } = ecsProps;
+      const { cpu, memoryLimitMiB, imageIdentifier, scaling, enableExecuteCommand = false } = ecsProps;
 
       const ecrRepoName = ecsProps.repositoryName ?? scope.repositoryName;
       if (!ecrRepoName) {
@@ -642,6 +657,15 @@ export class GuLoadBalancedAppExperimental extends Construct {
         logging: fireLensLogDriver,
         readonlyRootFilesystem: true,
         environment,
+        ...(enableExecuteCommand
+          ? {
+              linuxParameters: new LinuxParameters(scope, `${app}-linux-parameters`, { initProcessEnabled: true }),
+
+              // This violates FSBP ECS.5, but is needed for this feature
+              // See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-considerations
+              readonlyRootFilesystem: false,
+            }
+          : {}),
       });
 
       // Permissions passed to the ECS task...
@@ -700,6 +724,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
             vpc,
           }),
         ],
+        enableExecuteCommand,
       });
 
       ecsService.autoScaleTaskCount({


### PR DESCRIPTION
## What does this change?
This change enables [AWS ECS Exec](ttps://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec-run.html) to enable "ssh" to the running container. Once connected to a container, there's a limited number of things we can do. For example, if the image doesn't have `curl` then we won't be able to `curl` an endpoint without first installing it.

The change follows the requirements listed on https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-considerations. Specifically, it sets `readonlyRootFilesystem` to `false`, which is a direct violation of [FSBP ECS.5](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-5).

## How to test
See https://github.com/guardian/cdk-playground/pull/1171.

## How can we measure success?
We're able to "ssh" to a running container.

## Have we considered potential risks?
When enabled, the ECS cluster would actively violate FSBP EC2.5 and CloudBuster would alert us to this, for example:

<img width="696" height="307" alt="image" src="https://github.com/user-attachments/assets/8f71a2be-3790-49d9-b612-d3d0ac3bb33f" />

For this reason, I don't think this should ever be enabled on PROD.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
