### PR TITLE
Add log link to alarms

### DIFF
--- a/.changeset/crisp-terms-cut.md
+++ b/.changeset/crisp-terms-cut.md
@@ -1,0 +1,7 @@
+---
+"@guardian/cdk": patch
+---
+
+Add log link to alarms: Zero or more links can be appended to an alarm description.  
+
+The most trivial approach simply requires the name of a space in the ELK logs, and a full link will be generated for you.

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -4,7 +4,7 @@ import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { simpleGuStackForTesting } from "../../utils/test";
 import type { GuStack } from "../core";
 import { GuLambdaFunction } from "../lambda";
-import { GuAlarm } from "./alarm";
+import { GuAlarm, GuAlarmCta } from "./alarm";
 
 describe("The GuAlarm class", () => {
   const lambda = (stack: GuStack) =>
@@ -91,5 +91,32 @@ describe("The GuAlarm class", () => {
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
       OKActions: snsActionsCFN,
     });
+  });
+
+  it("should generate the correct log link from an elk space", () => {
+    const scope = simpleGuStackForTesting({ app: "myapp" });
+    const testLink = new GuAlarmCta(scope, {
+      elkSpace: "aaa",
+    }).ctaLinks;
+    expect(testLink).toEqual([
+      "https://logs.gutools.co.uk/s/aaa/app/discover#/?" +
+        "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))" +
+        "&" +
+        "_a=(" +
+        "columns:!(stack,stage,message,app)," +
+        "filters:!(" +
+        "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack)))," +
+        "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:myapp),type:phrase),query:(match_phrase:(app.keyword:myapp)))," +
+        "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST))))," +
+        "hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+    ]);
+  });
+
+  it("should generate the correct log link from a link", () => {
+    const scope = simpleGuStackForTesting();
+    const testLink = new GuAlarmCta(scope, {
+      link: "https://www.example.com",
+    }).ctaLinks;
+    expect(testLink).toEqual(["https://www.example.com"]);
   });
 });

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -95,28 +95,26 @@ describe("The GuAlarm class", () => {
 
   it("should generate the correct log link from an elk space", () => {
     const scope = simpleGuStackForTesting({ app: "myapp" });
-    const testLink = new GuAlarmCta(scope, {
-      elkSpace: "aaa",
-    }).ctaLinks;
-    expect(testLink).toEqual([
-      "https://logs.gutools.co.uk/s/aaa/app/discover#/?" +
-        "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))" +
-        "&" +
-        "_a=(" +
-        "columns:!(stack,stage,message,app)," +
-        "filters:!(" +
-        "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack)))," +
-        "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:myapp),type:phrase),query:(match_phrase:(app.keyword:myapp)))," +
-        "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST))))," +
-        "hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
-    ]);
+    const cta = new GuAlarmCta(scope, { elkSpace: "aaa" });
+
+    const expectedLink = "https://logs.gutools.co.uk/s/aaa/app/discover#/?" +
+      "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))" +
+      "&" +
+      "_a=(" +
+      "columns:!(stack,stage,message,app)," +
+      "filters:!(" +
+      "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack)))," +
+      "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:myapp),type:phrase),query:(match_phrase:(app.keyword:myapp)))," +
+      "('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST))))," +
+      "hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))";
+    expect(cta.ctaLinks).toEqual([expectedLink]);
+    expect(cta.markdown).toEqual(`---\n[logs](${expectedLink})`);
   });
 
   it("should generate the correct log link from a link", () => {
     const scope = simpleGuStackForTesting();
-    const testLink = new GuAlarmCta(scope, {
-      link: "https://www.example.com",
-    }).ctaLinks;
-    expect(testLink).toEqual(["https://www.example.com"]);
+    const cta = new GuAlarmCta(scope, { link: "https://www.example.com" });
+    expect(cta.ctaLinks).toEqual(["https://www.example.com"]);
+    expect(cta.markdown).toEqual("---\n[link](https://www.example.com)");
   });
 });

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -112,10 +112,10 @@ describe("The GuAlarm class", () => {
     expect(cta.markdown).toEqual(`---\n[logs](${expectedLink})`);
   });
 
-  it("should generate the correct log link from a link", () => {
+  it("should generate the correct log link from a runbook", () => {
     const scope = simpleGuStackForTesting();
-    const cta = new GuAlarmCta(scope, { link: "https://www.example.com" });
+    const cta = new GuAlarmCta(scope, { runbook: "https://www.example.com" });
     expect(cta.ctaLinks).toEqual(["https://www.example.com"]);
-    expect(cta.markdown).toEqual("---\n[link](https://www.example.com)");
+    expect(cta.markdown).toEqual("---\n[runbook](https://www.example.com)");
   });
 });

