### PR TITLE
refactor: Re-use tagging function for consistency

### DIFF
--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -758,7 +758,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
 
       // Specifically apply App tag to resources.
       // Other resources obtain this tag by extending `GuAppAwareConstruct`.
-      [cluster, taskDefinition, ecsService].forEach((_) => Tags.of(_).add("App", app));
+      [cluster, taskDefinition, ecsService].forEach((_) => AppIdentity.taggedConstruct(props, _));
     }
 
     // Set up the load balancer and listener components


### PR DESCRIPTION
## What does this change?
Refactor of the changes made in https://github.com/guardian/cdk/pull/2944. The [`AppIdentity.taggedConstruct`](https://github.com/guardian/cdk/blob/93a81f8c249f50bcc45cc7d691dbbba98a33b4a1/src/constructs/core/identity.ts#L27-L30) function is used across the repository to add an `App` tag to a resource; re-use it for consistency.

## How to test
This is a no-op, as demonstrated by CI passing and no changes to snapshots.

## How can we measure success?
Consistent coding style in the repository, improving maintenance.

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
