### PR TITLE
Set containerInsights to enhanced and add Monitoring properties for ecsService

### DIFF
--- a/.changeset/wild-worms-shake.md
+++ b/.changeset/wild-worms-shake.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cdk": minor
+---
+
+Sets containerInsights to enhanced and adds monitoring settings as default for ECS

--- a/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
+++ b/src/experimental/patterns/__snapshots__/gu-load-balanced-app.test.ts.snap
@@ -2783,6 +2783,17 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
             },
           },
         ],
+        "Monitoring": {
+          "MetricConfigurations": [
+            {
+              "MetricNames": [
+                "CPUUtilization",
+                "MemoryUtilization",
+              ],
+              "ResolutionSeconds": 20,
+            },
+          ],
+        },
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "DISABLED",
@@ -3576,6 +3587,12 @@ exports[`the GuLoadBalancedAppExperimental pattern should support new ECS and hy
     },
     "testguEcsCluster02799D79": {
       "Properties": {
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": "enhanced",
+          },
+        ],
         "Tags": [
           {
             "Key": "App",

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -10,7 +10,7 @@ import {
 import type { InstanceType, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { UserData } from "aws-cdk-lib/aws-ec2";
 import { Repository } from "aws-cdk-lib/aws-ecr";
-import { OperatingSystemFamily } from "aws-cdk-lib/aws-ecs";
+import { ContainerInsights, OperatingSystemFamily } from "aws-cdk-lib/aws-ecs";
 import { CpuArchitecture } from "aws-cdk-lib/aws-ecs";
 import { PropagatedTagSource } from "aws-cdk-lib/aws-ecs";
 import {
@@ -25,7 +25,6 @@ import {
 } from "aws-cdk-lib/aws-ecs";
 import type { CfnService } from "aws-cdk-lib/aws-ecs";
 import type { Volume } from "aws-cdk-lib/aws-ecs";
-import type { CfnCluster } from "aws-cdk-lib/aws-ecs";
 import type { HealthCheck as ALBHealthCheck } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { ApplicationProtocol, ListenerAction, ListenerCondition } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { AuthenticateCognitoAction } from "aws-cdk-lib/aws-elasticloadbalancingv2-actions";
@@ -588,7 +587,10 @@ export class GuLoadBalancedAppExperimental extends Construct {
         throw new Error("Could not determine an ECR repository name; please set this manually via ecsProps");
       }
 
-      const cluster = new Cluster(this, "EcsCluster", { vpc });
+      const cluster = new Cluster(this, "EcsCluster", {
+        vpc,
+        containerInsightsV2: ContainerInsights.ENHANCED,
+      });
 
       const image = ContainerImage.fromEcrRepository(
         // Images are published to the ECR registry in the DeployTools account, so reference that here
@@ -709,14 +711,6 @@ export class GuLoadBalancedAppExperimental extends Construct {
           }),
         ],
       });
-
-      const cfnCluster = cluster.node.defaultChild as CfnCluster;
-      cfnCluster.clusterSettings = [
-        {
-          name: "containerInsights",
-          value: "enhanced",
-        },
-      ];
 
       const cfnService = ecsService.node.defaultChild as CfnService;
       cfnService.addPropertyOverride("Monitoring", {

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -10,7 +10,6 @@ import {
 import type { InstanceType, ISubnet, IVpc } from "aws-cdk-lib/aws-ec2";
 import { UserData } from "aws-cdk-lib/aws-ec2";
 import { Repository } from "aws-cdk-lib/aws-ecr";
-import type { Volume } from "aws-cdk-lib/aws-ecs";
 import { OperatingSystemFamily } from "aws-cdk-lib/aws-ecs";
 import { CpuArchitecture } from "aws-cdk-lib/aws-ecs";
 import { PropagatedTagSource } from "aws-cdk-lib/aws-ecs";
@@ -24,6 +23,9 @@ import {
   LogDriver,
   VersionConsistency,
 } from "aws-cdk-lib/aws-ecs";
+import type { CfnService } from "aws-cdk-lib/aws-ecs";
+import type { Volume } from "aws-cdk-lib/aws-ecs";
+import type { CfnCluster } from "aws-cdk-lib/aws-ecs";
 import type { HealthCheck as ALBHealthCheck } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { ApplicationProtocol, ListenerAction, ListenerCondition } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { AuthenticateCognitoAction } from "aws-cdk-lib/aws-elasticloadbalancingv2-actions";
@@ -705,6 +707,24 @@ export class GuLoadBalancedAppExperimental extends Construct {
             app: `${app}-ecs`,
             vpc,
           }),
+        ],
+      });
+
+      const cfnCluster = cluster.node.defaultChild as CfnCluster;
+      cfnCluster.clusterSettings = [
+        {
+          name: "containerInsights",
+          value: "enhanced",
+        },
+      ];
+
+      const cfnService = ecsService.node.defaultChild as CfnService;
+      cfnService.addPropertyOverride("Monitoring", {
+        MetricConfigurations: [
+          {
+            MetricNames: ["CPUUtilization", "MemoryUtilization"],
+            ResolutionSeconds: 20,
+          },
         ],
       });
 


### PR DESCRIPTION
## What does this change?
Sets containerInsights to enhanced and add Monitoring properties for ecsService as a default

## Have we considered potential risks?
We need to update [dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/16557), where it is currently set manually.

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217199727794975