### PR TITLE
fix(cli): make generated projects pass their own lint check

### DIFF
--- a/.changeset/fix-new-project-lint.md
+++ b/.changeset/fix-new-project-lint.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": patch
+---
+
+Fix `new` command so generated projects pass their own lint check. The `eslint --fix` step passed `"lib/** bin/**"` as a single argument to `spawn` (with `shell: false`), so the globs never matched and no autofix ran. The globs are now passed as separate arguments. Additionally, generated import statements now place Node built-in modules (e.g. `path`) before third-party imports to satisfy the `import/order` rule.

--- a/src/bin/commands/new-project/index.ts
+++ b/src/bin/commands/new-project/index.ts
@@ -143,8 +143,10 @@ export const newCdkProject = async (props: NewProjectProps): CliCommandResponse 
     console.log(chalk.green("  ✅ Successfully installed dependencies"));
   }
 
-  // Run `eslint --fix` on the generated files instead of trying to generate code that completely satisfies the linter
-  await execute("./node_modules/.bin/eslint", ["lib/** bin/**", "--no-error-on-unmatched-pattern", "--fix"], {
+  // Run `eslint --fix` on the generated files instead of trying to generate code that completely satisfies the linter.
+  // Each glob must be a separate argument: `execute` uses `spawn` with `shell: false`, so a single
+  // "lib/** bin/**" string would be treated as one (non-matching) pattern and silently fixed nothing.
+  await execute("./node_modules/.bin/eslint", ["lib/**", "bin/**", "--no-error-on-unmatched-pattern", "--fix"], {
     cwd: config.cdkDir,
   });
 

--- a/src/bin/commands/new-project/utils/imports.ts
+++ b/src/bin/commands/new-project/utils/imports.ts
@@ -1,3 +1,4 @@
+import { isBuiltin } from "node:module";
 import type { CodeMaker } from "codemaker";
 import type { Name } from "./utils";
 
@@ -75,11 +76,16 @@ export class Imports {
   render(code: CodeMaker): void {
     Object.entries(this.imports)
       // Render "basic" imports before any others, still in alphabetical order
+      // Render Node built-in imports before third-party imports (to satisfy `import/order`)
       // Render relative imports after absolute imports
       .sort(([aKey, aImports], [bKey, bImports]) => {
         if (aImports.basic && !bImports.basic) {
           return -1;
         } else if (bImports.basic && !aImports.basic) {
+          return 1;
+        } else if (isBuiltin(aKey) && !isBuiltin(bKey)) {
+          return -1;
+        } else if (isBuiltin(bKey) && !isBuiltin(aKey)) {
           return 1;
         } else if (aKey.startsWith(".") && !bKey.startsWith(".")) {
           return 1;


### PR DESCRIPTION
## What does this change?

_AI assisted change and PR description, but I fully understand the autofix step, and have a high level understanding of the import/order by construction fix_
 
Fixes the `@guardian/cdk new` CLI command so that projects it generates pass their own lint check without manual intervention.

There were two related defects:

### The `eslint --fix` autofix step was a silent no-op

After scaffolding, the generator runs `eslint --fix` on the generated files *before* the lint check, with the comment "Run `eslint --fix` on the generated files instead of trying to generate code that completely satisfies the linter". However, it passed `"lib/** bin/**"` as a **single** argument to `execute`, which uses `spawn` with `shell: false`. With no shell to split it, ESLint received one literal pattern that matched nothing — and because `--no-error-on-unmatched-pattern` is set, it exited cleanly having fixed nothing. The subsequent `npm run lint` (`eslint lib/** bin/**`) *is* run through a shell, so the globs expanded and the lint error surfaced, failing the command. The globs are now passed as separate arguments (`["lib/**", "bin/**", ...]`).

### Generated imports violated `import/order` by construction

When using `--yaml-template-location`, the generated stack file imported the Node built-in `path` *after* third-party imports, because the `Imports.render()` comparator sorted purely alphabetically. `@guardian/eslint-config`'s `import/order` requires built-ins first. The comparator now sorts Node built-ins (detected via `isBuiltin` from `node:module`) ahead of third-party imports, so the output is correct by construction. Fix (1) alone would have masked this via autofix, but fixing both means the generated code is right the first time.

Fix (1) is the higher-value change: it restores the intended autofix safety net, so *future* drift between the generator's output and the lint config will be corrected automatically rather than breaking `new`.

## How to test

Before this branch (on `main`), running the generator against a YAML template fails at the lint step:

```sh
mkdir -p /tmp/repro && cd /tmp/repro && git init
mkdir cloudformation && printf 'AWSTemplateFormatVersion: "2010-09-09"\nResources:\n  Bucket:\n    Type: AWS::S3::Bucket\n' > cloudformation/test.cfn.yaml
npx @guardian/cdk new --app testapp --stack teststack --stage PROD --package-manager npm --yaml-template-location cloudformation/test.cfn.yaml
# ⇒ fails: "`path` import should occur before ... (import/order)"
```

On this branch, run the local CLI (`ts-node src/bin/index.ts new ...`) against the same repo. It now proceeds through the lint check, tests, and synth with no errors, and the generated `lib/testapp.ts` begins with `import { join } from "path";`. Verified end-to-end locally; `npm run lint` on `src` also passes.

## How can we measure success?

Fewer failed/aborted `@guardian/cdk new` runs and fewer "the generated project doesn't lint" reports from teams starting a migration. 

## Have we considered potential risks?

Low risk. Changes are confined to the `new-project` code generator; no runtime constructs or synthesised infrastructure are affected. The import-ordering change only alters the order of generated `import` lines. 

## Checklist

- [x] I have listed any breaking changes, along with a migration path — none; this is a bug fix to generator output only.
- [x] I have updated the documentation as required for the described changes — no docs affected; a patch changeset is included.