### PR TITLE
feat: Add support for publishing canaries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 ## How to test
 <!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
 <!-- FYI you can use https://github.com/guardian/cdk-playground to test changes before publishing to NPM. -->
+<!-- You can also label your PR with `🐥 Canaries` to trigger a canary release to NPM -->
 
 ## How can we measure success?
 <!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,12 +1,19 @@
 name: CD
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  # Trigger for canary release on PR label
+  pull_request:
+    types: [labeled, synchronize]
+
+  # Trigger for standard (changesets) release after CI on main
+  # If a changeset PR is merged to main, this will publish a new version of the package to npm
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
 
 jobs:
-  CD:
+  canaries:
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, '🐥 Canaries') }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -15,16 +22,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: ".tool-versions"
-          cache: npm
-
-      # See https://docs.npmjs.com/trusted-publishers
-      # Find the latest version with `npm info npm@latest version`
-      - name: Install suitable NPM version for trusted publishing
-        run: npm install -g npm@11.6.2
+          package-manager-cache: false # never use caching in release builds
 
       - name: Install
         run: npm ci
@@ -32,13 +34,69 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Lint
-        run: npm run lint
+      - name: Create Snapshot Version
+        run: npx changeset version --snapshot canary
 
-      - name: Test
-        run: npm run test
+      - name: Release
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        id: publish-canary
+        with:
+          # currently, you have to tag releases in git to get the action output to appear
+          # https://github.com/changesets/action/issues/141
+          # publish: pnpm changeset publish --no-git-tag --tag canary
+          publish: npx changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        if: steps.publish-canary.outputs.published == 'true'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const publishedPackages = ${{ steps.publish-canary.outputs.publishedPackages }};
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                `> [!NOTE]`,
+                `> The following canaries were published to NPM:`,
+                `>`,
+                ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),
+                '',
+                '🐥'
+              ].join('\n')
+            });
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: '🐥 Canaries',
+            });
+  release:
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: ".tool-versions"
+          cache: npm
+          package-manager-cache: false # never use caching in release builds
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -57,7 +115,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: npx changeset publish
           title: "🦋 Release package updates"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 jobs:
   CI:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -37,7 +37,7 @@ However, it's advised you configure your IDE to format on save to avoid horrible
 ### Development Environment
 
 This project comes with a [devcontainer.json](../.devcontainer/shared/devcontainer.json)
-file.  This enables use of development containers in compatible IDEs.  The
+file. This enables use of development containers in compatible IDEs. The
 devcontainer files were built with [devenv](https://github.com/guardian/devenv)
 and can be altered with the same tool.
 
@@ -108,6 +108,9 @@ stack to test your changes against a real AWS stack.
 This stack isn't user facing. Accidentally causing destruction there is ok - better there than on theguardian.com!
 
 ## Releasing
+
+> [!TIP]
+> You can add the `🐥 Canaries` label to your PR to publish a canary release to NPM before you merge!
 
 We use [changesets](https://github.com/changesets/changesets) to automate NPM releases.
 


### PR DESCRIPTION
## What does this change?

Adds support to our release workflow to release Canaries, by labelling a PR with `🐥 Canaries`.

This publishes the PR branch to NPM under the `canary` tag (not latest, to avoid automated tooling picking it up as a valid version to upgrade to), and under a specific canary version such as `0.0.0-canary-20260805130549`.

After publishing the canary the Github action then removes the `🐥 Canaries` so that it may be re-applied again to trigger another release, and comments on the PR to let the author know the artifact version to use.

This allows us to more easily test CDK changes as we can now use these canary versions to test how the library perform in CODE in other repositories such as DCR.

I've shamelessly stolen most of the Canary behaviour from [guardian/csnx](https://github.com/guardian/csnx/blob/main/.github/workflows/npm-publish.yml) and [guardian/stand](https://github.com/guardian/stand)

## How do Canaries work?

Essentially 2 commands:

 - `npx changeset version --snapshot canary`: Prepares the project for a canary release by setting the version field in `package.json` to a canary version, eg `0.0.0-canary-20260805133757`
 - `npx changeset publish --tag canary`: Publish the canary version to NPM. Tagging the version as `canary` instead of the default `latest` to avoid confusion with automated tooling.

## How to test

Labelled this PR with `🐥 Canaries` and then used the subsequent artifact in another repository.

Example from DCR:

<img width="350" height="250" alt="image" src="https://github.com/user-attachments/assets/97fd8a42-fcff-4350-b55f-db548669cd3c" />
