### PR TITLE
feat(GuLoadBalancedAppExperimental): Explictly use ARM64 and Linux

### DIFF
--- a/.changeset/slow-houses-run.md
+++ b/.changeset/slow-houses-run.md
@@ -1,0 +1,6 @@
+---
+"@guardian/cdk": minor
+---
+
+Explicitly configure ECS tasks in `GuLoadBalancedAppExperimental` to use ARM64 (Graviton) and Linux.
+This configuration matches our EC2 workloads.

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -3005,6 +3005,10 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -11,6 +11,8 @@ import type { InstanceType, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { UserData } from "aws-cdk-lib/aws-ec2";
 import { Repository } from "aws-cdk-lib/aws-ecr";
 import type { Volume } from "aws-cdk-lib/aws-ecs";
+import { OperatingSystemFamily } from "aws-cdk-lib/aws-ecs";
+import { CpuArchitecture } from "aws-cdk-lib/aws-ecs";
 import { PropagatedTagSource } from "aws-cdk-lib/aws-ecs";
 import {
   Cluster,
@@ -628,7 +630,11 @@ export class GuLoadBalancedAppExperimental extends Construct {
       // Add the GitHub repo if we can
       const environment = scope.repositoryName ? { ...env, GU_REPO: scope.repositoryName } : env;
 
-      const taskDefinition = new FargateTaskDefinition(scope, "EcsTaskDefinition", { memoryLimitMiB, cpu });
+      const taskDefinition = new FargateTaskDefinition(scope, "EcsTaskDefinition", {
+        memoryLimitMiB,
+        cpu,
+        runtimePlatform: { cpuArchitecture: CpuArchitecture.ARM64, operatingSystemFamily: OperatingSystemFamily.LINUX },
+      });
 
       taskDefinition.addContainer(app, {
         image,


### PR DESCRIPTION
## What does this change?
Explicitly configure ECS tasks in `GuLoadBalancedAppExperimental` to use ARM64 (Graviton) and Linux. This configuration matches our EC2 workloads.

## How to test
See updated snapshot.

## How can we measure success?
A better replication of our EC2 workloads on ECS.

## Have we considered potential risks?
This configuration is hardcoded in the pattern. If a client needs a different option an escape-hatch should be used as this is against the paved-road.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