--- a/src/constructs/cloudwatch/alarm.test.ts
+++ b/src/constructs/cloudwatch/alarm.test.ts
@@ -97,7 +97,8 @@ describe("The GuAlarm class", () => {
     const scope = simpleGuStackForTesting({ app: "myapp" });
     const cta = new GuAlarmCta(scope, { elkSpace: "aaa" });
 
-    const expectedLink = "https://logs.gutools.co.uk/s/aaa/app/discover#/?" +
+    const expectedLink =
+      "https://logs.gutools.co.uk/s/aaa/app/discover#/?" +
       "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))" +
       "&" +
       "_a=(" +

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -1,13 +1,19 @@
-import { Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import type { AlarmProps } from "aws-cdk-lib/aws-cloudwatch";
+import { Alarm } from "aws-cdk-lib/aws-cloudwatch";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
-import { Topic } from "aws-cdk-lib/aws-sns";
 import type { ITopic } from "aws-cdk-lib/aws-sns";
+import { Topic } from "aws-cdk-lib/aws-sns";
 import type { AppIdentity, GuStack } from "../core";
 
 export interface GuAlarmProps extends AlarmProps, AppIdentity {
   snsTopicName: string;
   okAction?: boolean;
+  cta?: GuAlarmCtaProps;
+}
+
+export interface GuAlarmCtaProps {
+  link?: string;
+  elkSpace?: string;
 }
 
 export interface Http4xxAlarmProps extends Omit<
@@ -24,6 +30,29 @@ export interface Http5xxAlarmProps extends Omit<
 > {
   tolerated5xxPercentage: number;
   numberOfMinutesAboveThresholdBeforeAlarm?: number;
+}
+
+export class GuAlarmCta {
+  ctaLinks: string[];
+  constructor(scope: GuStack, props: GuAlarmCtaProps) {
+    const providedLink = props.link ? [props.link] : [];
+    const generatedLink =
+      props.elkSpace && scope.app
+        ? [
+            [
+              `https://logs.gutools.co.uk/s/${props.elkSpace}/app/discover#/?`,
+              "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))",
+              "&",
+              "_a=(columns:!(stack,stage,message,app),filters:!(",
+              `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:${scope.stack}),type:phrase),query:(match_phrase:(stack.keyword:${scope.stack}))),`,
+              `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:${scope.app}),type:phrase),query:(match_phrase:(app.keyword:${scope.app}))),`,
+              `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:${scope.stage}),type:phrase),query:(match_phrase:(stage.keyword:${scope.stage}))))`,
+              ",hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+            ].join(""),
+          ]
+        : [];
+    this.ctaLinks = [...providedLink, ...generatedLink];
+  }
 }
 
 /**

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -12,7 +12,7 @@ export interface GuAlarmProps extends AlarmProps, AppIdentity {
 }
 
 export interface GuAlarmCtaProps {
-  link?: string;
+  runbook?: string;
   elkSpace?: string;
 }
 
@@ -36,7 +36,7 @@ export class GuAlarmCta {
   ctaLinks: string[];
   markdown: string;
   constructor(scope: GuStack, props: GuAlarmCtaProps) {
-    const providedLink = props.link;
+    const providedRunbook = props.runbook;
     const generatedLink =
       props.elkSpace && scope.app
         ? [
@@ -50,10 +50,10 @@ export class GuAlarmCta {
             ",hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
           ].join("")
         : undefined;
-    this.ctaLinks = [providedLink, generatedLink].filter((link): link is string => !!link);
+    this.ctaLinks = [providedRunbook, generatedLink].filter((link): link is string => !!link);
 
     const markdownLinks = [
-      providedLink ? `[link](${providedLink})` : undefined,
+      providedRunbook ? `[runbook](${providedRunbook})` : undefined,
       generatedLink ? `[logs](${generatedLink})` : undefined,
     ].filter((link): link is string => !!link);
     this.markdown = markdownLinks.length > 0 ? ["---", ...markdownLinks].join("\n") : "";

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -34,24 +34,29 @@ export interface Http5xxAlarmProps extends Omit<
 
 export class GuAlarmCta {
   ctaLinks: string[];
+  markdown: string;
   constructor(scope: GuStack, props: GuAlarmCtaProps) {
-    const providedLink = props.link ? [props.link] : [];
+    const providedLink = props.link;
     const generatedLink =
       props.elkSpace && scope.app
         ? [
-            [
-              `https://logs.gutools.co.uk/s/${props.elkSpace}/app/discover#/?`,
-              "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))",
-              "&",
-              "_a=(columns:!(stack,stage,message,app),filters:!(",
-              `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:${scope.stack}),type:phrase),query:(match_phrase:(stack.keyword:${scope.stack}))),`,
-              `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:${scope.app}),type:phrase),query:(match_phrase:(app.keyword:${scope.app}))),`,
-              `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:${scope.stage}),type:phrase),query:(match_phrase:(stage.keyword:${scope.stage}))))`,
-              ",hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
-            ].join(""),
-          ]
-        : [];
-    this.ctaLinks = [...providedLink, ...generatedLink];
+            `https://logs.gutools.co.uk/s/${props.elkSpace}/app/discover#/?`,
+            "_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))",
+            "&",
+            "_a=(columns:!(stack,stage,message,app),filters:!(",
+            `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:${scope.stack}),type:phrase),query:(match_phrase:(stack.keyword:${scope.stack}))),`,
+            `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:${scope.app}),type:phrase),query:(match_phrase:(app.keyword:${scope.app}))),`,
+            `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:${scope.stage}),type:phrase),query:(match_phrase:(stage.keyword:${scope.stage}))))`,
+            ",hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+          ].join("")
+        : undefined;
+    this.ctaLinks = [providedLink, generatedLink].filter((link): link is string => !!link);
+
+    const markdownLinks = [
+      providedLink ? `[link](${providedLink})` : undefined,
+      generatedLink ? `[logs](${generatedLink})` : undefined,
+    ].filter((link): link is string => !!link);
+    this.markdown = markdownLinks.length > 0 ? ["---", ...markdownLinks].join("\n") : "";
   }
 }
 

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -80,11 +80,16 @@ export class GuAlarm extends Alarm {
   constructor(scope: GuStack, id: string, props: GuAlarmProps) {
     const { region, account } = scope;
     const { snsTopicName, actionsEnabled = true, okAction } = props;
+    const alarmCta: GuAlarmCta | undefined = props.cta && new GuAlarmCta(scope, props.cta);
+    const alarmDescription = [props.alarmDescription, alarmCta?.markdown]
+      .filter((line): line is string => !!line)
+      .join("\n\n");
 
-    super(scope, id, { ...props, actionsEnabled });
+    super(scope, id, { ...props, alarmDescription, actionsEnabled });
 
     const topicArn: string = `arn:aws:sns:${region}:${account}:${snsTopicName}`;
     const snsTopic: ITopic = Topic.fromTopicArn(scope, `SnsTopicFor${id}`, topicArn);
+
     this.addAlarmAction(new SnsAction(snsTopic));
     if (okAction) {
       this.addOkAction(new SnsAction(snsTopic));

--- a/src/constructs/cloudwatch/alarm.ts
+++ b/src/constructs/cloudwatch/alarm.ts
@@ -46,9 +46,14 @@ export class GuAlarmCta {
             "_a=(columns:!(stack,stage,message,app),filters:!(",
             `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:${scope.stack}),type:phrase),query:(match_phrase:(stack.keyword:${scope.stack}))),`,
             `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:${scope.app}),type:phrase),query:(match_phrase:(app.keyword:${scope.app}))),`,
-            `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:${scope.stage}),type:phrase),query:(match_phrase:(stage.keyword:${scope.stage}))))`,
-            ",hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+            `('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:${scope.stage}),type:phrase),query:(match_phrase:(stage.keyword:${scope.stage})))`,
+            "),",
+            "hideChart:!t,interval:auto,query:(language:kuery,query:''),",
+            "sort:!(!('@timestamp',desc))",
+            ")"
           ].join("")
+
+
         : undefined;
     this.ctaLinks = [providedRunbook, generatedLink].filter((link): link is string => !!link);
 

--- a/src/constructs/cloudwatch/lambda-alarms.test.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.test.ts
@@ -125,4 +125,78 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
       AlarmName: "test-custom-alarm-name",
     });
   });
+
+  it("should generate a log link, if `logLink.elkSpace` and `scope.app` are provided", () => {
+    const stack = simpleGuStackForTesting({ app: "test" });
+    const lambda = new GuLambdaFunction(stack, "lambda", {
+      fileName: "lambda.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_12_X,
+      app: "testing",
+    });
+    const props = {
+      toleratedErrorPercentage: 65,
+      snsTopicName: "alerts-topic",
+      alarmDescription: "test with space",
+      lambda: lambda,
+      cta: {
+        elkSpace: "example",
+      },
+    };
+    new GuLambdaErrorPercentageAlarm(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmDescription:
+        "test with space\n\nhttps://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+    });
+  });
+
+  it("should generate a log link, if `logLink.link` is provided", () => {
+    const stack = simpleGuStackForTesting();
+    const lambda = new GuLambdaFunction(stack, "lambda", {
+      fileName: "lambda.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_12_X,
+      app: "testing",
+    });
+    const props = {
+      toleratedErrorPercentage: 65,
+      snsTopicName: "alerts-topic",
+      lambda: lambda,
+      alarmDescription: "test with link",
+      cta: {
+        link: "https://www.example.com",
+      },
+    };
+    new GuLambdaErrorPercentageAlarm(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmDescription: "test with link\n\nhttps://www.example.com",
+    });
+  });
+
+  it("should generate two links, if `logLink.link`, `logLink.elkSpace` and `scope.app` are all provided", () => {
+    const stack = simpleGuStackForTesting({ app: "test" });
+    const lambda = new GuLambdaFunction(stack, "lambda", {
+      fileName: "lambda.zip",
+      handler: "handler.ts",
+      runtime: Runtime.NODEJS_12_X,
+      app: "testing",
+    });
+    const props = {
+      toleratedErrorPercentage: 65,
+      snsTopicName: "alerts-topic",
+      alarmDescription: "test with space",
+      lambda: lambda,
+      cta: {
+        link: "https://www.example.com",
+        elkSpace: "example",
+      },
+    };
+    new GuLambdaErrorPercentageAlarm(stack, "my-lambda-function", props);
+    Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmDescription:
+        "test with space" +
+        "\n\nhttps://www.example.com" +
+        "\n\nhttps://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+    });
+  });
 });

--- a/src/constructs/cloudwatch/lambda-alarms.test.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.test.ts
@@ -126,7 +126,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
     });
   });
 
-  it("should generate a log link, if `logLink.elkSpace` and `scope.app` are provided", () => {
+  it("should generate a log link, if `cta.elkSpace` and `scope.app` are provided", () => {
     const stack = simpleGuStackForTesting({ app: "test" });
     const lambda = new GuLambdaFunction(stack, "lambda", {
       fileName: "lambda.zip",
@@ -150,7 +150,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
     });
   });
 
-  it("should generate a log link, if `logLink.link` is provided", () => {
+  it("should generate a log link, if `cta.runbook` is provided", () => {
     const stack = simpleGuStackForTesting();
     const lambda = new GuLambdaFunction(stack, "lambda", {
       fileName: "lambda.zip",
@@ -164,16 +164,16 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
       lambda: lambda,
       alarmDescription: "test with link",
       cta: {
-        link: "https://www.example.com",
+        runbook: "https://www.example.com",
       },
     };
     new GuLambdaErrorPercentageAlarm(stack, "my-lambda-function", props);
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
-      AlarmDescription: "test with link\n\n---\n[link](https://www.example.com)",
+      AlarmDescription: "test with link\n\n---\n[runbook](https://www.example.com)",
     });
   });
 
-  it("should generate two links, if `logLink.link`, `logLink.elkSpace` and `scope.app` are all provided", () => {
+  it("should generate two links, if `cta.runbook`, `cta.elkSpace` and `scope.app` are all provided", () => {
     const stack = simpleGuStackForTesting({ app: "test" });
     const lambda = new GuLambdaFunction(stack, "lambda", {
       fileName: "lambda.zip",
@@ -187,7 +187,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
       alarmDescription: "test with space",
       lambda: lambda,
       cta: {
-        link: "https://www.example.com",
+        runbook: "https://www.example.com",
         elkSpace: "example",
       },
     };
@@ -195,7 +195,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
       AlarmDescription:
         "test with space" +
-        "\n\n---\n[link](https://www.example.com)" +
+        "\n\n---\n[runbook](https://www.example.com)" +
         "\n[logs](https://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc))))",
     });
   });

--- a/src/constructs/cloudwatch/lambda-alarms.test.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.test.ts
@@ -146,7 +146,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
     new GuLambdaErrorPercentageAlarm(stack, "my-lambda-function", props);
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
       AlarmDescription:
-        "test with space\n\nhttps://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+        "test with space\n\n---\n[logs](https://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc))))",
     });
   });
 
@@ -169,7 +169,7 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
     };
     new GuLambdaErrorPercentageAlarm(stack, "my-lambda-function", props);
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
-      AlarmDescription: "test with link\n\nhttps://www.example.com",
+      AlarmDescription: "test with link\n\n---\n[link](https://www.example.com)",
     });
   });
 
@@ -195,8 +195,8 @@ describe("The GuLambdaErrorPercentageAlarm construct", () => {
     Template.fromStack(stack).hasResourceProperties("AWS::CloudWatch::Alarm", {
       AlarmDescription:
         "test with space" +
-        "\n\nhttps://www.example.com" +
-        "\n\nhttps://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc)))",
+        "\n\n---\n[link](https://www.example.com)" +
+        "\n[logs](https://logs.gutools.co.uk/s/example/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-1d,to:now))&_a=(columns:!(stack,stage,message,app),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stack.keyword,negate:!f,params:(query:test-stack),type:phrase),query:(match_phrase:(stack.keyword:test-stack))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:app.keyword,negate:!f,params:(query:test),type:phrase),query:(match_phrase:(app.keyword:test))),('$state':(store:appState),meta:(alias:!n,disabled:!f,key:stage.keyword,negate:!f,params:(query:TEST),type:phrase),query:(match_phrase:(stage.keyword:TEST)))),hideChart:!t,interval:auto,query:(language:kuery,query:exception),sort:!(!('@timestamp',desc))))",
     });
   });
 });

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -2,7 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import { ComparisonOperator, MathExpression, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import type { GuStack } from "../core";
 import type { GuLambdaFunction } from "../lambda";
-import { GuAlarm } from "./alarm";
+import { GuAlarm, GuAlarmCta } from "./alarm";
 import type { GuAlarmProps } from "./alarm";
 
 export interface GuLambdaErrorPercentageMonitoringProps extends Omit<
@@ -32,6 +32,9 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
     });
     const defaultAlarmName = `High error percentage from ${props.lambda.functionName} lambda in ${scope.stage}`;
     const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
+    const alarmCta: GuAlarmCta | undefined = props.cta && new GuAlarmCta(scope, props.cta);
+    const alarmCtaLinks = alarmCta ? alarmCta.ctaLinks : [];
+    const alarmDescription = [props.alarmDescription ?? defaultDescription, ...alarmCtaLinks].join("\n\n");
     const alarmProps: GuAlarmProps = {
       ...props,
       app: props.lambda.app,
@@ -41,7 +44,7 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       evaluationPeriods: props.numberOfEvaluationPeriodsAboveThresholdBeforeAlarm ?? 1,
       alarmName: props.alarmName ?? defaultAlarmName,
-      alarmDescription: props.alarmDescription ?? defaultDescription,
+      alarmDescription: alarmDescription,
     };
     super(scope, id, alarmProps);
   }

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -33,8 +33,9 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
     const defaultAlarmName = `High error percentage from ${props.lambda.functionName} lambda in ${scope.stage}`;
     const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
     const alarmCta: GuAlarmCta | undefined = props.cta && new GuAlarmCta(scope, props.cta);
-    const alarmCtaLinks = alarmCta ? alarmCta.ctaLinks : [];
-    const alarmDescription = [props.alarmDescription ?? defaultDescription, ...alarmCtaLinks].join("\n\n");
+    const alarmDescription = [props.alarmDescription ?? defaultDescription, alarmCta?.markdown]
+      .filter((line): line is string => !!line)
+      .join("\n\n");
     const alarmProps: GuAlarmProps = {
       ...props,
       app: props.lambda.app,

--- a/src/constructs/cloudwatch/lambda-alarms.ts
+++ b/src/constructs/cloudwatch/lambda-alarms.ts
@@ -2,7 +2,7 @@ import { Duration } from "aws-cdk-lib";
 import { ComparisonOperator, MathExpression, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import type { GuStack } from "../core";
 import type { GuLambdaFunction } from "../lambda";
-import { GuAlarm, GuAlarmCta } from "./alarm";
+import { GuAlarm } from "./alarm";
 import type { GuAlarmProps } from "./alarm";
 
 export interface GuLambdaErrorPercentageMonitoringProps extends Omit<
@@ -32,10 +32,8 @@ export class GuLambdaErrorPercentageAlarm extends GuAlarm {
     });
     const defaultAlarmName = `High error percentage from ${props.lambda.functionName} lambda in ${scope.stage}`;
     const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
-    const alarmCta: GuAlarmCta | undefined = props.cta && new GuAlarmCta(scope, props.cta);
-    const alarmDescription = [props.alarmDescription ?? defaultDescription, alarmCta?.markdown]
-      .filter((line): line is string => !!line)
-      .join("\n\n");
+
+    const alarmDescription = props.alarmDescription ?? defaultDescription;
     const alarmProps: GuAlarmProps = {
       ...props,
       app: props.lambda.app,


### PR DESCRIPTION
## What does this change?

This adds a useful 3am feature to an alarm: a direct deep link to the relevant logging.

It either takes a complete link, or (and this should be sufficient for most purposes) the ELK space in which to search for app/stack/stage.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
<!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
