### PR TITLE
feat(GuLoadBalancedAppExperimental): Add App to start of logical ID to influence target group name

### DIFF
--- a/.changeset/pink-rockets-sink.md
+++ b/.changeset/pink-rockets-sink.md
@@ -1,0 +1,20 @@
+---
+"@guardian/cdk": minor
+---
+
+Changes the stem of the logical ID fo the target group created for ECS in the `GuLoadBalancedAppExperimental` pattern.
+
+A target group has the following restrictions on its [name](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-name):
+- Max 32 characters
+- Must be regionally unique in an account
+
+The former can be checked at compile time. The latter is only checked at deploy time. For this reason, we let CloudFormation auto-generate a name. The algorithm used to generate a name appears to be: first 6 alphanumeric characters of CloudFormation stack name, first 6 alphanumeric characters of logical ID, 12 character GUID.
+Our CloudFormation stack names typically take the form `<stack>-<stage><app>`, for example `deploy-CODE-cdk-playground` or `deploy-PROD-prism`. For these stacks, the ECS target groups have names like `deploy-EcsTar-123456123456` and `deploy-EcsTar-123456123457`; it isn't possible to know which app these relate to at a glance.
+
+With this change, the target group will have a logical ID stem of `MyAppEcsTargetGroup`, resulting in a name such as `deploy-MyAppE-123456123456`.
+
+## Why not change all target groups?
+We should consider target groups as a [stateful resource](../docs/stateful-resources.md) as they're tied to metrics used to understand the performance of an application.
+Changing all target groups (e.g. the ones created for EC2 apps via the `GuEc2App` pattern) would be a significant breaking change.
+
+The ECS infrastructure created by the `GuLoadBalancedAppExperimental` pattern is not yet used in production, so we can afford to make this destructive change in this context.

--- a/.changeset/pink-rockets-sink.md
+++ b/.changeset/pink-rockets-sink.md
@@ -2,19 +2,8 @@
 "@guardian/cdk": minor
 ---
 
-Changes the stem of the logical ID fo the target group created for ECS in the `GuLoadBalancedAppExperimental` pattern.
+Changes the stem of the logical ID for the target group created for ECS in the `GuLoadBalancedAppExperimental` pattern. This results in a more a slightly more human-readable name.
 
-A target group has the following restrictions on its [name](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-name):
-- Max 32 characters
-- Must be regionally unique in an account
+For example, say we have a CloudFormation stack called `deploy-CODE-cdk-playground`, previously the target group name would be `deploy-EcsTar-123456123456`, now it will be `deploy-Cdkpl-123456123456`.
 
-The former can be checked at compile time. The latter is only checked at deploy time. For this reason, we let CloudFormation auto-generate a name. The algorithm used to generate a name appears to be: first 6 alphanumeric characters of CloudFormation stack name, first 6 alphanumeric characters of logical ID, 12 character GUID.
-Our CloudFormation stack names typically take the form `<stack>-<stage><app>`, for example `deploy-CODE-cdk-playground` or `deploy-PROD-prism`. For these stacks, the ECS target groups have names like `deploy-EcsTar-123456123456` and `deploy-EcsTar-123456123457`; it isn't possible to know which app these relate to at a glance.
-
-With this change, the target group will have a logical ID stem of `MyAppEcsTargetGroup`, resulting in a name such as `deploy-MyAppE-123456123456`.
-
-## Why not change all target groups?
-We should consider target groups as a [stateful resource](../docs/stateful-resources.md) as they're tied to metrics used to understand the performance of an application.
-Changing all target groups (e.g. the ones created for EC2 apps via the `GuEc2App` pattern) would be a significant breaking change.
-
-The ECS infrastructure created by the `GuLoadBalancedAppExperimental` pattern is not yet used in production, so we can afford to make this destructive change in this context.
+NOTE: As this is a change to an experimental pattern, it is not considered a breaking change even though it results in recreating a [stateful resource](../docs/stateful-resources.md).

