### PR TITLE
feat(`GuLoadBalancedAppExperimental`): Make the FireLens log driver accessible

### DIFF
--- a/.changeset/social-numbers-act.md
+++ b/.changeset/social-numbers-act.md
@@ -1,0 +1,32 @@
+---
+"@guardian/cdk": minor
+---
+
+Update `GuLoadBalancedAppExperimental` to make the FireLens log driver accessible.
+This allows clients to use it to ship the logs of their additional sidecars to Central ELK.
+For example:
+
+```ts
+const app = new GuLoadBalancedAppExperimental();
+
+if(app.ecsService) {
+  const { taskDefinition } = app.ecsService;
+
+  if(!app.fireLensLogDriver) {
+    throw new Error("Unable to re-use FireLens log driver"); // This should not happen!
+  }
+
+  const fireLensLogDriver = app.fireLensLogDriver;
+
+  taskDefinition.addContainer(
+    'aws-otel-collector',
+    {
+      image: ContainerImage.fromRegistry(
+        'public.ecr.aws/aws-observability/aws-otel-collector@sha256:90b3180c21acb9497110480371a413ed91f2836077f8a8fb4507b019d3c481c0',
+      ),
+      command: ['--config=/etc/ecs/ecs-default-config.yaml'],
+      logging: fireLensLogDriver,
+    },
+  );
+}
+```

--- a/src/experimental/patterns/gu-load-balanced-app.ts
+++ b/src/experimental/patterns/gu-load-balanced-app.ts
@@ -421,6 +421,13 @@ export class GuLoadBalancedAppExperimental extends Construct {
    */
   public readonly targetGroups: TargetGroups;
 
+  /**
+   * A log driver used to ship logs to Central ELK (via Kinesis).
+   *
+   * @note Only available when using ECS, i.e. when {@link GuLoadBalancedAppExperimental.ecsService} is defined.
+   */
+  public readonly fireLensLogDriver?: FireLensLogDriver;
+
   constructor(scope: GuStack, props: GuLoadBalancedAppExperimentalProps) {
     const {
       access,
@@ -621,6 +628,8 @@ export class GuLoadBalancedAppExperimental extends Construct {
           retry_limit: "2",
         },
       });
+
+      this.fireLensLogDriver = fireLensLogDriver;
 
       const env = {
         STACK: stack,


### PR DESCRIPTION
## What does this change?
Updates `GuLoadBalancedAppExperimental` to make the FireLens log driver accessible. This allows clients to use it to ship the logs of their additional sidecars to Central ELK.

## How to test
N/A.

## How can we measure success?
Reducing the amount of code in clients, for example [guardian/dotcom-rendering](https://github.com/guardian/dotcom-rendering/blob/cbd424c81ffbc090332d0a2063d4572eb3e6a470/dotcom-rendering/cdk/lib/renderingStack.ts#L323-L330).

## Have we considered potential risks?
N/A.

## Checklist

- [ ] I have listed any breaking changes, along with a migration path [^1]
- [x] I have updated the documentation as required for the described changes [^2]

[^1]: Consider whether this is something that will mean changes to projects that have already been migrated, or to the CDK CLI tool. If changes are required, consider adding a checklist here and/or linking to related PRs.
[^2]: If you are adding a new construct or pattern, has new documentation been added? If you are amending defaults or changing behaviour, are the existing docs still valid?
