### PR TITLE
fix(GuLoadBalancedAppExperimental): Ensure all taggable resources use standard Guardian tags

### DIFF
--- a/.changeset/heavy-dancers-grab.md
+++ b/.changeset/heavy-dancers-grab.md
@@ -1,0 +1,11 @@
+---
+"@guardian/cdk": patch
+---
+
+Explicitly add the `App` tag to all resources created by `GuLoadBalancedAppExperimental`. Namely, `App` is added to:
+- `AWS::ECS::Cluster`
+- `AWS::ECS::TaskDefinition`
+- `AWS::ECS::Service`
+
+Previously, these resources implicitly inherited the `App` tag of the parent CloudFormation stack.
+The CloudFormation's `App` tag is implicitly set by Riff-Raff via the contents of the `riff-raff.yaml` configuration.

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -2802,6 +2802,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         "PropagateTags": "SERVICE",
         "Tags": [
           {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -3052,6 +3056,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         ],
         "Tags": [
           {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -3097,6 +3105,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
           "Version": "2012-10-17",
         },
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -3190,6 +3202,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         "RetentionInDays": 1,
         "Tags": [
           {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -3225,6 +3241,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
           "Version": "2012-10-17",
         },
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -3553,6 +3573,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
     "testguEcsCluster02799D79": {
       "Properties": {
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/src/experimental/patterns/gu-load-balanced-app.test.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.test.ts
@@ -1,4 +1,4 @@
-import { App, Duration } from "aws-cdk-lib";
+import { App, CfnResource, Duration, TagManager } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import {
   BlockDeviceVolume,
@@ -39,6 +39,35 @@ describe("the GuLoadBalancedAppExperimental pattern should support new ECS and h
       },
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+  });
+
+  it("should apply standard tags to all taggable resources", function () {
+    const stack = simpleGuStackForTesting({ env: { region: "eu-west-1" } });
+    new GuLoadBalancedAppExperimental(stack, {
+      monitoringConfiguration: { noMonitoring: true },
+      applicationPort: 3000,
+      access: { scope: AccessScope.PUBLIC },
+      app: "test-gu",
+      certificateProps: {
+        domainName: "domain-name-for-your-application.example",
+      },
+      ecsProps: {
+        cpu: 1024,
+        memoryLimitMiB: 2048,
+        scaling: { minimumTasks: 3, maximumTasks: 6 },
+        imageIdentifier: "sha256:12345",
+      },
+    });
+
+    const taggableResources: CfnResource[] = stack.node
+      .findAll()
+      .filter((_) => TagManager.isTaggable(_) || TagManager.isTaggableV2(_))
+      .filter((_) => CfnResource.isCfnResource(_));
+
+    const template = GuTemplate.fromStack(stack);
+    taggableResources.forEach(({ cfnResourceType }) => {
+      template.hasGuTaggedResource(cfnResourceType, { appIdentity: { app: "test-gu" } });
+    });
   });
 
   it("should be capable of splitting traffic between EC2 and ECS target groups", function () {

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -755,6 +755,10 @@ export class GuLoadBalancedAppExperimental extends Construct {
         ...targetGroups,
         ecs: ecsTargetGroup,
       };
+
+      // Specifically apply App tag to resources.
+      // Other resources obtain this tag by extending `GuAppAwareConstruct`.
+      [cluster, taskDefinition, ecsService].forEach((_) => Tags.of(_).add("App", app));
     }
 
     // Set up the load balancer and listener components

--- a/src/utils/test/assertions.ts
+++ b/src/utils/test/assertions.ts
@@ -102,7 +102,11 @@ export class GuTemplate {
       });
     }
 
-    this.template.hasResourceProperties(type, { Tags: sortTagsByKey(Array.from(tagMap.values())) });
+    // Default behaviour (`Match.object`) seems to be "is exact".
+    // Use `Match.arrayWith` for "includes" matching, as AWS CDK also tags some resources which we're not checking for.
+    this.template.hasResourceProperties(type, {
+      Tags: Match.arrayWith(sortTagsByKey(Array.from(tagMap.values()))),
+    });
   }
 
   hasResourceWithTag(type: string, tag: Tag) {


### PR DESCRIPTION
## What does this change?
Updates all resources created by `GuLoadBalancedAppExperimental` with standard Guardian tags. Namely `App` is added to:
- `AWS::ECS::Cluster`
- `AWS::ECS::TaskDefinition`
- `AWS::ECS::Service`

Other resources, for example [`AWS::ElasticLoadBalancingV2::LoadBalancer`](https://github.com/guardian/cdk/blob/6cd190b1304da630e2b533ae300dc00d0840fa51/src/constructs/loadbalancing/alb/application-load-balancer.ts#L59), already have Guardian tags via the [`GuAppAwareConstruct` mixin](https://github.com/guardian/cdk/blob/6cd190b1304da630e2b533ae300dc00d0840fa51/src/utils/mixin/app-aware-construct.ts).

> [!NOTE]
> Previously, these resources implicitly inherited the `App` tag of the parent CloudFormation stack.
The CloudFormation's `App` tag is implicitly set by Riff-Raff via the contents of the `riff-raff.yaml` configuration. For example, in [this CloudFormation deployment of a DCR service](https://github.com/guardian/dotcom-rendering/blob/792024d40354ae2dbaa90d5ef8ae5a34eda7ea1f/dotcom-rendering/scripts/deploy/riff-raff.yaml#L70-L78), Riff-Raff sets `App` to `tag-page-rendering-cfn`. In this instance `tag-page-rendering` is the desired `App` value.

To support this, the [`hasGuTaggedResource` assertion](https://github.com/guardian/cdk/blob/6cd190b1304da630e2b533ae300dc00d0840fa51/src/utils/test/assertions.ts#L67) needed tweaking to perform an "includes" [match](https://github.com/aws/aws-cdk/blob/a5148255673fe7d4f37d229ba2839f3ab7a3b707/packages/aws-cdk-lib/assertions/README.md) (previously it was an "exact" match). This is because AWS CDK adds tags to some resources, for example [`Name` is added to a `AWS::CertificateManager::Certificate` resource](https://github.com/aws/aws-cdk/blob/a5148255673fe7d4f37d229ba2839f3ab7a3b707/packages/aws-cdk-lib/aws-certificatemanager/lib/certificate.ts#L363).

## How to test
See added unit test.

## How can we measure success?
Tags of a resource are explicitly created and are reflected in the snapshot test.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