--- a/src/constructs/acm/certificate.ts
+++ b/src/constructs/acm/certificate.ts
@@ -23,7 +23,7 @@ export class GuCertificate extends GuAppAwareConstruct(Certificate) {
     const { app, domainName, hostedZoneId } = props;
 
     const maybeHostedZone = hostedZoneId
-      ? HostedZone.fromHostedZoneId(scope, AppIdentity.suffixText({ app }, "HostedZone"), hostedZoneId)
+      ? HostedZone.fromHostedZoneId(scope, AppIdentity.addAppToStringEnd({ app }, "HostedZone"), hostedZoneId)
       : undefined;
 
     const awsCertificateProps: CertificateProps & AppIdentity = {

--- a/src/constructs/cloudwatch/api-gateway-alarms.ts
+++ b/src/constructs/cloudwatch/api-gateway-alarms.ts
@@ -38,6 +38,6 @@ export class GuApiGateway5xxPercentageAlarm extends GuAlarm {
       alarmDescription: props.alarmDescription ?? defaultDescription,
       evaluationPeriods: props.numberOfMinutesAboveThresholdBeforeAlarm ?? 1,
     };
-    super(scope, AppIdentity.suffixText(props, "ApiGatewayHigh5xxPercentageAlarm"), alarmProps);
+    super(scope, AppIdentity.addAppToStringEnd(props, "ApiGatewayHigh5xxPercentageAlarm"), alarmProps);
   }
 }

--- a/src/constructs/cloudwatch/ec2-alarms.ts
+++ b/src/constructs/cloudwatch/ec2-alarms.ts
@@ -46,7 +46,7 @@ export class GuAlb5xxPercentageAlarm extends GuAlarm {
       alarmDescription: props.alarmDescription ?? defaultDescription,
       evaluationPeriods: props.numberOfMinutesAboveThresholdBeforeAlarm ?? 1,
     };
-    super(scope, AppIdentity.suffixText(props, "High5xxPercentageAlarm"), alarmProps);
+    super(scope, AppIdentity.addAppToStringEnd(props, "High5xxPercentageAlarm"), alarmProps);
   }
 }
 
@@ -78,7 +78,7 @@ export class GuAlb4xxPercentageAlarm extends GuAlarm {
       alarmDescription: props.alarmDescription ?? defaultDescription,
       evaluationPeriods: props.numberOfMinutesAboveThresholdBeforeAlarm ?? 1,
     };
-    super(scope, AppIdentity.suffixText(props, "High4xxPercentageAlarm"), alarmProps);
+    super(scope, AppIdentity.addAppToStringEnd(props, "High4xxPercentageAlarm"), alarmProps);
   }
 }
 
@@ -109,6 +109,6 @@ export class GuUnhealthyInstancesAlarm extends GuAlarm {
       datapointsToAlarm: 30,
       evaluationPeriods,
     };
-    super(scope, AppIdentity.suffixText(props, "UnhealthyInstancesAlarm"), alarmProps);
+    super(scope, AppIdentity.addAppToStringEnd(props, "UnhealthyInstancesAlarm"), alarmProps);
   }
 }

--- a/src/constructs/core/identity.test.ts
+++ b/src/constructs/core/identity.test.ts
@@ -3,27 +3,27 @@ import { Template } from "aws-cdk-lib/assertions";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { AppIdentity } from "./identity";
 
-describe("AppIdentity.suffixText", () => {
+describe("AppIdentity.addAppToStringEnd", () => {
   it("should title case the app before suffixing it", () => {
-    const actual = AppIdentity.suffixText({ app: "myapp" }, "InstanceType");
+    const actual = AppIdentity.addAppToStringEnd({ app: "myapp" }, "InstanceType");
     const expected = "InstanceTypeMyapp";
     expect(actual).toEqual(expected);
   });
 
   it("should work with title case input", () => {
-    const actual = AppIdentity.suffixText({ app: "MyApp" }, "InstanceType");
+    const actual = AppIdentity.addAppToStringEnd({ app: "MyApp" }, "InstanceType");
     const expected = "InstanceTypeMyApp";
     expect(actual).toEqual(expected);
   });
 
   it("should work with uppercase input", () => {
-    const actual = AppIdentity.suffixText({ app: "MYAPP" }, "InstanceType");
+    const actual = AppIdentity.addAppToStringEnd({ app: "MYAPP" }, "InstanceType");
     const expected = "InstanceTypeMYAPP";
     expect(actual).toEqual(expected);
   });
 
   it("should handle non-alphanumeric characters (e.g. hyphens)", () => {
-    const actual = AppIdentity.suffixText({ app: "my-app" }, "InstanceType");
+    const actual = AppIdentity.addAppToStringEnd({ app: "my-app" }, "InstanceType");
     const expected = "InstanceTypeMyapp";
     expect(actual).toEqual(expected);
   });

--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -18,7 +18,7 @@ export const AppIdentity = {
     return props ? "app" in props : false;
   },
 
-  suffixText(appIdentity: AppIdentity, text: string): string {
+  addAppToStringEnd(appIdentity: AppIdentity, text: string): string {
     const titleCaseApp = appIdentity.app.charAt(0).toUpperCase() + appIdentity.app.slice(1);
     // CloudFormation Logical Ids must be alphanumeric, so remove any non-alphanumeric characters: https://stackoverflow.com/a/20864946
     const alphanumericTitleCaseApp = titleCaseApp.replace(/[\W_]+/g, "");

--- a/src/constructs/core/identity.ts
+++ b/src/constructs/core/identity.ts
@@ -18,12 +18,20 @@ export const AppIdentity = {
     return props ? "app" in props : false;
   },
 
-  addAppToStringEnd(appIdentity: AppIdentity, text: string): string {
+  toAlphanumericTitleCase(appIdentity: AppIdentity) {
     const titleCaseApp = appIdentity.app.charAt(0).toUpperCase() + appIdentity.app.slice(1);
     // CloudFormation Logical Ids must be alphanumeric, so remove any non-alphanumeric characters: https://stackoverflow.com/a/20864946
-    const alphanumericTitleCaseApp = titleCaseApp.replace(/[\W_]+/g, "");
-    return `${text}${alphanumericTitleCaseApp}`;
+    return titleCaseApp.replace(/[\W_]+/g, "");
   },
+
+  addAppToStringEnd(appIdentity: AppIdentity, text: string): string {
+    return [text, AppIdentity.toAlphanumericTitleCase(appIdentity)].join("");
+  },
+
+  addAppToStringStart(appIdentity: AppIdentity, text: string): string {
+    return [AppIdentity.toAlphanumericTitleCase(appIdentity), text].join("");
+  },
+
   taggedConstruct<T extends IConstruct>(appIdentity: AppIdentity, construct: T): T {
     Tags.of(construct).add("App", appIdentity.app);
     return construct;

--- a/src/constructs/core/parameters/acm.ts
+++ b/src/constructs/core/parameters/acm.ts
@@ -5,7 +5,7 @@ import { GuStringParameter } from "./base";
 
 export class GuCertificateArnParameter extends GuStringParameter {
   constructor(scope: GuStack, props: AppIdentity) {
-    super(scope, AppIdentity.suffixText(props, "TLSCertificate"), {
+    super(scope, AppIdentity.addAppToStringEnd(props, "TLSCertificate"), {
       allowedPattern: RegexPattern.ACM_ARN,
       constraintDescription: "Must be an ACM ARN resource",
       description: "The ARN of an ACM certificate for use on a load balancer",

--- a/src/constructs/core/parameters/ec2.ts
+++ b/src/constructs/core/parameters/ec2.ts
@@ -5,7 +5,7 @@ import type { GuNoTypeParameterPropsWithAppIdentity } from "./base";
 
 export class GuAmiParameter extends GuParameter {
   constructor(scope: GuStack, props: GuNoTypeParameterPropsWithAppIdentity) {
-    super(scope, AppIdentity.suffixText(props, "AMI"), {
+    super(scope, AppIdentity.addAppToStringEnd(props, "AMI"), {
       type: "AWS::EC2::Image::Id",
       description: `Amazon Machine Image ID for the app ${props.app}. Use this in conjunction with AMIgo to keep AMIs up to date.`,
       ...props,

--- a/src/constructs/ecs/ecs-task.ts
+++ b/src/constructs/ecs/ecs-task.ts
@@ -285,7 +285,7 @@ export class GuEcsTask extends Construct {
     if (!monitoringConfiguration.noMonitoring) {
       const alarmTopic = Topic.fromTopicArn(
         scope,
-        AppIdentity.suffixText(props, "AlarmTopic"),
+        AppIdentity.addAppToStringEnd(props, "AlarmTopic"),
         monitoringConfiguration.snsTopicArn,
       );
       const alarms = [

--- a/src/constructs/loadbalancing/alb/application-load-balancer.ts
+++ b/src/constructs/loadbalancing/alb/application-load-balancer.ts
@@ -76,7 +76,7 @@ export class GuApplicationLoadBalancer extends GuAppAwareConstruct(ApplicationLo
     if (withAccessLogging) {
       const bucket = Bucket.fromBucketName(
         scope,
-        AppIdentity.suffixText(props, "AccessLoggingBucket"),
+        AppIdentity.addAppToStringEnd(props, "AccessLoggingBucket"),
         GuAccessLoggingBucketParameter.getInstance(scope).valueAsString,
       );
       const prefix = `application-load-balancer/${stage}/${stack}/${app}`;

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -2779,7 +2779,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
             "ContainerName": "test-gu",
             "ContainerPort": 3000,
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroupTestguFCB7574C",
+              "Ref": "TestguEcsTargetGroupTestguC2E4D411",
             },
           },
         ],
@@ -2873,55 +2873,6 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         "ServiceNamespace": "ecs",
       },
       "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
-    },
-    "EcsTargetGroupTestguFCB7574C": {
-      "Properties": {
-        "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/healthcheck",
-        "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 5,
-        "Port": 3000,
-        "Protocol": "HTTP",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "test-gu",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk",
-          },
-          {
-            "Key": "Stack",
-            "Value": "test-stack",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "TargetGroupAttributes": [
-          {
-            "Key": "deregistration_delay.timeout_seconds",
-            "Value": "30",
-          },
-          {
-            "Key": "stickiness.enabled",
-            "Value": "false",
-          },
-        ],
-        "TargetType": "ip",
-        "UnhealthyThresholdCount": 2,
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "EcsTaskDefinition63157ED3": {
       "Properties": {
@@ -3376,7 +3327,7 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         "DefaultActions": [
           {
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroupTestguFCB7574C",
+              "Ref": "TestguEcsTargetGroupTestguC2E4D411",
             },
             "Type": "forward",
           },
@@ -3569,6 +3520,55 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "TestguEcsTargetGroupTestguC2E4D411": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 3000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "test-gu",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk",
+          },
+          {
+            "Key": "Stack",
+            "Value": "test-stack",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "testguEcsCluster02799D79": {
       "Properties": {

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -426,7 +426,7 @@ export class GuLoadBalancedAppExperimental extends Construct {
       applicationPort,
       certificateProps,
       monitoringConfiguration,
-      vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText({ app }, "VPC")),
+      vpc = GuVpc.fromIdParameter(scope, AppIdentity.addAppToStringEnd({ app }, "VPC")),
       privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app }),
       publicSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       waf,

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -743,13 +743,22 @@ export class GuLoadBalancedAppExperimental extends Construct {
       });
 
       // We need a new target group even if we share the other load balancer components with the EC2 infrastructure
-      const ecsTargetGroup = new GuApplicationTargetGroup(scope, "EcsTargetGroup", {
-        vpc,
-        app,
-        port: applicationPort,
-        targets: [ecsService],
-        healthCheck: healthcheck,
-      });
+      const ecsTargetGroup = new GuApplicationTargetGroup(
+        scope,
+
+        // This ID parameter is used to form the resource's logical ID.
+        // If a target group is not explicitly named, CloudFormation will use the logical ID to generate a name of form `<CFN_STACK_NAME>-<LOGICAL_ID>-<12 CHAR GUID>` to a max of 32 chars.
+        // Add the App to the start of the logical ID to make the generated names (slightly) glanceable, e.g "MyAppE-123456123456" vs. "EcsTar-123456123456".
+        AppIdentity.addAppToStringStart(props, "EcsTargetGroup"),
+
+        {
+          vpc,
+          app,
+          port: applicationPort,
+          targets: [ecsService],
+          healthCheck: healthcheck,
+        },
+      );
 
       targetGroups = {
         ...targetGroups,

--- a/src/patterns/ec2-app/base.ts
+++ b/src/patterns/ec2-app/base.ts
@@ -393,7 +393,7 @@ export class GuEc2App extends Construct {
       scaling: { minimumInstances, maximumInstances = minimumInstances * 2 },
       userData: userDataLike,
       imageRecipe,
-      vpc = GuVpc.fromIdParameter(scope, AppIdentity.suffixText({ app }, "VPC")),
+      vpc = GuVpc.fromIdParameter(scope, AppIdentity.addAppToStringEnd({ app }, "VPC")),
       privateSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PRIVATE, app }),
       publicSubnets = GuVpc.subnetsFromParameter(scope, { type: SubnetType.PUBLIC, app }),
       instanceMetadataHopLimit,

--- a/src/utils/mixin/app-aware-construct.ts
+++ b/src/utils/mixin/app-aware-construct.ts
@@ -20,7 +20,7 @@ export function GuAppAwareConstruct<TBase extends AnyConstructor>(BaseClass: TBa
       }
 
       const app: string = props.app;
-      const idWithApp = AppIdentity.suffixText({ app }, id as string);
+      const idWithApp = AppIdentity.addAppToStringEnd({ app }, id as string);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- mixin
       const newArgs = [scope, idWithApp, props, ...rest];


### PR DESCRIPTION
## What does this change?
Changes the stem of the logical ID fo the target group created for ECS in the `GuLoadBalancedAppExperimental` pattern.

A target group has the following restrictions on its [name](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-name):
- Max 32 characters
- Must be regionally unique in an account

The former can be checked at compile time. The latter is only checked at deploy time. For this reason, we let CloudFormation auto-generate a name. The algorithm used to generate a name appears to be: first 6 alphanumeric characters of CloudFormation stack name, first 6 alphanumeric characters of logical ID, 12 character GUID.

Our CloudFormation stack names typically take the form `<stack>-<stage><app>`, for example `deploy-CODE-cdk-playground` or `deploy-PROD-prism`. For these stacks, the ECS target groups have names like `deploy-EcsTar-123456123456` and `deploy-EcsTar-123456123457`; it isn't possible to know which app these relate to at a glance.

With this change, the target group will have a logical ID stem of `MyAppEcsTargetGroup`, resulting in a name such as `deploy-MyAppE-123456123456`.

### Why not change all target groups?
We should consider target groups as a [stateful resource](https://github.com/guardian/cdk/blob/main/docs/stateful-resources.md) as they're tied to metrics used to understand the performance of an application. Changing all target groups (e.g. the ones created for EC2 apps via the `GuEc2App` pattern) would be a significant breaking change.

The ECS infrastructure created by the `GuLoadBalancedAppExperimental` pattern is not yet used in production, so we can afford to make this destructive change in this context.

> [!NOTE]
> This is not considered to be a breaking change as its an update to an experimental pattern.

## How to test
See updated tests.

## How can we measure success?
Target group resources are more glanceable in the AWS console.

## Have we considered potential risks?
As we're changing the logical ID, this is a replacement operation. Brief testing suggests AWS will provision the new target group first and then delete the existing one. That is, there should not be impact to service availability.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [ ] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
